### PR TITLE
Update Identity Protection API scope requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The Falcon MCP Server supports different modules, each requiring specific API sc
 | **Hosts** | `Hosts:read` | Manage and query host/device information |
 | **Cloud Security** | `Falcon Container Image:read` | Find and analyze kubernetes containers inventory and container imges vulnerabilities |
 | **Spotlight** | `Vulnerabilities:read` | Manage and analyze vulnerability data and security assessments |
-| **Identity Protection** | `Identity Protection GraphQL:write` | Comprehensive entity investigation and identity protection analysis |
+| **Identity Protection** | `Identity Protection Entities:read`<br>`Identity Protection Timeline:read`<br>`Identity Protection Detections:read` <br> `Identity Protection Assessment:read` | Comprehensive entity investigation and identity protection analysis |
 
 ## Available Modules, Tools & Resources
 

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -37,7 +37,8 @@ API_SCOPE_REQUIREMENTS = {
     "ReadContainerCount": ["Falcon Container Image:read"],
     "ReadCombinedVulnerabilities": ["Falcon Container Image:read"],
     # Identity Protection operations
-    "api_preempt_proxy_post_graphql": ["Identity Protection GraphQL:write"],
+    "api_preempt_proxy_post_graphql": ["Identity Protection Entities:read", "Identity Protection Timeline:read",
+                                       "Identity Protection Detections:read", "Identity Protection Assessment:read"],
     # Add more mappings as needed
 }
 

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -37,8 +37,12 @@ API_SCOPE_REQUIREMENTS = {
     "ReadContainerCount": ["Falcon Container Image:read"],
     "ReadCombinedVulnerabilities": ["Falcon Container Image:read"],
     # Identity Protection operations
-    "api_preempt_proxy_post_graphql": ["Identity Protection Entities:read", "Identity Protection Timeline:read",
-                                       "Identity Protection Detections:read", "Identity Protection Assessment:read"],
+    "api_preempt_proxy_post_graphql": [
+        "Identity Protection Entities:read",
+        "Identity Protection Timeline:read",
+        "Identity Protection Detections:read",
+        "Identity Protection Assessment:read"
+    ],
     # Add more mappings as needed
 }
 


### PR DESCRIPTION
Replace single GraphQL:write scope with granular read-only scopes for entities, timeline, detections, and assessment operations