### PR TITLE
feat: auto discover modules if they were not yet discovered

### DIFF
--- a/src/registry.py
+++ b/src/registry.py
@@ -21,6 +21,15 @@ MODULE_TYPE = 'BaseModule'  # type: ignore
 AVAILABLE_MODULES: Dict[str, Type[MODULE_TYPE]] = {}
 
 
+def is_modules_discovered() -> bool:
+    """Check if modules have been discovered.
+
+    Returns:
+        bool: True if modules have been discovered, False otherwise
+    """
+    return bool(AVAILABLE_MODULES)
+
+
 def discover_modules():
     """Discover available modules by scanning the modules directory."""
     # Get the path to the modules directory
@@ -44,7 +53,6 @@ def discover_modules():
                     logger.debug("Discovered module: %s", module_name)
 
 
-
 def get_module_names() -> List[str]:
     """Get the names of all registered modules.
 
@@ -52,3 +60,12 @@ def get_module_names() -> List[str]:
         List of module names
     """
     return list(AVAILABLE_MODULES.keys())
+
+
+def get_available_modules() -> Dict[str, Type[MODULE_TYPE]]:
+    """Get the dictionary of available modules.
+
+    Returns:
+        Dict[str, Type[MODULE_TYPE]]: Dictionary mapping module names to module classes
+    """
+    return AVAILABLE_MODULES

--- a/src/server.py
+++ b/src/server.py
@@ -36,11 +36,15 @@ class FalconMCPServer:
             debug: Enable debug logging
             enabled_modules: Set of module names to enable (defaults to all modules)
         """
+        # Ensure modules are discovered
+        if not registry.is_modules_discovered():
+            registry.discover_modules()
+
         # Store configuration
         self.base_url = base_url
         self.debug = debug
 
-        self.enabled_modules = enabled_modules or set(registry.AVAILABLE_MODULES.keys())
+        self.enabled_modules = enabled_modules or set(registry.get_module_names())
 
         # Configure logging
         configure_logging(debug=self.debug)
@@ -67,9 +71,10 @@ class FalconMCPServer:
 
         # Initialize and register modules
         self.modules = {}
+        available_modules = registry.get_available_modules()
         for module_name in self.enabled_modules:
-            if module_name in registry.AVAILABLE_MODULES:
-                module_class = registry.AVAILABLE_MODULES[module_name]
+            if module_name in available_modules:
+                module_class = available_modules[module_name]
                 self.modules[module_name] = module_class(self.falcon_client)
                 logger.debug("Initialized module: %s", module_name)
 
@@ -159,7 +164,7 @@ def parse_args():
     )
 
     # Module selection
-    available_modules = list(registry.AVAILABLE_MODULES.keys())
+    available_modules = registry.get_module_names()
     parser.add_argument(
         "--modules", "-m",
         nargs="+",

--- a/tests/e2e/utils/base_e2e_test.py
+++ b/tests/e2e/utils/base_e2e_test.py
@@ -13,7 +13,6 @@ from langchain_openai import ChatOpenAI
 from mcp_use import MCPAgent, MCPClient
 
 from src.server import FalconMCPServer
-from src import registry
 
 # Models to test against
 MODELS_TO_TEST = ["gpt-4.1-mini", "gpt-4o-mini"]
@@ -86,9 +85,6 @@ class BaseE2ETest(unittest.TestCase):
         cls._mock_api_instance.login.return_value = True
         cls._mock_api_instance.token_valid.return_value = True
         mock_apiharness_class.return_value = cls._mock_api_instance
-
-        # Ensure modules are discovered before creating the server
-        registry.discover_modules()
 
         server = FalconMCPServer(debug=False)
         cls._server_thread = threading.Thread(target=server.run, args=("sse",))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,111 @@
+"""
+Tests for the registry module.
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+from src import registry
+
+
+class TestRegistry(unittest.TestCase):
+    """Test cases for the registry module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Save original AVAILABLE_MODULES to restore after tests
+        self.original_modules = registry.AVAILABLE_MODULES.copy()
+        # Clear AVAILABLE_MODULES for tests
+        registry.AVAILABLE_MODULES.clear()
+
+    def tearDown(self):
+        """Tear down test fixtures."""
+        # Restore original AVAILABLE_MODULES after tests
+        registry.AVAILABLE_MODULES.clear()
+        registry.AVAILABLE_MODULES.update(self.original_modules)
+
+    def test_is_modules_discovered_empty(self):
+        """Test is_modules_discovered when no modules are discovered."""
+        # Ensure AVAILABLE_MODULES is empty
+        registry.AVAILABLE_MODULES.clear()
+
+        # Test the function
+        result = registry.is_modules_discovered()
+
+        # Verify result is False when no modules are discovered
+        self.assertFalse(result)
+
+    def test_is_modules_discovered_with_modules(self):
+        """Test is_modules_discovered when modules are discovered."""
+        # Add a mock module to AVAILABLE_MODULES
+        mock_module = MagicMock()
+        registry.AVAILABLE_MODULES["test_module"] = mock_module
+
+        # Test the function
+        result = registry.is_modules_discovered()
+
+        # Verify result is True when modules are discovered
+        self.assertTrue(result)
+
+    def test_discover_modules(self):
+        """Test discover_modules function."""
+        # Mock pkgutil.iter_modules to return a test module
+        mock_module_info = ("path", "test_module", False)
+
+        with patch("pkgutil.iter_modules", return_value=[mock_module_info]), \
+             patch("importlib.import_module") as mock_import, \
+             patch("os.path.dirname", return_value="/fake/path"):
+
+            # Setup mock module with a TestModule class
+            mock_module = MagicMock()
+            mock_module_class = MagicMock()
+            # Set TestModule as an attribute on the mock module
+            setattr(mock_module, "TestModule", mock_module_class)
+            # Configure dir to return TestModule
+            type(mock_module).__dir__ = lambda x: ["TestModule"]
+
+            # Make importlib.import_module return our mock module
+            mock_import.return_value = mock_module
+
+            # Call discover_modules
+            registry.discover_modules()
+
+            # Verify module was imported
+            mock_import.assert_any_call("src.modules.test_module")
+
+            # Verify module was registered
+            self.assertIn("test", registry.AVAILABLE_MODULES)
+            self.assertEqual(registry.AVAILABLE_MODULES["test"], mock_module_class)
+
+    def test_get_module_names(self):
+        """Test get_module_names function."""
+        # Add mock modules to AVAILABLE_MODULES
+        registry.AVAILABLE_MODULES.clear()
+        registry.AVAILABLE_MODULES["module1"] = MagicMock()
+        registry.AVAILABLE_MODULES["module2"] = MagicMock()
+
+        # Call get_module_names
+        result = registry.get_module_names()
+
+        # Verify result contains the module names
+        self.assertEqual(set(result), {"module1", "module2"})
+
+    def test_get_available_modules(self):
+        """Test get_available_modules function."""
+        # Add mock modules to AVAILABLE_MODULES
+        registry.AVAILABLE_MODULES.clear()
+        mock_module1 = MagicMock()
+        mock_module2 = MagicMock()
+        registry.AVAILABLE_MODULES["module1"] = mock_module1
+        registry.AVAILABLE_MODULES["module2"] = mock_module2
+
+        # Call get_available_modules
+        result = registry.get_available_modules()
+
+        # Verify result is the same dictionary
+        self.assertEqual(result, registry.AVAILABLE_MODULES)
+        self.assertEqual(result["module1"], mock_module1)
+        self.assertEqual(result["module2"], mock_module2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,11 +11,6 @@ from src.server import FalconMCPServer
 class TestFalconMCPServer(unittest.TestCase):
     """Test cases for the Falcon MCP server."""
 
-    def setUp(self):
-        """Set up test fixtures before each test method."""
-        # Ensure modules are discovered before each test
-        registry.discover_modules()
-
     @patch('src.server.FalconClient')
     @patch('src.server.FastMCP')
     def test_server_initialization(self, mock_fastmcp, mock_client):
@@ -53,8 +48,9 @@ class TestFalconMCPServer(unittest.TestCase):
         )
 
         # Verify modules initialization
-        self.assertEqual(len(server.modules), len(registry.AVAILABLE_MODULES))
-        for module_name in registry.AVAILABLE_MODULES:
+        available_module_names = registry.get_module_names()
+        self.assertEqual(len(server.modules), len(available_module_names))
+        for module_name in available_module_names:
             self.assertIn(module_name, server.modules)
 
     @patch('src.server.FalconClient')


### PR DESCRIPTION
When running examples we would get 0 tools loaded (apart from the default ones).

This was because discovering modules moved to `parse_args()` method. An alternative to this PR would be to call `discover_modules()` in each example.