### PR TITLE
feat: implement RFC-compliant User-Agent format and address PR review comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ FALCON_BASE_URL=https://api.us-2.crowdstrike.com
 # Default: 8000
 #FALCON_MCP_PORT=8000
 
+# User agent comment to include in API requests
+# This will be added to the User-Agent header comment section
+# Example: CustomApp/1.0
+#FALCON_MCP_USER_AGENT_COMMENT=
+
 # =============================================================================
 # Optional: E2E Testing Configuration
 # =============================================================================

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -28,7 +28,7 @@ class FalconMCPServer:
         base_url: Optional[str] = None,
         debug: bool = False,
         enabled_modules: Optional[Set[str]] = None,
-        custom_user_agent: Optional[str] = None,
+        user_agent_comment: Optional[str] = None,
     ):
         """Initialize the Falcon MCP server.
 
@@ -36,11 +36,12 @@ class FalconMCPServer:
             base_url: Falcon API base URL
             debug: Enable debug logging
             enabled_modules: Set of module names to enable (defaults to all modules)
+            user_agent_comment: Additional information to include in the User-Agent comment section
         """
         # Store configuration
         self.base_url = base_url
         self.debug = debug
-        self.custom_user_agent = custom_user_agent
+        self.user_agent_comment = user_agent_comment
 
         self.enabled_modules = enabled_modules or set(registry.get_module_names())
 
@@ -52,7 +53,7 @@ class FalconMCPServer:
         self.falcon_client = FalconClient(
             base_url=self.base_url,
             debug=self.debug,
-            custom_user_agent=self.custom_user_agent,
+            user_agent_comment=self.user_agent_comment,
         )
 
         # Authenticate with the Falcon API
@@ -259,9 +260,9 @@ def parse_args():
     )
 
     parser.add_argument(
-        "--user-agent", "-ua",
-        default=os.environ.get('USER_AGENT'),
-        help="User agent string to be appended to the default user agent header"
+        "--user-agent-comment",
+        default=os.environ.get('FALCON_MCP_USER_AGENT_COMMENT'),
+        help="Additional information to include in the User-Agent comment section (env: FALCON_MCP_USER_AGENT_COMMENT)"
     )
 
     return parser.parse_args()
@@ -281,7 +282,7 @@ def main():
             base_url=args.base_url,
             debug=args.debug,
             enabled_modules=set(args.modules),
-            custom_user_agent=args.user_agent,
+            user_agent_comment=args.user_agent_comment,
         )
         logger.info("Starting server with %s transport", args.transport)
         server.run(args.transport, host=args.host, port=args.port)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -208,8 +208,8 @@ class TestFalconClient(unittest.TestCase):
     @patch('falcon_mcp.client.version')
     @patch('falcon_mcp.client.os.environ.get')
     @patch('falcon_mcp.client.APIHarnessV2')
-    def test_get_user_agent_with_custom_user_agent(self, mock_apiharness, mock_environ_get, mock_version):
-        """Test get_user_agent method with a custom user agent."""
+    def test_get_user_agent_with_user_agent_comment(self, mock_apiharness, mock_environ_get, mock_version):
+        """Test get_user_agent method with a user agent comment."""
         # Setup mock environment variables
         mock_environ_get.side_effect = lambda key, default=None: {
             "FALCON_CLIENT_ID": "test-client-id",
@@ -227,14 +227,14 @@ class TestFalconClient(unittest.TestCase):
         mock_version.side_effect = version_side_effect
         mock_apiharness.return_value = MagicMock()
 
-        # Create client with custom user agent
-        client = FalconClient(custom_user_agent="CustomApp/1.0")
+        # Create client with user agent comment
+        client = FalconClient(user_agent_comment="CustomApp/1.0")
         user_agent = client.get_user_agent()
 
-        # Verify user agent format and content
+        # Verify user agent format and content (RFC-compliant format)
         python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
         platform_info = f"{platform.system()}/{platform.release()}"
-        expected = f"falcon-mcp/1.2.3 (falconpy/1.3.4; Python/{python_version}; {platform_info}; CustomApp/1.0)"
+        expected = f"falcon-mcp/1.2.3 (CustomApp/1.0; falconpy/1.3.4; Python/{python_version}; {platform_info})"
 
         self.assertEqual(user_agent, expected)
 


### PR DESCRIPTION
- Enhanced version detection with pyproject.toml fallback for Docker/dev environments
- Implemented RFC-compliant User-Agent format with custom comment inside parentheses
- Renamed parameter from 'custom_user_agent' to 'user_agent_comment' for clarity
- Added FALCON_MCP_USER_AGENT_COMMENT environment variable support
- Updated all tests to reflect new parameter names and RFC format expectations

Format changes:
- Before: falcon-mcp/1.2.3 (falconpy/1.3.4; Python/3.12.10; Darwin/24.5.0; CustomApp/1.0)
- After:  falcon-mcp/1.2.3 (CustomApp/1.0; falconpy/1.3.4; Python/3.12.10; Darwin/24.5.0)

Addresses GitHub PR review feedback from @protiumx  for improved RFC compliance and parameter naming.