### PR TITLE
feat: implement lazy module discovery

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -7,7 +7,6 @@ This script demonstrates how to initialize and run the Falcon MCP server.
 import os
 from dotenv import load_dotenv
 
-from src import registry
 from src.server import FalconMCPServer
 
 
@@ -15,9 +14,6 @@ def main():
     """Run the Falcon MCP server with default settings."""
     # Load environment variables from .env file
     load_dotenv()
-
-    # Discover all available modules
-    registry.discover_modules()
 
     # Create and run the server with stdio transport
     server = FalconMCPServer(

--- a/examples/sse_usage.py
+++ b/examples/sse_usage.py
@@ -7,7 +7,6 @@ This script demonstrates how to initialize and run the Falcon MCP server with SS
 import os
 from dotenv import load_dotenv
 
-from src import registry
 from src.server import FalconMCPServer
 
 
@@ -15,9 +14,6 @@ def main():
     """Run the Falcon MCP server with SSE transport."""
     # Load environment variables from .env file
     load_dotenv()
-
-    # Discover all available modules
-    registry.discover_modules()
 
     # Create and run the server with SSE transport
     server = FalconMCPServer(

--- a/examples/streamable_http_usage.py
+++ b/examples/streamable_http_usage.py
@@ -8,7 +8,6 @@ with streamable-http transport for custom integrations and web-based deployments
 import os
 from dotenv import load_dotenv
 
-from src import registry
 from src.server import FalconMCPServer
 
 
@@ -16,9 +15,6 @@ def main():
     """Run the Falcon MCP server with streamable-http transport."""
     # Load environment variables from .env file
     load_dotenv()
-
-    # Discover all available modules
-    registry.discover_modules()
 
     # Create and run the server with streamable-http transport
     server = FalconMCPServer(

--- a/src/registry.py
+++ b/src/registry.py
@@ -45,10 +45,22 @@ def discover_modules():
 
 
 
+def get_available_modules() -> Dict[str, Type[MODULE_TYPE]]:
+    """Get available modules dict, discovering if needed (lazy loading).
+
+    Returns:
+        Dict mapping module names to module classes
+    """
+    if not AVAILABLE_MODULES:
+        logger.debug("No modules discovered yet, performing lazy discovery")
+        discover_modules()
+    return AVAILABLE_MODULES
+
+
 def get_module_names() -> List[str]:
-    """Get the names of all registered modules.
+    """Get the names of all registered modules, discovering if needed (lazy loading).
 
     Returns:
         List of module names
     """
-    return list(AVAILABLE_MODULES.keys())
+    return list(get_available_modules().keys())

--- a/src/server.py
+++ b/src/server.py
@@ -67,9 +67,10 @@ class FalconMCPServer:
 
         # Initialize and register modules
         self.modules = {}
+        available_modules = registry.get_available_modules()
         for module_name in self.enabled_modules:
-            if module_name in registry.AVAILABLE_MODULES:
-                module_class = registry.AVAILABLE_MODULES[module_name]
+            if module_name in available_modules:
+                module_class = available_modules[module_name]
                 self.modules[module_name] = module_class(self.falcon_client)
                 logger.debug("Initialized module: %s", module_name)
 
@@ -154,9 +155,6 @@ class FalconMCPServer:
 
 def parse_args():
     """Parse command line arguments."""
-    # Ensure modules are discovered before creating the parser
-    registry.discover_modules()
-
     parser = argparse.ArgumentParser(description="Falcon MCP Server")
 
     # Transport options

--- a/tests/e2e/utils/base_e2e_test.py
+++ b/tests/e2e/utils/base_e2e_test.py
@@ -13,7 +13,6 @@ from langchain_openai import ChatOpenAI
 from mcp_use import MCPAgent, MCPClient
 
 from src.server import FalconMCPServer
-from src import registry
 
 # Models to test against
 MODELS_TO_TEST = ["gpt-4.1-mini", "gpt-4o-mini"]
@@ -86,9 +85,6 @@ class BaseE2ETest(unittest.TestCase):
         cls._mock_api_instance.login.return_value = True
         cls._mock_api_instance.token_valid.return_value = True
         mock_apiharness_class.return_value = cls._mock_api_instance
-
-        # Ensure modules are discovered before creating the server
-        registry.discover_modules()
 
         server = FalconMCPServer(debug=False)
         cls._server_thread = threading.Thread(target=server.run, args=("sse",))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -51,16 +51,21 @@ class TestRegistry(unittest.TestCase):
         self.assertEqual(set(module_names), {'test1', 'test2', 'test3'})
         self.assertEqual(len(module_names), 3)
 
-    def test_get_module_names_empty(self):
-        """Test that get_module_names returns an empty list when no modules are registered."""
+    def test_get_module_names_lazy_discovery(self):
+        """Test that get_module_names performs lazy discovery when no modules are registered."""
         # Ensure AVAILABLE_MODULES is empty
         registry.AVAILABLE_MODULES.clear()
 
-        # Call get_module_names
+        # Call get_module_names (should trigger lazy discovery)
         module_names = registry.get_module_names()
 
-        # Verify that the returned list is empty
-        self.assertEqual(module_names, [])
+        # Verify that modules were discovered (should not be empty)
+        self.assertGreater(len(module_names), 0)
+
+        # Verify that the expected modules are discovered
+        expected_modules = ['detections', 'incidents', 'intel']
+        for module_name in expected_modules:
+            self.assertIn(module_name, module_names)
 
     def test_actual_modules_discovery(self):
         """Test that actual modules in the project are discovered correctly."""


### PR DESCRIPTION
## Problem
Currently, developers need to manually call `registry.discover_modules()` in examples and tests, creating dependency issues and boilerplate code.

## Solution
Implements lazy module discovery that automatically discovers modules only when first needed.

## Technical Changes
- `get_module_names()` checks if `AVAILABLE_MODULES` is empty and calls `discover_modules()` if needed
- `discover_modules()` only populates modules (no clearing)
- Removes manual `registry.discover_modules()` calls from examples and E2E tests
- Updates registry test to reflect lazy discovery behavior

## Benefits
- Zero redundant discovery calls
- Automatic discovery when needed
- Both use cases work: CLI (`--help`) and programmatic (`FalconMCPServer()`)
- No breaking changes

## Testing
- All existing tests pass
- Both use cases validated
- Examples and E2E tests cleaned up