### PR TITLE
feat: implement explicit module rediscovery

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -7,7 +7,6 @@ This script demonstrates how to initialize and run the Falcon MCP server.
 import os
 from dotenv import load_dotenv
 
-from src import registry
 from src.server import FalconMCPServer
 
 
@@ -15,9 +14,6 @@ def main():
     """Run the Falcon MCP server with default settings."""
     # Load environment variables from .env file
     load_dotenv()
-
-    # Discover all available modules
-    registry.discover_modules()
 
     # Create and run the server with stdio transport
     server = FalconMCPServer(

--- a/examples/sse_usage.py
+++ b/examples/sse_usage.py
@@ -7,7 +7,6 @@ This script demonstrates how to initialize and run the Falcon MCP server with SS
 import os
 from dotenv import load_dotenv
 
-from src import registry
 from src.server import FalconMCPServer
 
 
@@ -15,9 +14,6 @@ def main():
     """Run the Falcon MCP server with SSE transport."""
     # Load environment variables from .env file
     load_dotenv()
-
-    # Discover all available modules
-    registry.discover_modules()
 
     # Create and run the server with SSE transport
     server = FalconMCPServer(

--- a/examples/streamable_http_usage.py
+++ b/examples/streamable_http_usage.py
@@ -8,7 +8,6 @@ with streamable-http transport for custom integrations and web-based deployments
 import os
 from dotenv import load_dotenv
 
-from src import registry
 from src.server import FalconMCPServer
 
 
@@ -16,9 +15,6 @@ def main():
     """Run the Falcon MCP server with streamable-http transport."""
     # Load environment variables from .env file
     load_dotenv()
-
-    # Discover all available modules
-    registry.discover_modules()
 
     # Create and run the server with streamable-http transport
     server = FalconMCPServer(

--- a/src/registry.py
+++ b/src/registry.py
@@ -22,7 +22,14 @@ AVAILABLE_MODULES: Dict[str, Type[MODULE_TYPE]] = {}
 
 
 def discover_modules():
-    """Discover available modules by scanning the modules directory."""
+    """Discover available modules by scanning the modules directory.
+
+    Always clears and rediscovers modules. Safe to call multiple times.
+    """
+    # Clear existing modules first
+    AVAILABLE_MODULES.clear()
+    logger.debug("Clearing and rediscovering modules")
+
     # Get the path to the modules directory
     current_dir = os.path.dirname(__file__)
     modules_path = os.path.join(current_dir, 'modules')
@@ -42,6 +49,8 @@ def discover_modules():
                     module_name = attr_name.lower().replace('module', '')
                     AVAILABLE_MODULES[module_name] = module_class
                     logger.debug("Discovered module: %s", module_name)
+
+    logger.debug("Module discovery completed - found %d modules", len(AVAILABLE_MODULES))
 
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -36,6 +36,9 @@ class FalconMCPServer:
             debug: Enable debug logging
             enabled_modules: Set of module names to enable (defaults to all modules)
         """
+        # Ensure modules are discovered
+        registry.discover_modules()
+
         # Store configuration
         self.base_url = base_url
         self.debug = debug

--- a/tests/e2e/utils/base_e2e_test.py
+++ b/tests/e2e/utils/base_e2e_test.py
@@ -13,7 +13,6 @@ from langchain_openai import ChatOpenAI
 from mcp_use import MCPAgent, MCPClient
 
 from src.server import FalconMCPServer
-from src import registry
 
 # Models to test against
 MODELS_TO_TEST = ["gpt-4.1-mini", "gpt-4o-mini"]
@@ -86,9 +85,6 @@ class BaseE2ETest(unittest.TestCase):
         cls._mock_api_instance.login.return_value = True
         cls._mock_api_instance.token_valid.return_value = True
         mock_apiharness_class.return_value = cls._mock_api_instance
-
-        # Ensure modules are discovered before creating the server
-        registry.discover_modules()
 
         server = FalconMCPServer(debug=False)
         cls._server_thread = threading.Thread(target=server.run, args=("sse",))


### PR DESCRIPTION
## Problem
Currently, developers need to manually call `registry.discover_modules()` in examples and tests, creating dependency issues and boilerplate code.

## Solution
Implements explicit module rediscovery that ensures clean module state through discovery calls in key initialization points.

## Technical Changes
- `discover_modules()` always clears `AVAILABLE_MODULES` first, then rediscovers
- Adds discovery calls in both `parse_args()` and `FalconMCPServer.__init__()`
- `get_module_names()` simply returns keys from `AVAILABLE_MODULES`
- Removes manual `registry.discover_modules()` calls from examples and E2E tests
- Safe to call multiple times

## Benefits
- Simple and explicit approach
- Clean module state on each discovery
- Both use cases work: CLI (`--help`) and programmatic (`FalconMCPServer()`)
- No breaking changes

## Testing
- All existing tests pass
- Both use cases validated
- Examples and E2E tests cleaned up