### PR TITLE
feat(resources/spotlight): FQL filter as tuples

### DIFF
--- a/falcon_mcp/common/utils.py
+++ b/falcon_mcp/common/utils.py
@@ -156,7 +156,11 @@ def generate_table(data: List[Tuple]) -> str:
     # Build the table
     table = [header_row, separator]
 
-    for row in rows:
+    for idx, row in enumerate(rows):
+        # Check if row has more items than headers
+        if len(row) > len(headers):
+            raise ValueError(f"Row {idx+1} has {len(row)} items, which is more than the {len(headers)} headers")
+
         # Convert row values to strings and handle special cases
         row_values = []
         for i, value in enumerate(row):
@@ -168,9 +172,9 @@ def generate_table(data: List[Tuple]) -> str:
                 elif isinstance(value, (int, float)):
                     row_values.append(str(value))
                 else:
-                    # Join multi-line text with spaces and strip leading/trailing spaces
+                    # Join multi-line text with spaces and strip leading/trailing spaces from each line
                     text = str(value)
-                    row_values.append(" ".join(text.split('\n')).strip())
+                    row_values.append(" ".join(line.strip() for line in text.split('\n')).strip())
 
         # Pad the row if it's shorter than headers
         while len(row_values) < len(headers):

--- a/falcon_mcp/common/utils.py
+++ b/falcon_mcp/common/utils.py
@@ -123,6 +123,9 @@ def generate_table(data: List[Tuple]) -> str:
 
     Raises:
         TypeError: If the first row (headers) contains non-string values
+        TypeError: If there are not at least 2 items (header and a value row)
+        ValueError: If the header row is empty
+        ValueError: If a row has more items than headers
     """
     if not data or len(data) < 2:
         raise TypeError("Need at least 2 items. The header and a value row")

--- a/falcon_mcp/common/utils.py
+++ b/falcon_mcp/common/utils.py
@@ -5,7 +5,7 @@ This module provides common utility functions for the Falcon MCP server.
 """
 
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from .errors import _format_error_response, is_success_response
 from .logging import get_logger
@@ -105,3 +105,78 @@ def sanitize_input(input_str: str) -> str:
 
     # Additional safety: limit length to prevent excessively long inputs
     return sanitized[:255]
+
+
+def generate_table(data: List[Tuple]) -> str:
+    """Generate a Markdown table from a list of tuples.
+
+    This function creates a minimal Markdown table with the provided data.
+    It's designed to minimize token usage while maintaining readability.
+    The first row of data is used as the header row.
+
+    Args:
+        data: List of tuples where the first tuple contains the headers
+              and the remaining tuples contain the table data
+
+    Returns:
+        str: Formatted Markdown table as a string
+
+    Raises:
+        TypeError: If the first row (headers) contains non-string values
+    """
+    if not data or len(data) < 2:
+        raise TypeError(f"Need at least 2 items. The header and a value row")
+
+    # Extract headers from the first row
+    headers = data[0]
+    
+    # Check that the header row is not empty
+    if len(headers) == 0:
+        raise ValueError("Header row cannot be empty")
+    
+    # Check that all headers are strings
+    for header in headers:
+        if not isinstance(header, str):
+            raise TypeError(f"Header values must be strings, got {type(header).__name__}")
+
+    # Use the remaining rows as data
+    rows = data[1:]
+
+    # Create the table header, stripping spaces from header values
+    header_parts = []
+    for h in headers:
+        # Strip spaces from header values
+        header_parts.append(str(h).strip())
+
+    header_row = "|" + "|".join(header_parts) + "|"
+
+    # Create the separator row with the exact expected format
+    separator = "|" + "|".join(["-" for _ in range(len(headers))]) + "|"
+
+    # Build the table
+    table = [header_row, separator]
+
+    for row in rows:
+        # Convert row values to strings and handle special cases
+        row_values = []
+        for i, value in enumerate(row):
+            if i < len(headers):
+                if value is None:
+                    row_values.append("")
+                elif isinstance(value, bool):
+                    row_values.append(str(value).lower())
+                elif isinstance(value, (int, float)):
+                    row_values.append(str(value))
+                else:
+                    # Join multi-line text with spaces and strip leading/trailing spaces
+                    text = str(value)
+                    row_values.append(" ".join(text.split('\n')).strip())
+
+        # Pad the row if it's shorter than headers
+        while len(row_values) < len(headers):
+            row_values.append("")
+
+        # Add the row to the table
+        table.append("|" + "|".join(row_values) + "|")
+
+    return "\n".join(table)

--- a/falcon_mcp/common/utils.py
+++ b/falcon_mcp/common/utils.py
@@ -154,7 +154,7 @@ def generate_md_table(data: List[Tuple]) -> str:
     header_row = "|" + "|".join(header_parts) + "|"
 
     # Create the separator row with the exact expected format
-    separator = "|" + "|".join(["-" for _ in range(len(headers))]) + "|"
+    separator = "|-" * len(headers) + "|"
 
     # Build the table
     table = [header_row, separator]

--- a/falcon_mcp/common/utils.py
+++ b/falcon_mcp/common/utils.py
@@ -125,7 +125,7 @@ def generate_table(data: List[Tuple]) -> str:
         TypeError: If the first row (headers) contains non-string values
     """
     if not data or len(data) < 2:
-        raise TypeError(f"Need at least 2 items. The header and a value row")
+        raise TypeError("Need at least 2 items. The header and a value row")
 
     # Extract headers from the first row
     headers = data[0]

--- a/falcon_mcp/common/utils.py
+++ b/falcon_mcp/common/utils.py
@@ -107,10 +107,10 @@ def sanitize_input(input_str: str) -> str:
     return sanitized[:255]
 
 
-def generate_table(data: List[Tuple]) -> str:
+def generate_md_table(data: List[Tuple]) -> str:
     """Generate a Markdown table from a list of tuples.
 
-    This function creates a minimal Markdown table with the provided data.
+    This function creates a compact Markdown table with the provided data.
     It's designed to minimize token usage while maintaining readability.
     The first row of data is used as the header row.
 

--- a/falcon_mcp/resources/spotlight.py
+++ b/falcon_mcp/resources/spotlight.py
@@ -6,45 +6,429 @@ from falcon_mcp.common.utils import generate_table
 
 # List of tuples containing filter options data: (name, type, operators, description)
 SEARCH_VULNERABILITIES_FQL_FILTERS = [
-    ("Name", "Type", "Operators", "Description"),
-    ("aid", "String", "No", "Unique agent identifier (AID) of the sensor where the vulnerability was found. For assets without a Falcon sensor installed, this field matches the asset ID field.\nEx: aid:'abcde6b9a3427d8c4a1af416424d6231'"),
-    ("apps.remediation.ids", "String", "Yes", "Unique identifier of a remediation. Supports multiple values and negation.\nEx: apps.remediation.ids:'7bba2e543744a92962be7afeb6484858'\nEx: apps.remediation.ids:['ID1','ID2','ID3']"),
-    ("cid", "String", "No", "Unique system-generated customer identifier (CID) of the account. In multi-CID environments, you can filter by both parent and child CIDs.\nEx: cid:'0123456789ABCDEFGHIJKLMNOPQRSTUV'"),
-    ("closed_timestamp", "Timestamp", "Yes", "Date and time a vulnerability was set to a status of CLOSED.\nEx: closed_timestamp:>'2021-06-25T10:32'\nEx: closed_timestamp:<'2021-10-18'"),
-    ("confidence", "String", "Yes", "Whether or not the vulnerability has been confirmed.\nValues: confirmed, potential\nEx: confidence:'potential'"),
-    ("created_timestamp", "Timestamp", "Yes", "Date and time when this vulnerability was found in your environment. Use this to get vulnerabilities created after the timestamp you last pulled data on.\nEx: created_timestamp:<'2021-09-25T13:22'\nEx: created_timestamp:>'2021-02-12'"),
-    ("cve.base_score", "Number", "Yes", "CVE base score.\nEx: cve.base_score:>5.0"),
-    ("cve.cwes", "String", "Yes", "Unique identifier for a vulnerability from the Common Weakness Enumeration (CWE) list.\nEx: cve.cwes:['CWE-787','CWE-699']"),
-    ("cve.exploit_status", "String", "Yes", "Numeric value of the most severe known exploit. Supports multiple values and negation.\nValues: 0=Unproven, 30=Available, 60=Easily accessible, 90=Actively used\nEx: cve.exploit_status:'60'\nEx: cve.exploit_status:!'0'"),
-    ("cve.exprt_rating", "String", "Yes", "ExPRT rating assigned by CrowdStrike's predictive AI rating system. Value must be in all caps. Supports multiple values and negation.\nValues: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL\nEx: cve.exprt_rating:'HIGH'\nEx: cve.exprt_rating:['HIGH','CRITICAL']"),
-    ("cve.id", "String", "Yes", "Unique identifier for a vulnerability as cataloged in the National Vulnerability Database (NVD). Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name.\nNote: All values must be enclosed in brackets.\nEx: cve.id:['CVE-2022-1234']\nEx: cve.id:['CVE-2022-1234','CVE-2023-1234']"),
-    ("cve.is_cisa_kev", "Boolean", "Yes", "Filter for vulnerabilities that are in the CISA Known Exploited Vulnerabilities (KEV) catalog. Supports negation.\nEx: cve.is_cisa_kev:true"),
-    ("cve.remediation_level", "String", "Yes", "CVSS remediation level of the vulnerability. Supports multiple values and negation.\nEx: cve.remediation_level:'O' (official fix)\nEx: cve.remediation_level:'U' (no available fix)"),
-    ("cve.severity", "String", "Yes", "CVSS severity rating of the vulnerability. Value must be in all caps. Supports multiple values and negation.\nValues: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL\nEx: cve.severity:'LOW'\nEx: cve.severity:!'UNKNOWN'"),
-    ("cve.types", "String", "Yes", "Vulnerability type.\nValues: Vulnerability, Misconfiguration, Unsupported software\nEx: cve.types:!'Misconfiguration'"),
-    ("data_providers.ports", "String", "Yes", "Ports on the host where the vulnerability was found by the third-party provider.\nEx: data_providers.ports:'53'\nEx: data_providers.ports:!'0' (any port)"),
-    ("data_providers.provider", "String", "No", "Name of the data provider.\nEx: data_providers.provider:'{provider name}'"),
-    ("data_providers.rating", "String", "Yes", "Third-party provider rating.\nValues: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL\nEx: data_providers.rating:'CRITICAL'"),
-    ("data_providers.scan_time", "Timestamp", "Yes", "UTC date and time when the vulnerability was most recently identified by the third-party provider.\nEx: data_providers.scan_time:>'2023-08-03'"),
-    ("data_providers.scanner_id", "String", "No", "ID of the third-party scanner that identified the vulnerability.\nEx: data_providers.scanner_id:'{scanner id}'"),
-    ("host_info.asset_criticality", "String", "Yes", "Assigned criticality level of the asset.\nValues: Critical, High, Noncritical, Unassigned\nEx: host_info.asset_criticality:['Critical','High']\nEx: host_info.asset_criticality:!'Unassigned'"),
-    ("host_info.groups", "String", "Yes", "Unique system-assigned ID of a host group. Supports multiple values and negation. All values must be enclosed in brackets.\nEx: host_info.groups:['03f0b54af2692e99c4cec945818fbef7']\nEx: host_info.groups:!['03f0b54af2692e99c4cec945818fbef7']"),
-    ("host_info.has_run_container", "Boolean", "No", "Whether or not the host is running Kubernetes containers.\nEx: host_info.has_run_container:true"),
-    ("host_info.internet_exposure", "String", "No", "Whether or not the asset is internet-facing.\nValues: Yes, No, Pending\nEx: host_info.internet_exposure:'Yes'"),
-    ("host_info.managed_by", "String", "Yes", "Indicates if the asset has the Falcon sensor installed.\nValues: Falcon sensor, Unmanaged\nSupports multiple values and negation.\nEx: host_info.managed_by:'Unmanaged'"),
-    ("host_info.platform_name", "String", "Yes", "Operating system platform. Supports negation.\nValues: Windows, Mac, Linux\nEx: host_info.platform_name:'Windows'\nEx: host_info.platform_name:!'Linux'"),
-    ("host_info.product_type_desc", "String", "Yes", "Type of host a sensor is running on. Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name. Enter values with first letter capitalized.\nValues: Workstation, Server, Domain Controller\nEx: host_info.product_type_desc:'Workstation'\nEx: host_info.product_type_desc:!'Workstation'"),
-    ("host_info.tags", "String", "Yes", "Name of a tag assigned to a host. Supports multiple values and negation. All values must be enclosed in brackets.\nEx: host_info.tags:['ephemeral']\nEx: host_info.tags:!['search','ephemeral']"),
-    ("host_info.third_party_asset_ids", "String", "Yes", "Asset IDs assigned to the host by third-party providers in the format: {data_provider}: {data_provider_asset_id}\nSupports multiple values and negation.\nEx: host_info.third_party_asset_ids:'{provider}: {asset_id}'"),
-    ("last_seen_within", "Number", "No", "Filter for vulnerabilities based on the number of days since a host last connected to Falcon. Enter a numeric value from 3 to 45 to indicate the number of days to look back.\nEx: last_seen_within:'10'"),
-    ("services.port", "String", "No", "Port on the host where a vulnerability was found by Falcon EASM or a third-party provider.\nEx: services.port:'443'"),
-    ("services.protocol", "String", "No", "Network protocols recognized by Falcon EASM.\nEx: services.protocol:'pop3'"),
-    ("services.transport", "String", "No", "Transport methods recognized by Falcon EASM.\nEx: services.transport:'tcp'"),
-    ("status", "String", "Yes", "Status of a vulnerability. Value must be in all lowercase letters. Supports multiple values and negation.\nValues: open, closed, reopen, expired\nEx: status:'open'\nEx: status:!'closed'\nEx: status:['open','reopen']"),
-    ("suppression_info.is_suppressed", "Boolean", "No", "Indicates if the vulnerability is suppressed by a suppression rule or not.\nEx: suppression_info.is_suppressed:true"),
-    ("suppression_info.reason", "String", "Yes", "Attribute assigned to a suppression rule. Supports multiple values and negation. All values must be enclosed in brackets.\nValues: ACCEPT_RISK, COMPENSATING_CONTROL, FALSE_POSITIVE\nEx: suppression_info.reason:['ACCEPT_RISK']\nEx: suppression_info.reason:!['FALSE_POSITIVE']"),
-    ("updated_timestamp", "Timestamp", "Yes", "UTC date and time of the last update made on a vulnerability.\nEx: updated_timestamp:<'2021-10-20T22:36'\nEx: updated_timestamp:>'2021-09-15'"),
-    ("vulnerability_id", "String", "Yes", "CVE ID of the vulnerability. If there's no CVE ID, this is the CrowdStrike or third-party ID of the vulnerability.\nFor case-insensitive filtering, add .insensitive to the field name. Supports multiple values and negation.\nEx: vulnerability_id:['CVE-2022-1234']\nEx: vulnerability_id:['CVE-2022-1234','CVE-2023-4321']"),
+    (
+        "Name",
+        "Type",
+        "Operators",
+        "Description"
+    ),
+    (
+        "aid",
+        "String",
+        "No",
+        """
+            Unique agent identifier (AID) of the sensor where the vulnerability was found.
+            For assets without a Falcon sensor installed, this field matches the asset ID field.
+
+            Ex: aid:'abcde6b9a3427d8c4a1af416424d6231'
+        """
+    ),
+    (
+        "apps.remediation.ids",
+        "String",
+        "Yes",
+        """
+            Unique identifier of a remediation. Supports multiple values and negation.
+
+            Ex: apps.remediation.ids:'7bba2e543744a92962be7afeb6484858'
+            Ex: apps.remediation.ids:['ID1','ID2','ID3']
+        """
+    ),
+    (
+        "cid",
+        "String",
+        "No",
+        """
+            Unique system-generated customer identifier (CID) of the account. In multi-CID environments, you can filter by both parent and child CIDs.
+
+            Ex: cid:'0123456789ABCDEFGHIJKLMNOPQRSTUV'
+        """
+    ),
+    (
+        "closed_timestamp",
+        "Timestamp",
+        "Yes",
+        """
+            Date and time a vulnerability was set to a status of CLOSED.
+
+            Ex: closed_timestamp:>'2021-06-25T10:32'
+            Ex: closed_timestamp:<'2021-10-18'
+        """
+    ),
+    (
+        "confidence",
+        "String",
+        "Yes",
+        """
+            Whether or not the vulnerability has been confirmed.
+            Values: confirmed, potential
+
+            Ex: confidence:'potential'
+        """
+    ),
+    (
+        "created_timestamp",
+        "Timestamp",
+        "Yes",
+        """
+            Date and time when this vulnerability was found in your environment. Use this to get vulnerabilities created after the timestamp you last pulled data on.
+
+            Ex: created_timestamp:<'2021-09-25T13:22'
+            Ex: created_timestamp:>'2021-02-12'
+        """
+    ),
+    (
+        "cve.base_score",
+        "Number",
+        "Yes",
+        """
+            CVE base score.
+
+            Ex: cve.base_score:>5.0
+        """
+    ),
+    (
+        "cve.cwes",
+        "String",
+        "Yes",
+        """
+            Unique identifier for a vulnerability from the Common Weakness Enumeration (CWE) list.
+
+            Ex: cve.cwes:['CWE-787','CWE-699']
+        """
+    ),
+    (
+        "cve.exploit_status",
+        "String",
+        "Yes",
+        """
+            Numeric value of the most severe known exploit. Supports multiple values and negation.
+            Values: 0=Unproven, 30=Available, 60=Easily accessible, 90=Actively used
+
+            Ex: cve.exploit_status:'60'
+            Ex: cve.exploit_status:!'0'
+        """
+    ),
+    (
+        "cve.exprt_rating",
+        "String",
+        "Yes",
+        """
+            ExPRT rating assigned by CrowdStrike's predictive AI rating system. Value must be in all caps. Supports multiple values and negation.
+            Values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
+
+            Ex: cve.exprt_rating:'HIGH'
+            Ex: cve.exprt_rating:['HIGH','CRITICAL']
+        """
+    ),
+    (
+        "cve.id",
+        "String",
+        "Yes",
+        """
+            Unique identifier for a vulnerability as cataloged in the National Vulnerability Database (NVD). Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name.
+            Note: All values must be enclosed in brackets.
+
+            Ex: cve.id:['CVE-2022-1234']
+            Ex: cve.id:['CVE-2022-1234','CVE-2023-1234']
+        """
+    ),
+    (
+        "cve.is_cisa_kev",
+        "Boolean",
+        "Yes",
+        """
+            Filter for vulnerabilities that are in the CISA Known Exploited Vulnerabilities (KEV) catalog. Supports negation.
+
+            Ex: cve.is_cisa_kev:true
+        """
+    ),
+    (
+        "cve.remediation_level",
+        "String",
+        "Yes",
+        """
+            CVSS remediation level of the vulnerability. Supports multiple values and negation.
+
+            Ex: cve.remediation_level:'O' (official fix)
+            Ex: cve.remediation_level:'U' (no available fix)
+        """
+    ),
+    (
+        "cve.severity",
+        "String",
+        "Yes",
+        """
+            CVSS severity rating of the vulnerability. Value must be in all caps. Supports multiple values and negation.
+            Values: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL
+
+            Ex: cve.severity:'LOW'
+            Ex: cve.severity:!'UNKNOWN'
+        """
+    ),
+    (
+        "cve.types",
+        "String",
+        "Yes",
+        """
+            Vulnerability type.
+            Values: Vulnerability, Misconfiguration, Unsupported software
+
+            Ex: cve.types:!'Misconfiguration'
+        """
+    ),
+    (
+        "data_providers.ports",
+        "String",
+        "Yes",
+        """
+            Ports on the host where the vulnerability was found by the third-party provider.
+
+            Ex: data_providers.ports:'53'
+            Ex: data_providers.ports:!'0' (any port)
+        """
+    ),
+    (
+        "data_providers.provider",
+        "String",
+        "No",
+        """
+            Name of the data provider.
+
+            Ex: data_providers.provider:'{provider name}'
+        """
+    ),
+    (
+        "data_providers.rating",
+        "String",
+        "Yes",
+        """
+            Third-party provider rating.
+            Values: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL
+
+            Ex: data_providers.rating:'CRITICAL'
+        """
+    ),
+    (
+        "data_providers.scan_time",
+        "Timestamp",
+        "Yes",
+        """
+            UTC date and time when the vulnerability was most recently identified by the third-party provider.
+
+            Ex: data_providers.scan_time:>'2023-08-03'
+        """
+    ),
+    (
+        "data_providers.scanner_id",
+        "String",
+        "No",
+        """
+            ID of the third-party scanner that identified the vulnerability.
+
+            Ex: data_providers.scanner_id:'{scanner id}'
+        """
+    ),
+    (
+        "host_info.asset_criticality",
+        "String",
+        "Yes",
+        """
+            Assigned criticality level of the asset.
+            Values: Critical, High, Noncritical, Unassigned
+
+            Ex: host_info.asset_criticality:['Critical','High']
+            Ex: host_info.asset_criticality:!'Unassigned'
+        """
+    ),
+    (
+        "host_info.groups",
+        "String",
+        "Yes",
+        """
+            Unique system-assigned ID of a host group. Supports multiple values and negation. All values must be enclosed in brackets.
+
+            Ex: host_info.groups:['03f0b54af2692e99c4cec945818fbef7']
+            Ex: host_info.groups:!['03f0b54af2692e99c4cec945818fbef7']
+        """
+    ),
+    (
+        "host_info.has_run_container",
+        "Boolean",
+        "No",
+        """
+            Whether or not the host is running Kubernetes containers.
+
+            Ex: host_info.has_run_container:true
+        """
+    ),
+    (
+        "host_info.internet_exposure",
+        "String",
+        "No",
+        """
+            Whether or not the asset is internet-facing.
+            Values: Yes, No, Pending
+
+            Ex: host_info.internet_exposure:'Yes'
+        """
+    ),
+    (
+        "host_info.managed_by",
+        "String",
+        "Yes",
+        """
+            Indicates if the asset has the Falcon sensor installed.
+            Values: Falcon sensor, Unmanaged
+            Supports multiple values and negation.
+
+            Ex: host_info.managed_by:'Unmanaged'
+        """
+    ),
+    (
+        "host_info.platform_name",
+        "String",
+        "Yes",
+        """
+            Operating system platform. Supports negation.
+            Values: Windows, Mac, Linux
+
+            Ex: host_info.platform_name:'Windows'
+            Ex: host_info.platform_name:!'Linux'
+        """
+    ),
+    (
+        "host_info.product_type_desc",
+        "String",
+        "Yes",
+        """
+            Type of host a sensor is running on. Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name. Enter values with first letter capitalized.
+            Values: Workstation, Server, Domain Controller
+
+            Ex: host_info.product_type_desc:'Workstation'
+            Ex: host_info.product_type_desc:!'Workstation'
+        """
+    ),
+    (
+        "host_info.tags",
+        "String",
+        "Yes",
+        """
+            Name of a tag assigned to a host. Supports multiple values and negation. All values must be enclosed in brackets.
+
+            Ex: host_info.tags:['ephemeral']
+            Ex: host_info.tags:!['search','ephemeral']
+        """
+    ),
+    (
+        "host_info.third_party_asset_ids",
+        "String",
+        "Yes",
+        """
+            Asset IDs assigned to the host by third-party providers in the format: {data_provider}: {data_provider_asset_id}
+            Supports multiple values and negation.
+
+            Ex: host_info.third_party_asset_ids:'{provider}: {asset_id}'
+        """
+    ),
+    (
+        "last_seen_within",
+        "Number",
+        "No",
+        """
+            Filter for vulnerabilities based on the number of days since a host last connected to Falcon. Enter a numeric value from 3 to 45 to indicate the number of days to look back.
+
+            Ex: last_seen_within:'10'
+        """
+    ),
+    (
+        "services.port",
+        "String",
+        "No",
+        """
+            Port on the host where a vulnerability was found by Falcon EASM or a third-party provider.
+
+            Ex: services.port:'443'
+        """
+    ),
+    (
+        "services.protocol",
+        "String",
+        "No",
+        """
+            Network protocols recognized by Falcon EASM.
+
+            Ex: services.protocol:'pop3'
+        """
+    ),
+    (
+        "services.transport",
+        "String",
+        "No",
+        """
+            Transport methods recognized by Falcon EASM.
+
+            Ex: services.transport:'tcp'
+        """
+    ),
+    (
+        "status",
+        "String",
+        "Yes",
+        """
+            Status of a vulnerability. Value must be in all lowercase letters. Supports multiple values and negation.
+            Values: open, closed, reopen, expired
+
+            Ex: status:'open'
+            Ex: status:!'closed'
+            Ex: status:['open','reopen']
+        """
+    ),
+    (
+        "suppression_info.is_suppressed",
+        "Boolean",
+        "No",
+        """
+            Indicates if the vulnerability is suppressed by a suppression rule or not.
+
+            Ex: suppression_info.is_suppressed:true
+        """
+    ),
+    (
+        "suppression_info.reason",
+        "String",
+        "Yes",
+        """
+            Attribute assigned to a suppression rule. Supports multiple values and negation. All values must be enclosed in brackets.
+            Values: ACCEPT_RISK, COMPENSATING_CONTROL, FALSE_POSITIVE
+
+            Ex: suppression_info.reason:['ACCEPT_RISK']
+            Ex: suppression_info.reason:!['FALSE_POSITIVE']
+        """
+    ),
+    (
+        "updated_timestamp",
+        "Timestamp",
+        "Yes",
+        """
+            UTC date and time of the last update made on a vulnerability.
+
+            Ex: updated_timestamp:<'2021-10-20T22:36'
+            Ex: updated_timestamp:>'2021-09-15'
+        """
+    ),
+    (
+        "vulnerability_id",
+        "String",
+        "Yes",
+        """
+            CVE ID of the vulnerability. If there's no CVE ID, this is the CrowdStrike or third-party ID of the vulnerability.
+            For case-insensitive filtering, add .insensitive to the field name. Supports multiple values and negation.
+
+            Ex: vulnerability_id:['CVE-2022-1234']
+            Ex: vulnerability_id:['CVE-2022-1234','CVE-2023-4321']
+        """
+    ),
 ]
 
 SEARCH_VULNERABILITIES_FQL_DOCUMENTATION = """Falcon Query Language (FQL) - Search Vulnerabilities Guide

--- a/falcon_mcp/resources/spotlight.py
+++ b/falcon_mcp/resources/spotlight.py
@@ -2,7 +2,7 @@
 Contains Spotlight Vulnerabilities resources.
 """
 
-from falcon_mcp.common.utils import generate_table
+from falcon_mcp.common.utils import generate_md_table
 
 # List of tuples containing filter options data: (name, type, operators, description)
 SEARCH_VULNERABILITIES_FQL_FILTERS = [
@@ -17,10 +17,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "No",
         """
-            Unique agent identifier (AID) of the sensor where the vulnerability was found.
-            For assets without a Falcon sensor installed, this field matches the asset ID field.
+        Unique agent identifier (AID) of the sensor where the vulnerability was found.
+        For assets without a Falcon sensor installed, this field matches the asset ID field.
 
-            Ex: aid:'abcde6b9a3427d8c4a1af416424d6231'
+        Ex: aid:'abcde6b9a3427d8c4a1af416424d6231'
         """
     ),
     (
@@ -28,10 +28,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Unique identifier of a remediation. Supports multiple values and negation.
+        Unique identifier of a remediation. Supports multiple values and negation.
 
-            Ex: apps.remediation.ids:'7bba2e543744a92962be7afeb6484858'
-            Ex: apps.remediation.ids:['ID1','ID2','ID3']
+        Ex: apps.remediation.ids:'7bba2e543744a92962be7afeb6484858'
+        Ex: apps.remediation.ids:['ID1','ID2','ID3']
         """
     ),
     (
@@ -39,9 +39,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "No",
         """
-            Unique system-generated customer identifier (CID) of the account. In multi-CID environments, you can filter by both parent and child CIDs.
+        Unique system-generated customer identifier (CID) of the account. In multi-CID environments, you can filter by both parent and child CIDs.
 
-            Ex: cid:'0123456789ABCDEFGHIJKLMNOPQRSTUV'
+        Ex: cid:'0123456789ABCDEFGHIJKLMNOPQRSTUV'
         """
     ),
     (
@@ -49,10 +49,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "Timestamp",
         "Yes",
         """
-            Date and time a vulnerability was set to a status of CLOSED.
+        Date and time a vulnerability was set to a status of CLOSED.
 
-            Ex: closed_timestamp:>'2021-06-25T10:32'
-            Ex: closed_timestamp:<'2021-10-18'
+        Ex: closed_timestamp:>'2021-06-25T10:32'
+        Ex: closed_timestamp:<'2021-10-18'
         """
     ),
     (
@@ -60,10 +60,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Whether or not the vulnerability has been confirmed.
-            Values: confirmed, potential
+        Whether or not the vulnerability has been confirmed.
+        Values: confirmed, potential
 
-            Ex: confidence:'potential'
+        Ex: confidence:'potential'
         """
     ),
     (
@@ -71,10 +71,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "Timestamp",
         "Yes",
         """
-            Date and time when this vulnerability was found in your environment. Use this to get vulnerabilities created after the timestamp you last pulled data on.
+        Date and time when this vulnerability was found in your environment. Use this to get vulnerabilities created after the timestamp you last pulled data on.
 
-            Ex: created_timestamp:<'2021-09-25T13:22'
-            Ex: created_timestamp:>'2021-02-12'
+        Ex: created_timestamp:<'2021-09-25T13:22'
+        Ex: created_timestamp:>'2021-02-12'
         """
     ),
     (
@@ -82,9 +82,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "Number",
         "Yes",
         """
-            CVE base score.
+        CVE base score.
 
-            Ex: cve.base_score:>5.0
+        Ex: cve.base_score:>5.0
         """
     ),
     (
@@ -92,9 +92,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Unique identifier for a vulnerability from the Common Weakness Enumeration (CWE) list.
+        Unique identifier for a vulnerability from the Common Weakness Enumeration (CWE) list.
 
-            Ex: cve.cwes:['CWE-787','CWE-699']
+        Ex: cve.cwes:['CWE-787','CWE-699']
         """
     ),
     (
@@ -102,11 +102,11 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Numeric value of the most severe known exploit. Supports multiple values and negation.
-            Values: 0=Unproven, 30=Available, 60=Easily accessible, 90=Actively used
+        Numeric value of the most severe known exploit. Supports multiple values and negation.
+        Values: 0=Unproven, 30=Available, 60=Easily accessible, 90=Actively used
 
-            Ex: cve.exploit_status:'60'
-            Ex: cve.exploit_status:!'0'
+        Ex: cve.exploit_status:'60'
+        Ex: cve.exploit_status:!'0'
         """
     ),
     (
@@ -114,11 +114,11 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            ExPRT rating assigned by CrowdStrike's predictive AI rating system. Value must be in all caps. Supports multiple values and negation.
-            Values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
+        ExPRT rating assigned by CrowdStrike's predictive AI rating system. Value must be in all caps. Supports multiple values and negation.
+        Values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
 
-            Ex: cve.exprt_rating:'HIGH'
-            Ex: cve.exprt_rating:['HIGH','CRITICAL']
+        Ex: cve.exprt_rating:'HIGH'
+        Ex: cve.exprt_rating:['HIGH','CRITICAL']
         """
     ),
     (
@@ -126,11 +126,11 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Unique identifier for a vulnerability as cataloged in the National Vulnerability Database (NVD). Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name.
-            Note: All values must be enclosed in brackets.
+        Unique identifier for a vulnerability as cataloged in the National Vulnerability Database (NVD). Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name.
+        Note: All values must be enclosed in brackets.
 
-            Ex: cve.id:['CVE-2022-1234']
-            Ex: cve.id:['CVE-2022-1234','CVE-2023-1234']
+        Ex: cve.id:['CVE-2022-1234']
+        Ex: cve.id:['CVE-2022-1234','CVE-2023-1234']
         """
     ),
     (
@@ -138,9 +138,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "Boolean",
         "Yes",
         """
-            Filter for vulnerabilities that are in the CISA Known Exploited Vulnerabilities (KEV) catalog. Supports negation.
+        Filter for vulnerabilities that are in the CISA Known Exploited Vulnerabilities (KEV) catalog. Supports negation.
 
-            Ex: cve.is_cisa_kev:true
+        Ex: cve.is_cisa_kev:true
         """
     ),
     (
@@ -148,10 +148,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            CVSS remediation level of the vulnerability. Supports multiple values and negation.
+        CVSS remediation level of the vulnerability. Supports multiple values and negation.
 
-            Ex: cve.remediation_level:'O' (official fix)
-            Ex: cve.remediation_level:'U' (no available fix)
+        Ex: cve.remediation_level:'O' (official fix)
+        Ex: cve.remediation_level:'U' (no available fix)
         """
     ),
     (
@@ -159,11 +159,11 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            CVSS severity rating of the vulnerability. Value must be in all caps. Supports multiple values and negation.
-            Values: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL
+        CVSS severity rating of the vulnerability. Value must be in all caps. Supports multiple values and negation.
+        Values: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL
 
-            Ex: cve.severity:'LOW'
-            Ex: cve.severity:!'UNKNOWN'
+        Ex: cve.severity:'LOW'
+        Ex: cve.severity:!'UNKNOWN'
         """
     ),
     (
@@ -171,10 +171,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Vulnerability type.
-            Values: Vulnerability, Misconfiguration, Unsupported software
+        Vulnerability type.
+        Values: Vulnerability, Misconfiguration, Unsupported software
 
-            Ex: cve.types:!'Misconfiguration'
+        Ex: cve.types:!'Misconfiguration'
         """
     ),
     (
@@ -182,10 +182,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Ports on the host where the vulnerability was found by the third-party provider.
+        Ports on the host where the vulnerability was found by the third-party provider.
 
-            Ex: data_providers.ports:'53'
-            Ex: data_providers.ports:!'0' (any port)
+        Ex: data_providers.ports:'53'
+        Ex: data_providers.ports:!'0' (any port)
         """
     ),
     (
@@ -193,9 +193,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "No",
         """
-            Name of the data provider.
+        Name of the data provider.
 
-            Ex: data_providers.provider:'{provider name}'
+        Ex: data_providers.provider:'{provider name}'
         """
     ),
     (
@@ -203,10 +203,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Third-party provider rating.
-            Values: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL
+        Third-party provider rating.
+        Values: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL
 
-            Ex: data_providers.rating:'CRITICAL'
+        Ex: data_providers.rating:'CRITICAL'
         """
     ),
     (
@@ -214,9 +214,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "Timestamp",
         "Yes",
         """
-            UTC date and time when the vulnerability was most recently identified by the third-party provider.
+        UTC date and time when the vulnerability was most recently identified by the third-party provider.
 
-            Ex: data_providers.scan_time:>'2023-08-03'
+        Ex: data_providers.scan_time:>'2023-08-03'
         """
     ),
     (
@@ -224,9 +224,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "No",
         """
-            ID of the third-party scanner that identified the vulnerability.
+        ID of the third-party scanner that identified the vulnerability.
 
-            Ex: data_providers.scanner_id:'{scanner id}'
+        Ex: data_providers.scanner_id:'{scanner id}'
         """
     ),
     (
@@ -234,11 +234,11 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Assigned criticality level of the asset.
-            Values: Critical, High, Noncritical, Unassigned
+        Assigned criticality level of the asset.
+        Values: Critical, High, Noncritical, Unassigned
 
-            Ex: host_info.asset_criticality:['Critical','High']
-            Ex: host_info.asset_criticality:!'Unassigned'
+        Ex: host_info.asset_criticality:['Critical','High']
+        Ex: host_info.asset_criticality:!'Unassigned'
         """
     ),
     (
@@ -246,10 +246,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Unique system-assigned ID of a host group. Supports multiple values and negation. All values must be enclosed in brackets.
+        Unique system-assigned ID of a host group. Supports multiple values and negation. All values must be enclosed in brackets.
 
-            Ex: host_info.groups:['03f0b54af2692e99c4cec945818fbef7']
-            Ex: host_info.groups:!['03f0b54af2692e99c4cec945818fbef7']
+        Ex: host_info.groups:['03f0b54af2692e99c4cec945818fbef7']
+        Ex: host_info.groups:!['03f0b54af2692e99c4cec945818fbef7']
         """
     ),
     (
@@ -257,9 +257,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "Boolean",
         "No",
         """
-            Whether or not the host is running Kubernetes containers.
+        Whether or not the host is running Kubernetes containers.
 
-            Ex: host_info.has_run_container:true
+        Ex: host_info.has_run_container:true
         """
     ),
     (
@@ -267,10 +267,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "No",
         """
-            Whether or not the asset is internet-facing.
-            Values: Yes, No, Pending
+        Whether or not the asset is internet-facing.
+        Values: Yes, No, Pending
 
-            Ex: host_info.internet_exposure:'Yes'
+        Ex: host_info.internet_exposure:'Yes'
         """
     ),
     (
@@ -278,11 +278,11 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Indicates if the asset has the Falcon sensor installed.
-            Values: Falcon sensor, Unmanaged
-            Supports multiple values and negation.
+        Indicates if the asset has the Falcon sensor installed.
+        Values: Falcon sensor, Unmanaged
+        Supports multiple values and negation.
 
-            Ex: host_info.managed_by:'Unmanaged'
+        Ex: host_info.managed_by:'Unmanaged'
         """
     ),
     (
@@ -290,11 +290,11 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Operating system platform. Supports negation.
-            Values: Windows, Mac, Linux
+        Operating system platform. Supports negation.
+        Values: Windows, Mac, Linux
 
-            Ex: host_info.platform_name:'Windows'
-            Ex: host_info.platform_name:!'Linux'
+        Ex: host_info.platform_name:'Windows'
+        Ex: host_info.platform_name:!'Linux'
         """
     ),
     (
@@ -302,11 +302,11 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Type of host a sensor is running on. Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name. Enter values with first letter capitalized.
-            Values: Workstation, Server, Domain Controller
+        Type of host a sensor is running on. Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name. Enter values with first letter capitalized.
+        Values: Workstation, Server, Domain Controller
 
-            Ex: host_info.product_type_desc:'Workstation'
-            Ex: host_info.product_type_desc:!'Workstation'
+        Ex: host_info.product_type_desc:'Workstation'
+        Ex: host_info.product_type_desc:!'Workstation'
         """
     ),
     (
@@ -314,10 +314,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Name of a tag assigned to a host. Supports multiple values and negation. All values must be enclosed in brackets.
+        Name of a tag assigned to a host. Supports multiple values and negation. All values must be enclosed in brackets.
 
-            Ex: host_info.tags:['ephemeral']
-            Ex: host_info.tags:!['search','ephemeral']
+        Ex: host_info.tags:['ephemeral']
+        Ex: host_info.tags:!['search','ephemeral']
         """
     ),
     (
@@ -325,10 +325,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Asset IDs assigned to the host by third-party providers in the format: {data_provider}: {data_provider_asset_id}
-            Supports multiple values and negation.
+        Asset IDs assigned to the host by third-party providers in the format: {data_provider}: {data_provider_asset_id}
+        Supports multiple values and negation.
 
-            Ex: host_info.third_party_asset_ids:'{provider}: {asset_id}'
+        Ex: host_info.third_party_asset_ids:'{provider}: {asset_id}'
         """
     ),
     (
@@ -336,9 +336,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "Number",
         "No",
         """
-            Filter for vulnerabilities based on the number of days since a host last connected to Falcon. Enter a numeric value from 3 to 45 to indicate the number of days to look back.
+        Filter for vulnerabilities based on the number of days since a host last connected to Falcon. Enter a numeric value from 3 to 45 to indicate the number of days to look back.
 
-            Ex: last_seen_within:'10'
+        Ex: last_seen_within:'10'
         """
     ),
     (
@@ -346,9 +346,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "No",
         """
-            Port on the host where a vulnerability was found by Falcon EASM or a third-party provider.
+        Port on the host where a vulnerability was found by Falcon EASM or a third-party provider.
 
-            Ex: services.port:'443'
+        Ex: services.port:'443'
         """
     ),
     (
@@ -356,9 +356,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "No",
         """
-            Network protocols recognized by Falcon EASM.
+        Network protocols recognized by Falcon EASM.
 
-            Ex: services.protocol:'pop3'
+        Ex: services.protocol:'pop3'
         """
     ),
     (
@@ -366,9 +366,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "No",
         """
-            Transport methods recognized by Falcon EASM.
+        Transport methods recognized by Falcon EASM.
 
-            Ex: services.transport:'tcp'
+        Ex: services.transport:'tcp'
         """
     ),
     (
@@ -376,12 +376,12 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Status of a vulnerability. Value must be in all lowercase letters. Supports multiple values and negation.
-            Values: open, closed, reopen, expired
+        Status of a vulnerability. Value must be in all lowercase letters. Supports multiple values and negation.
+        Values: open, closed, reopen, expired
 
-            Ex: status:'open'
-            Ex: status:!'closed'
-            Ex: status:['open','reopen']
+        Ex: status:'open'
+        Ex: status:!'closed'
+        Ex: status:['open','reopen']
         """
     ),
     (
@@ -389,9 +389,9 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "Boolean",
         "No",
         """
-            Indicates if the vulnerability is suppressed by a suppression rule or not.
+        Indicates if the vulnerability is suppressed by a suppression rule or not.
 
-            Ex: suppression_info.is_suppressed:true
+        Ex: suppression_info.is_suppressed:true
         """
     ),
     (
@@ -399,11 +399,11 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            Attribute assigned to a suppression rule. Supports multiple values and negation. All values must be enclosed in brackets.
-            Values: ACCEPT_RISK, COMPENSATING_CONTROL, FALSE_POSITIVE
+        Attribute assigned to a suppression rule. Supports multiple values and negation. All values must be enclosed in brackets.
+        Values: ACCEPT_RISK, COMPENSATING_CONTROL, FALSE_POSITIVE
 
-            Ex: suppression_info.reason:['ACCEPT_RISK']
-            Ex: suppression_info.reason:!['FALSE_POSITIVE']
+        Ex: suppression_info.reason:['ACCEPT_RISK']
+        Ex: suppression_info.reason:!['FALSE_POSITIVE']
         """
     ),
     (
@@ -411,10 +411,10 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "Timestamp",
         "Yes",
         """
-            UTC date and time of the last update made on a vulnerability.
+        UTC date and time of the last update made on a vulnerability.
 
-            Ex: updated_timestamp:<'2021-10-20T22:36'
-            Ex: updated_timestamp:>'2021-09-15'
+        Ex: updated_timestamp:<'2021-10-20T22:36'
+        Ex: updated_timestamp:>'2021-09-15'
         """
     ),
     (
@@ -422,11 +422,11 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
         "String",
         "Yes",
         """
-            CVE ID of the vulnerability. If there's no CVE ID, this is the CrowdStrike or third-party ID of the vulnerability.
-            For case-insensitive filtering, add .insensitive to the field name. Supports multiple values and negation.
+        CVE ID of the vulnerability. If there's no CVE ID, this is the CrowdStrike or third-party ID of the vulnerability.
+        For case-insensitive filtering, add .insensitive to the field name. Supports multiple values and negation.
 
-            Ex: vulnerability_id:['CVE-2022-1234']
-            Ex: vulnerability_id:['CVE-2022-1234','CVE-2023-4321']
+        Ex: vulnerability_id:['CVE-2022-1234']
+        Ex: vulnerability_id:['CVE-2022-1234','CVE-2023-4321']
         """
     ),
 ]
@@ -459,7 +459,7 @@ property_name:[operator]'value'
 
 === falcon_search_vulnerabilities FQL filter options ===
 
-""" + generate_table(SEARCH_VULNERABILITIES_FQL_FILTERS) + """
+""" + generate_md_table(SEARCH_VULNERABILITIES_FQL_FILTERS) + """
 
 === IMPORTANT NOTES ===
 • Use single quotes around string values: 'value'

--- a/falcon_mcp/resources/spotlight.py
+++ b/falcon_mcp/resources/spotlight.py
@@ -2,6 +2,51 @@
 Contains Spotlight Vulnerabilities resources.
 """
 
+# List of tuples containing filter options data: (name, type, operators, description)
+SEARCH_VULNERABILITIES_FQL_FILTERS = [
+    ("Name", "Type", "Operators", "Description"),
+    ("aid", "String", "No", "Unique agent identifier (AID) of the sensor where the vulnerability was found. For assets without a Falcon sensor installed, this field matches the asset ID field.\nEx: aid:'abcde6b9a3427d8c4a1af416424d6231'"),
+    ("apps.remediation.ids", "String", "Yes", "Unique identifier of a remediation. Supports multiple values and negation.\nEx: apps.remediation.ids:'7bba2e543744a92962be7afeb6484858'\nEx: apps.remediation.ids:['ID1','ID2','ID3']"),
+    ("cid", "String", "No", "Unique system-generated customer identifier (CID) of the account. In multi-CID environments, you can filter by both parent and child CIDs.\nEx: cid:'0123456789ABCDEFGHIJKLMNOPQRSTUV'"),
+    ("closed_timestamp", "Timestamp", "Yes", "Date and time a vulnerability was set to a status of CLOSED.\nEx: closed_timestamp:>'2021-06-25T10:32'\nEx: closed_timestamp:<'2021-10-18'"),
+    ("confidence", "String", "Yes", "Whether or not the vulnerability has been confirmed.\nValues: confirmed, potential\nEx: confidence:'potential'"),
+    ("created_timestamp", "Timestamp", "Yes", "Date and time when this vulnerability was found in your environment. Use this to get vulnerabilities created after the timestamp you last pulled data on.\nEx: created_timestamp:<'2021-09-25T13:22'\nEx: created_timestamp:>'2021-02-12'"),
+    ("cve.base_score", "Number", "Yes", "CVE base score.\nEx: cve.base_score:>5.0"),
+    ("cve.cwes", "String", "Yes", "Unique identifier for a vulnerability from the Common Weakness Enumeration (CWE) list.\nEx: cve.cwes:['CWE-787','CWE-699']"),
+    ("cve.exploit_status", "String", "Yes", "Numeric value of the most severe known exploit. Supports multiple values and negation.\nValues: 0=Unproven, 30=Available, 60=Easily accessible, 90=Actively used\nEx: cve.exploit_status:'60'\nEx: cve.exploit_status:!'0'"),
+    ("cve.exprt_rating", "String", "Yes", "ExPRT rating assigned by CrowdStrike's predictive AI rating system. Value must be in all caps. Supports multiple values and negation.\nValues: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL\nEx: cve.exprt_rating:'HIGH'\nEx: cve.exprt_rating:['HIGH','CRITICAL']"),
+    ("cve.id", "String", "Yes", "Unique identifier for a vulnerability as cataloged in the National Vulnerability Database (NVD). Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name.\nNote: All values must be enclosed in brackets.\nEx: cve.id:['CVE-2022-1234']\nEx: cve.id:['CVE-2022-1234','CVE-2023-1234']"),
+    ("cve.is_cisa_kev", "Boolean", "Yes", "Filter for vulnerabilities that are in the CISA Known Exploited Vulnerabilities (KEV) catalog. Supports negation.\nEx: cve.is_cisa_kev:true"),
+    ("cve.remediation_level", "String", "Yes", "CVSS remediation level of the vulnerability. Supports multiple values and negation.\nEx: cve.remediation_level:'O' (official fix)\nEx: cve.remediation_level:'U' (no available fix)"),
+    ("cve.severity", "String", "Yes", "CVSS severity rating of the vulnerability. Value must be in all caps. Supports multiple values and negation.\nValues: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL\nEx: cve.severity:'LOW'\nEx: cve.severity:!'UNKNOWN'"),
+    ("cve.types", "String", "Yes", "Vulnerability type.\nValues: Vulnerability, Misconfiguration, Unsupported software\nEx: cve.types:!'Misconfiguration'"),
+    ("data_providers.ports", "String", "Yes", "Ports on the host where the vulnerability was found by the third-party provider.\nEx: data_providers.ports:'53'\nEx: data_providers.ports:!'0' (any port)"),
+    ("data_providers.provider", "String", "No", "Name of the data provider.\nEx: data_providers.provider:'{provider name}'"),
+    ("data_providers.rating", "String", "Yes", "Third-party provider rating.\nValues: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL\nEx: data_providers.rating:'CRITICAL'"),
+    ("data_providers.scan_time", "Timestamp", "Yes", "UTC date and time when the vulnerability was most recently identified by the third-party provider.\nEx: data_providers.scan_time:>'2023-08-03'"),
+    ("data_providers.scanner_id", "String", "No", "ID of the third-party scanner that identified the vulnerability.\nEx: data_providers.scanner_id:'{scanner id}'"),
+    ("host_info.asset_criticality", "String", "Yes", "Assigned criticality level of the asset.\nValues: Critical, High, Noncritical, Unassigned\nEx: host_info.asset_criticality:['Critical','High']\nEx: host_info.asset_criticality:!'Unassigned'"),
+    ("host_info.groups", "String", "Yes", "Unique system-assigned ID of a host group. Supports multiple values and negation. All values must be enclosed in brackets.\nEx: host_info.groups:['03f0b54af2692e99c4cec945818fbef7']\nEx: host_info.groups:!['03f0b54af2692e99c4cec945818fbef7']"),
+    ("host_info.has_run_container", "Boolean", "No", "Whether or not the host is running Kubernetes containers.\nEx: host_info.has_run_container:true"),
+    ("host_info.internet_exposure", "String", "No", "Whether or not the asset is internet-facing.\nValues: Yes, No, Pending\nEx: host_info.internet_exposure:'Yes'"),
+    ("host_info.managed_by", "String", "Yes", "Indicates if the asset has the Falcon sensor installed.\nValues: Falcon sensor, Unmanaged\nSupports multiple values and negation.\nEx: host_info.managed_by:'Unmanaged'"),
+    ("host_info.platform_name", "String", "Yes", "Operating system platform. Supports negation.\nValues: Windows, Mac, Linux\nEx: host_info.platform_name:'Windows'\nEx: host_info.platform_name:!'Linux'"),
+    ("host_info.product_type_desc", "String", "Yes", "Type of host a sensor is running on. Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name. Enter values with first letter capitalized.\nValues: Workstation, Server, Domain Controller\nEx: host_info.product_type_desc:'Workstation'\nEx: host_info.product_type_desc:!'Workstation'"),
+    ("host_info.tags", "String", "Yes", "Name of a tag assigned to a host. Supports multiple values and negation. All values must be enclosed in brackets.\nEx: host_info.tags:['ephemeral']\nEx: host_info.tags:!['search','ephemeral']"),
+    ("host_info.third_party_asset_ids", "String", "Yes", "Asset IDs assigned to the host by third-party providers in the format: {data_provider}: {data_provider_asset_id}\nSupports multiple values and negation.\nEx: host_info.third_party_asset_ids:'{provider}: {asset_id}'"),
+    ("last_seen_within", "Number", "No", "Filter for vulnerabilities based on the number of days since a host last connected to Falcon. Enter a numeric value from 3 to 45 to indicate the number of days to look back.\nEx: last_seen_within:'10'"),
+    ("services.port", "String", "No", "Port on the host where a vulnerability was found by Falcon EASM or a third-party provider.\nEx: services.port:'443'"),
+    ("services.protocol", "String", "No", "Network protocols recognized by Falcon EASM.\nEx: services.protocol:'pop3'"),
+    ("services.transport", "String", "No", "Transport methods recognized by Falcon EASM.\nEx: services.transport:'tcp'"),
+    ("status", "String", "Yes", "Status of a vulnerability. Value must be in all lowercase letters. Supports multiple values and negation.\nValues: open, closed, reopen, expired\nEx: status:'open'\nEx: status:!'closed'\nEx: status:['open','reopen']"),
+    ("suppression_info.is_suppressed", "Boolean", "No", "Indicates if the vulnerability is suppressed by a suppression rule or not.\nEx: suppression_info.is_suppressed:true"),
+    ("suppression_info.reason", "String", "Yes", "Attribute assigned to a suppression rule. Supports multiple values and negation. All values must be enclosed in brackets.\nValues: ACCEPT_RISK, COMPENSATING_CONTROL, FALSE_POSITIVE\nEx: suppression_info.reason:['ACCEPT_RISK']\nEx: suppression_info.reason:!['FALSE_POSITIVE']"),
+    ("updated_timestamp", "Timestamp", "Yes", "UTC date and time of the last update made on a vulnerability.\nEx: updated_timestamp:<'2021-10-20T22:36'\nEx: updated_timestamp:>'2021-09-15'"),
+    ("vulnerability_id", "String", "Yes", "CVE ID of the vulnerability. If there's no CVE ID, this is the CrowdStrike or third-party ID of the vulnerability.\nFor case-insensitive filtering, add .insensitive to the field name. Supports multiple values and negation.\nEx: vulnerability_id:['CVE-2022-1234']\nEx: vulnerability_id:['CVE-2022-1234','CVE-2023-4321']"),
+]
+
+from falcon_mcp.common.utils import generate_table
+
 SEARCH_VULNERABILITIES_FQL_DOCUMENTATION = """Falcon Query Language (FQL) - Search Vulnerabilities Guide
 
 === BASIC SYNTAX ===
@@ -30,193 +75,7 @@ property_name:[operator]'value'
 
 === falcon_search_vulnerabilities FQL filter options ===
 
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| Name                             | Type                      | Operators| Description                                                      |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| aid                              | String                    | No       | Unique agent identifier (AID) of the sensor where the           |
-|                                  |                           |          | vulnerability was found. For assets without a Falcon sensor     |
-|                                  |                           |          | installed, this field matches the asset ID field.               |
-|                                  |                           |          | Ex: aid:'abcde6b9a3427d8c4a1af416424d6231'                      |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| apps.remediation.ids             | String                    | Yes      | Unique identifier of a remediation. Supports multiple values     |
-|                                  |                           |          | and negation.                                                    |
-|                                  |                           |          | Ex: apps.remediation.ids:'7bba2e543744a92962be7afeb6484858'      |
-|                                  |                           |          | Ex: apps.remediation.ids:['ID1','ID2','ID3']                    |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| cid                              | String                    | No       | Unique system-generated customer identifier (CID) of the        |
-|                                  |                           |          | account. In multi-CID environments, you can filter by both      |
-|                                  |                           |          | parent and child CIDs.                                           |
-|                                  |                           |          | Ex: cid:'0123456789ABCDEFGHIJKLMNOPQRSTUV'                       |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| closed_timestamp                 | Timestamp                 | Yes      | Date and time a vulnerability was set to a status of CLOSED.    |
-|                                  |                           |          | Ex: closed_timestamp:>'2021-06-25T10:32'                        |
-|                                  |                           |          | Ex: closed_timestamp:<'2021-10-18'                              |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| confidence                       | String                    | Yes      | Whether or not the vulnerability has been confirmed.             |
-|                                  |                           |          | Values: confirmed, potential                                     |
-|                                  |                           |          | Ex: confidence:'potential'                                       |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| created_timestamp                | Timestamp                 | Yes      | Date and time when this vulnerability was found in your          |
-|                                  |                           |          | environment. Use this to get vulnerabilities created after      |
-|                                  |                           |          | the timestamp you last pulled data on.                          |
-|                                  |                           |          | Ex: created_timestamp:<'2021-09-25T13:22'                       |
-|                                  |                           |          | Ex: created_timestamp:>'2021-02-12'                             |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| cve.base_score                   | Number                    | Yes      | CVE base score.                                                  |
-|                                  |                           |          | Ex: cve.base_score:>5.0                                          |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| cve.cwes                         | String                    | Yes      | Unique identifier for a vulnerability from the Common            |
-|                                  |                           |          | Weakness Enumeration (CWE) list.                                |
-|                                  |                           |          | Ex: cve.cwes:['CWE-787','CWE-699']                               |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| cve.exploit_status               | String                    | Yes      | Numeric value of the most severe known exploit. Supports        |
-|                                  |                           |          | multiple values and negation.                                    |
-|                                  |                           |          | Values: 0=Unproven, 30=Available, 60=Easily accessible,        |
-|                                  |                           |          | 90=Actively used                                                 |
-|                                  |                           |          | Ex: cve.exploit_status:'60'                                      |
-|                                  |                           |          | Ex: cve.exploit_status:!'0'                                      |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| cve.exprt_rating                 | String                    | Yes      | ExPRT rating assigned by CrowdStrike's predictive AI rating     |
-|                                  |                           |          | system. Value must be in all caps. Supports multiple values     |
-|                                  |                           |          | and negation.                                                    |
-|                                  |                           |          | Values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL                    |
-|                                  |                           |          | Ex: cve.exprt_rating:'HIGH'                                      |
-|                                  |                           |          | Ex: cve.exprt_rating:['HIGH','CRITICAL']                        |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| cve.id                           | String                    | Yes      | Unique identifier for a vulnerability as cataloged in the       |
-|                                  |                           |          | National Vulnerability Database (NVD). Supports multiple        |
-|                                  |                           |          | values and negation. For case-insensitive filtering, add        |
-|                                  |                           |          | .insensitive to the field name.                                 |
-|                                  |                           |          | Note: All values must be enclosed in brackets.                  |
-|                                  |                           |          | Ex: cve.id:['CVE-2022-1234']                                    |
-|                                  |                           |          | Ex: cve.id:['CVE-2022-1234','CVE-2023-1234']                    |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| cve.is_cisa_kev                  | Boolean                   | Yes      | Filter for vulnerabilities that are in the CISA Known          |
-|                                  |                           |          | Exploited Vulnerabilities (KEV) catalog. Supports negation.     |
-|                                  |                           |          | Ex: cve.is_cisa_kev:true                                         |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| cve.remediation_level            | String                    | Yes      | CVSS remediation level of the vulnerability. Supports           |
-|                                  |                           |          | multiple values and negation.                                    |
-|                                  |                           |          | Ex: cve.remediation_level:'O' (official fix)                    |
-|                                  |                           |          | Ex: cve.remediation_level:'U' (no available fix)                |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| cve.severity                     | String                    | Yes      | CVSS severity rating of the vulnerability. Value must be in     |
-|                                  |                           |          | all caps. Supports multiple values and negation.                |
-|                                  |                           |          | Values: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL              |
-|                                  |                           |          | Ex: cve.severity:'LOW'                                           |
-|                                  |                           |          | Ex: cve.severity:!'UNKNOWN'                                      |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| cve.types                        | String                    | Yes      | Vulnerability type.                                              |
-|                                  |                           |          | Values: Vulnerability, Misconfiguration, Unsupported software   |
-|                                  |                           |          | Ex: cve.types:!'Misconfiguration'                               |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| data_providers.ports             | String                    | Yes      | Ports on the host where the vulnerability was found by the      |
-|                                  |                           |          | third-party provider.                                            |
-|                                  |                           |          | Ex: data_providers.ports:'53'                                    |
-|                                  |                           |          | Ex: data_providers.ports:!'0' (any port)                        |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| data_providers.provider          | String                    | No       | Name of the data provider.                                       |
-|                                  |                           |          | Ex: data_providers.provider:'{provider name}'                    |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| data_providers.rating            | String                    | Yes      | Third-party provider rating.                                     |
-|                                  |                           |          | Values: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL              |
-|                                  |                           |          | Ex: data_providers.rating:'CRITICAL'                            |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| data_providers.scan_time         | Timestamp                 | Yes      | UTC date and time when the vulnerability was most recently      |
-|                                  |                           |          | identified by the third-party provider.                         |
-|                                  |                           |          | Ex: data_providers.scan_time:>'2023-08-03'                      |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| data_providers.scanner_id        | String                    | No       | ID of the third-party scanner that identified the               |
-|                                  |                           |          | vulnerability.                                                   |
-|                                  |                           |          | Ex: data_providers.scanner_id:'{scanner id}'                    |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| host_info.asset_criticality      | String                    | Yes      | Assigned criticality level of the asset.                        |
-|                                  |                           |          | Values: Critical, High, Noncritical, Unassigned                 |
-|                                  |                           |          | Ex: host_info.asset_criticality:['Critical','High']             |
-|                                  |                           |          | Ex: host_info.asset_criticality:!'Unassigned'                   |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| host_info.groups                 | String                    | Yes      | Unique system-assigned ID of a host group. Supports multiple    |
-|                                  |                           |          | values and negation. All values must be enclosed in brackets.   |
-|                                  |                           |          | Ex: host_info.groups:['03f0b54af2692e99c4cec945818fbef7']        |
-|                                  |                           |          | Ex: host_info.groups:!['03f0b54af2692e99c4cec945818fbef7']       |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| host_info.has_run_container      | Boolean                   | No       | Whether or not the host is running Kubernetes containers.       |
-|                                  |                           |          | Ex: host_info.has_run_container:true                             |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| host_info.internet_exposure      | String                    | No       | Whether or not the asset is internet-facing.                    |
-|                                  |                           |          | Values: Yes, No, Pending                                         |
-|                                  |                           |          | Ex: host_info.internet_exposure:'Yes'                           |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| host_info.managed_by             | String                    | Yes      | Indicates if the asset has the Falcon sensor installed.         |
-|                                  |                           |          | Values: Falcon sensor, Unmanaged                                |
-|                                  |                           |          | Supports multiple values and negation.                          |
-|                                  |                           |          | Ex: host_info.managed_by:'Unmanaged'                            |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| host_info.platform_name          | String                    | Yes      | Operating system platform. Supports negation.                   |
-|                                  |                           |          | Values: Windows, Mac, Linux                                      |
-|                                  |                           |          | Ex: host_info.platform_name:'Windows'                           |
-|                                  |                           |          | Ex: host_info.platform_name:!'Linux'                            |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| host_info.product_type_desc      | String                    | Yes      | Type of host a sensor is running on. Supports multiple values   |
-|                                  |                           |          | and negation. For case-insensitive filtering, add .insensitive  |
-|                                  |                           |          | to the field name. Enter values with first letter capitalized.  |
-|                                  |                           |          | Values: Workstation, Server, Domain Controller                   |
-|                                  |                           |          | Ex: host_info.product_type_desc:'Workstation'                   |
-|                                  |                           |          | Ex: host_info.product_type_desc:!'Workstation'                  |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| host_info.tags                   | String                    | Yes      | Name of a tag assigned to a host. Supports multiple values      |
-|                                  |                           |          | and negation. All values must be enclosed in brackets.          |
-|                                  |                           |          | Ex: host_info.tags:['ephemeral']                                |
-|                                  |                           |          | Ex: host_info.tags:!['search','ephemeral']                      |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| host_info.third_party_asset_ids  | String                    | Yes      | Asset IDs assigned to the host by third-party providers in      |
-|                                  |                           |          | the format: {data_provider}: {data_provider_asset_id}           |
-|                                  |                           |          | Supports multiple values and negation.                          |
-|                                  |                           |          | Ex: host_info.third_party_asset_ids:'{provider}: {asset_id}'    |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| last_seen_within                 | Number                    | No       | Filter for vulnerabilities based on the number of days since    |
-|                                  |                           |          | a host last connected to Falcon. Enter a numeric value from     |
-|                                  |                           |          | 3 to 45 to indicate the number of days to look back.            |
-|                                  |                           |          | Ex: last_seen_within:'10'                                       |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| services.port                    | String                    | No       | Port on the host where a vulnerability was found by Falcon      |
-|                                  |                           |          | EASM or a third-party provider.                                 |
-|                                  |                           |          | Ex: services.port:'443'                                         |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| services.protocol                | String                    | No       | Network protocols recognized by Falcon EASM.                    |
-|                                  |                           |          | Ex: services.protocol:'pop3'                                    |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| services.transport               | String                    | No       | Transport methods recognized by Falcon EASM.                    |
-|                                  |                           |          | Ex: services.transport:'tcp'                                    |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| status                           | String                    | Yes      | Status of a vulnerability. Value must be in all lowercase       |
-|                                  |                           |          | letters. Supports multiple values and negation.                 |
-|                                  |                           |          | Values: open, closed, reopen, expired                           |
-|                                  |                           |          | Ex: status:'open'                                               |
-|                                  |                           |          | Ex: status:!'closed'                                            |
-|                                  |                           |          | Ex: status:['open','reopen']                                    |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| suppression_info.is_suppressed   | Boolean                   | No       | Indicates if the vulnerability is suppressed by a suppression   |
-|                                  |                           |          | rule or not.                                                     |
-|                                  |                           |          | Ex: suppression_info.is_suppressed:true                         |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| suppression_info.reason          | String                    | Yes      | Attribute assigned to a suppression rule. Supports multiple     |
-|                                  |                           |          | values and negation. All values must be enclosed in brackets.   |
-|                                  |                           |          | Values: ACCEPT_RISK, COMPENSATING_CONTROL, FALSE_POSITIVE       |
-|                                  |                           |          | Ex: suppression_info.reason:['ACCEPT_RISK']                     |
-|                                  |                           |          | Ex: suppression_info.reason:!['FALSE_POSITIVE']                 |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| updated_timestamp                | Timestamp                 | Yes      | UTC date and time of the last update made on a vulnerability.   |
-|                                  |                           |          | Ex: updated_timestamp:<'2021-10-20T22:36'                       |
-|                                  |                           |          | Ex: updated_timestamp:>'2021-09-15'                             |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
-| vulnerability_id                 | String                    | Yes      | CVE ID of the vulnerability. If there's no CVE ID, this is      |
-|                                  |                           |          | the CrowdStrike or third-party ID of the vulnerability.         |
-|                                  |                           |          | For case-insensitive filtering, add .insensitive to the field   |
-|                                  |                           |          | name. Supports multiple values and negation.                    |
-|                                  |                           |          | Ex: vulnerability_id:['CVE-2022-1234']                          |
-|                                  |                           |          | Ex: vulnerability_id:['CVE-2022-1234','CVE-2023-4321']          |
-+----------------------------------+---------------------------+----------+------------------------------------------------------------------+
+""" + generate_table(SEARCH_VULNERABILITIES_FQL_FILTERS) + """
 
 === IMPORTANT NOTES ===
 • Use single quotes around string values: 'value'

--- a/falcon_mcp/resources/spotlight.py
+++ b/falcon_mcp/resources/spotlight.py
@@ -2,6 +2,8 @@
 Contains Spotlight Vulnerabilities resources.
 """
 
+from falcon_mcp.common.utils import generate_table
+
 # List of tuples containing filter options data: (name, type, operators, description)
 SEARCH_VULNERABILITIES_FQL_FILTERS = [
     ("Name", "Type", "Operators", "Description"),
@@ -44,8 +46,6 @@ SEARCH_VULNERABILITIES_FQL_FILTERS = [
     ("updated_timestamp", "Timestamp", "Yes", "UTC date and time of the last update made on a vulnerability.\nEx: updated_timestamp:<'2021-10-20T22:36'\nEx: updated_timestamp:>'2021-09-15'"),
     ("vulnerability_id", "String", "Yes", "CVE ID of the vulnerability. If there's no CVE ID, this is the CrowdStrike or third-party ID of the vulnerability.\nFor case-insensitive filtering, add .insensitive to the field name. Supports multiple values and negation.\nEx: vulnerability_id:['CVE-2022-1234']\nEx: vulnerability_id:['CVE-2022-1234','CVE-2023-4321']"),
 ]
-
-from falcon_mcp.common.utils import generate_table
 
 SEARCH_VULNERABILITIES_FQL_DOCUMENTATION = """Falcon Query Language (FQL) - Search Vulnerabilities Guide
 

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -242,15 +242,6 @@ For testing purposes.
         for header in data[0]:
             self.assertIn(header.strip(), header_row)
 
-        # Check separator row
-        self.assertEqual(lines[1], "|-|-|-|-|-|")
-
-        # Check data rows exist with correct content
-        self.assertEqual(lines[2], "|test_string|String|Yes|This is a test description. It has multiple lines. For testing purposes.||")
-        self.assertEqual(lines[3], "|test_bool|Boolean|Yes|This is a test description. It has multiple lines. For testing purposes.|true|")
-        self.assertEqual(lines[4], "|test_none|None|No|Multi line description. Hello||")
-        self.assertEqual(lines[5], "|test_number|Number|No|Single line description.|42|")
-
         # Check for multi-line handling - descriptions should be combined with spaces
         self.assertIn("This is a test description. It has multiple lines. For testing purposes.", lines[2])
 

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -9,7 +9,7 @@ from falcon_mcp.common.utils import (
     extract_first_resource,
     extract_resources,
     filter_none_values,
-    generate_table,
+    generate_md_table,
     prepare_api_parameters,
 )
 
@@ -174,8 +174,8 @@ class TestUtilFunctions(unittest.TestCase):
         )
         self.assertEqual(resource, {"error": "Resource not found"})
 
-    def test_generate_table(self):
-        """Test generate_table function."""
+    def test_generate_md_table(self):
+        """Test generate_md_table function."""
         # Test data with headers as the first row
         data = [
             # Header row
@@ -218,7 +218,7 @@ For testing purposes.
         ]
 
         # Generate table
-        table = generate_table(data)
+        table = generate_md_table(data)
 
         # Expected table format (with exact spacing and formatting)
         expected_table = """|Name|Type|Operators|Description|Extra|
@@ -270,7 +270,7 @@ For testing purposes.
 
         # Verify that TypeError is raised
         with self.assertRaises(TypeError) as context:
-            generate_table(data)
+            generate_md_table(data)
 
         # Check the error message
         self.assertIn("Header values must be strings", str(context.exception))
@@ -289,7 +289,7 @@ For testing purposes.
         ]
 
         # Generate table
-        table = generate_table(data)
+        table = generate_md_table(data)
 
         # Expected table format (with exact spacing and formatting)
         expected_table = """|Name|
@@ -338,7 +338,7 @@ For testing purposes.
 
         # Verify that ValueError is raised
         with self.assertRaises(ValueError) as context:
-            generate_table(data)
+            generate_md_table(data)
         
         # Check the error message
         self.assertIn("Header row cannot be empty", str(context.exception))
@@ -353,14 +353,14 @@ For testing purposes.
 
         # Verify that TypeError is raised
         with self.assertRaises(TypeError) as context:
-            generate_table(data)
+            generate_md_table(data)
         
         # Check the error message
         self.assertIn("Need at least 2 items", str(context.exception))
         
         # Test with empty data
         with self.assertRaises(TypeError) as context:
-            generate_table([])
+            generate_md_table([])
         
         # Check the error message
         self.assertIn("Need at least 2 items", str(context.exception))

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -185,16 +185,16 @@ class TestUtilFunctions(unittest.TestCase):
                 "test_string",
                 "String",
                 "Yes",
-                """\
+                """
 This is a test description.
 It has multiple lines.
-For testing purposes.\
+For testing purposes.
 """
             ),
             (
                 "test_bool",
-                "Boolean", 
-                "Yes",
+                "\nBoolean", 
+                "\nYes",
                 "This is a test description.\nIt has multiple lines.\nFor testing purposes.",
                 True,
             ),
@@ -202,7 +202,10 @@ For testing purposes.\
                 "test_none",
                 " None",
                 "   No",
-                "Single line description.",
+                """
+                    Multi line description.
+                    Hello
+                """,
                 None,
             ),
             (
@@ -222,7 +225,7 @@ For testing purposes.\
 |-|-|-|-|-|
 |test_string|String|Yes|This is a test description. It has multiple lines. For testing purposes.||
 |test_bool|Boolean|Yes|This is a test description. It has multiple lines. For testing purposes.|true|
-|test_none|None|No|Single line description.||
+|test_none|None|No|Multi line description. Hello||
 |test_number|Number|No|Single line description.|42|"""
 
         # Compare the generated table with the expected table
@@ -245,7 +248,7 @@ For testing purposes.\
         # Check data rows exist with correct content
         self.assertEqual(lines[2], "|test_string|String|Yes|This is a test description. It has multiple lines. For testing purposes.||")
         self.assertEqual(lines[3], "|test_bool|Boolean|Yes|This is a test description. It has multiple lines. For testing purposes.|true|")
-        self.assertEqual(lines[4], "|test_none|None|No|Single line description.||")
+        self.assertEqual(lines[4], "|test_none|None|No|Multi line description. Hello||")
         self.assertEqual(lines[5], "|test_number|Number|No|Single line description.|42|")
 
         # Check for multi-line handling - descriptions should be combined with spaces

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -9,6 +9,7 @@ from falcon_mcp.common.utils import (
     extract_first_resource,
     extract_resources,
     filter_none_values,
+    generate_table,
     prepare_api_parameters,
 )
 
@@ -172,6 +173,203 @@ class TestUtilFunctions(unittest.TestCase):
             "Resource not found", operation="TestOperation"
         )
         self.assertEqual(resource, {"error": "Resource not found"})
+
+    def test_generate_table(self):
+        """Test generate_table function."""
+        # Test data with headers as the first row
+        data = [
+            # Header row
+            (" Name", "    Type", "Operators ", "Description    ", "Extra"),
+            # Data rows
+            (
+                "test_string",
+                "String",
+                "Yes",
+                """\
+This is a test description.
+It has multiple lines.
+For testing purposes.\
+"""
+            ),
+            (
+                "test_bool",
+                "Boolean", 
+                "Yes",
+                "This is a test description.\nIt has multiple lines.\nFor testing purposes.",
+                True,
+            ),
+            (
+                "test_none",
+                " None",
+                "   No",
+                "Single line description.",
+                None,
+            ),
+            (
+                "test_number",
+                "Number ",
+                "No   ",
+                "Single line description.",
+                42,
+            )
+        ]
+
+        # Generate table
+        table = generate_table(data)
+
+        # Expected table format (with exact spacing and formatting)
+        expected_table = """|Name|Type|Operators|Description|Extra|
+|-|-|-|-|-|
+|test_string|String|Yes|This is a test description. It has multiple lines. For testing purposes.||
+|test_bool|Boolean|Yes|This is a test description. It has multiple lines. For testing purposes.|true|
+|test_none|None|No|Single line description.||
+|test_number|Number|No|Single line description.|42|"""
+
+        # Compare the generated table with the expected table
+        self.assertEqual(table, expected_table)
+
+        # Split into lines for easier assertion
+        lines = table.split('\n')
+
+        # Check basic structure
+        self.assertEqual(len(lines), 6)  # header + separator + 4 data rows
+
+        # Check header row exists and contains all headers (stripped of spaces)
+        header_row = lines[0]
+        for header in data[0]:
+            self.assertIn(header.strip(), header_row)
+
+        # Check separator row
+        self.assertEqual(lines[1], "|-|-|-|-|-|")
+
+        # Check data rows exist with correct content
+        self.assertEqual(lines[2], "|test_string|String|Yes|This is a test description. It has multiple lines. For testing purposes.||")
+        self.assertEqual(lines[3], "|test_bool|Boolean|Yes|This is a test description. It has multiple lines. For testing purposes.|true|")
+        self.assertEqual(lines[4], "|test_none|None|No|Single line description.||")
+        self.assertEqual(lines[5], "|test_number|Number|No|Single line description.|42|")
+
+        # Check for multi-line handling - descriptions should be combined with spaces
+        self.assertIn("This is a test description. It has multiple lines. For testing purposes.", lines[2])
+
+        # Check for proper pipe character usage
+        for i in range(6):  # Check all lines
+            self.assertTrue(lines[i].startswith('|'))
+            self.assertTrue(lines[i].endswith('|'))
+            # Should have exactly 6 | characters (start, end, and 4 column separators)
+            self.assertEqual(lines[i].count('|'), 6)
+
+    def test_generate_table_with_non_string_headers(self):
+        """Test generate_table function with non-string headers."""
+        # Test data with non-string headers
+        data = [
+            # Header row with a non-string value
+            ("Name", 123, "Operators", "Description", "Extra"),
+            # Data rows
+            (
+                "test_string",
+                "String",
+                "Yes",
+                "This is a test description.",
+                None,
+            ),
+        ]
+
+        # Verify that TypeError is raised
+        with self.assertRaises(TypeError) as context:
+            generate_table(data)
+
+        # Check the error message
+        self.assertIn("Header values must be strings", str(context.exception))
+        self.assertIn("got int", str(context.exception))
+
+    def test_generate_table_with_single_column(self):
+        """Test generate_table function with a single column."""
+        # Test data with a single column
+        data = [
+            # Header row with a single value
+            ("Name",),
+            # Data rows with a single value
+            ("test_string",),
+            ("test_bool",),
+            ("test_none",),
+        ]
+
+        # Generate table
+        table = generate_table(data)
+
+        # Expected table format (with exact spacing and formatting)
+        expected_table = """|Name|
+|-|
+|test_string|
+|test_bool|
+|test_none|"""
+
+        # Compare the generated table with the expected table
+        self.assertEqual(table, expected_table)
+
+        # Split into lines for easier assertion
+        lines = table.split('\n')
+
+        # Check basic structure
+        self.assertEqual(len(lines), 5)  # header + separator + 3 data rows
+
+        # Check header row exists and contains the header
+        header_row = lines[0]
+        self.assertEqual(header_row, "|Name|")
+
+        # Check separator row
+        self.assertEqual(lines[1], "|-|")
+
+        # Check data rows exist with correct content
+        self.assertEqual(lines[2], "|test_string|")
+        self.assertEqual(lines[3], "|test_bool|")
+        self.assertEqual(lines[4], "|test_none|")
+
+        # Check for proper pipe character usage
+        for i in range(5):  # Check all lines
+            self.assertTrue(lines[i].startswith('|'))
+            self.assertTrue(lines[i].endswith('|'))
+            # Should have exactly 2 | characters (start and end)
+            self.assertEqual(lines[i].count('|'), 2)
+            
+    def test_generate_table_with_empty_header_row(self):
+        """Test generate_table function with an empty header row."""
+        # Test data with an empty header row
+        data = [
+            # Empty header row
+            (),
+            # Data rows
+            ("test_string",),
+        ]
+
+        # Verify that ValueError is raised
+        with self.assertRaises(ValueError) as context:
+            generate_table(data)
+        
+        # Check the error message
+        self.assertIn("Header row cannot be empty", str(context.exception))
+        
+    def test_generate_table_with_insufficient_data(self):
+        """Test generate_table function with insufficient data."""
+        # Test data with only a header row and no data rows
+        data = [
+            # Header row
+            ("Name", "Type"),
+        ]
+
+        # Verify that TypeError is raised
+        with self.assertRaises(TypeError) as context:
+            generate_table(data)
+        
+        # Check the error message
+        self.assertIn("Need at least 2 items", str(context.exception))
+        
+        # Test with empty data
+        with self.assertRaises(TypeError) as context:
+            generate_table([])
+        
+        # Check the error message
+        self.assertIn("Need at least 2 items", str(context.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Notes

I focused on maximum readability of the code with minimal token usage
Handles multiple edge cases and some "compile" time checks
Allows for multiple ways to write/format the resource params depending on preferences, while still maintaining consistent output
Ruff compatible

# Sample Output

```
Falcon Query Language (FQL) - Search Vulnerabilities Guide

=== BASIC SYNTAX ===
property_name:[operator]'value'

=== AVAILABLE OPERATORS ===
• No operator = equals (default)
• ! = not equal to
• > = greater than
• >= = greater than or equal
• < = less than
• <= = less than or equal
• ~ = text match (ignores case, spaces, punctuation)
• !~ = does not text match

=== DATA TYPES & SYNTAX ===
• Strings: 'value' or ['exact_value'] for exact match
• Dates: 'YYYY-MM-DDTHH:MM:SSZ' (UTC format)
• Booleans: true or false (no quotes)
• Numbers: 123 (no quotes)

=== COMBINING CONDITIONS ===
• + = AND condition
• , = OR condition
• ( ) = Group expressions

=== falcon_search_vulnerabilities FQL filter options ===

|Name|Type|Operators|Description|
|-|-|-|-|
|aid|String|No|Unique agent identifier (AID) of the sensor where the vulnerability was found. For assets without a Falcon sensor installed, this field matches the asset ID field.  Ex: aid:'abcde6b9a3427d8c4a1af416424d6231'|
|apps.remediation.ids|String|Yes|Unique identifier of a remediation. Supports multiple values and negation.  Ex: apps.remediation.ids:'7bba2e543744a92962be7afeb6484858' Ex: apps.remediation.ids:['ID1','ID2','ID3']|
|cid|String|No|Unique system-generated customer identifier (CID) of the account. In multi-CID environments, you can filter by both parent and child CIDs.  Ex: cid:'0123456789ABCDEFGHIJKLMNOPQRSTUV'|
|closed_timestamp|Timestamp|Yes|Date and time a vulnerability was set to a status of CLOSED.  Ex: closed_timestamp:>'2021-06-25T10:32' Ex: closed_timestamp:<'2021-10-18'|
|confidence|String|Yes|Whether or not the vulnerability has been confirmed. Values: confirmed, potential  Ex: confidence:'potential'|
|created_timestamp|Timestamp|Yes|Date and time when this vulnerability was found in your environment. Use this to get vulnerabilities created after the timestamp you last pulled data on.  Ex: created_timestamp:<'2021-09-25T13:22' Ex: created_timestamp:>'2021-02-12'|
|cve.base_score|Number|Yes|CVE base score.  Ex: cve.base_score:>5.0|
|cve.cwes|String|Yes|Unique identifier for a vulnerability from the Common Weakness Enumeration (CWE) list.  Ex: cve.cwes:['CWE-787','CWE-699']|
|cve.exploit_status|String|Yes|Numeric value of the most severe known exploit. Supports multiple values and negation. Values: 0=Unproven, 30=Available, 60=Easily accessible, 90=Actively used  Ex: cve.exploit_status:'60' Ex: cve.exploit_status:!'0'|
|cve.exprt_rating|String|Yes|ExPRT rating assigned by CrowdStrike's predictive AI rating system. Value must be in all caps. Supports multiple values and negation. Values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL  Ex: cve.exprt_rating:'HIGH' Ex: cve.exprt_rating:['HIGH','CRITICAL']|
|cve.id|String|Yes|Unique identifier for a vulnerability as cataloged in the National Vulnerability Database (NVD). Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name. Note: All values must be enclosed in brackets.  Ex: cve.id:['CVE-2022-1234'] Ex: cve.id:['CVE-2022-1234','CVE-2023-1234']|
|cve.is_cisa_kev|Boolean|Yes|Filter for vulnerabilities that are in the CISA Known Exploited Vulnerabilities (KEV) catalog. Supports negation.  Ex: cve.is_cisa_kev:true|
|cve.remediation_level|String|Yes|CVSS remediation level of the vulnerability. Supports multiple values and negation.  Ex: cve.remediation_level:'O' (official fix) Ex: cve.remediation_level:'U' (no available fix)|
|cve.severity|String|Yes|CVSS severity rating of the vulnerability. Value must be in all caps. Supports multiple values and negation. Values: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL  Ex: cve.severity:'LOW' Ex: cve.severity:!'UNKNOWN'|
|cve.types|String|Yes|Vulnerability type. Values: Vulnerability, Misconfiguration, Unsupported software  Ex: cve.types:!'Misconfiguration'|
|data_providers.ports|String|Yes|Ports on the host where the vulnerability was found by the third-party provider.  Ex: data_providers.ports:'53' Ex: data_providers.ports:!'0' (any port)|
|data_providers.provider|String|No|Name of the data provider.  Ex: data_providers.provider:'{provider name}'|
|data_providers.rating|String|Yes|Third-party provider rating. Values: UNKNOWN, NONE, LOW, MEDIUM, HIGH, CRITICAL  Ex: data_providers.rating:'CRITICAL'|
|data_providers.scan_time|Timestamp|Yes|UTC date and time when the vulnerability was most recently identified by the third-party provider.  Ex: data_providers.scan_time:>'2023-08-03'|
|data_providers.scanner_id|String|No|ID of the third-party scanner that identified the vulnerability.  Ex: data_providers.scanner_id:'{scanner id}'|
|host_info.asset_criticality|String|Yes|Assigned criticality level of the asset. Values: Critical, High, Noncritical, Unassigned  Ex: host_info.asset_criticality:['Critical','High'] Ex: host_info.asset_criticality:!'Unassigned'|
|host_info.groups|String|Yes|Unique system-assigned ID of a host group. Supports multiple values and negation. All values must be enclosed in brackets.  Ex: host_info.groups:['03f0b54af2692e99c4cec945818fbef7'] Ex: host_info.groups:!['03f0b54af2692e99c4cec945818fbef7']|
|host_info.has_run_container|Boolean|No|Whether or not the host is running Kubernetes containers.  Ex: host_info.has_run_container:true|
|host_info.internet_exposure|String|No|Whether or not the asset is internet-facing. Values: Yes, No, Pending  Ex: host_info.internet_exposure:'Yes'|
|host_info.managed_by|String|Yes|Indicates if the asset has the Falcon sensor installed. Values: Falcon sensor, Unmanaged Supports multiple values and negation.  Ex: host_info.managed_by:'Unmanaged'|
|host_info.platform_name|String|Yes|Operating system platform. Supports negation. Values: Windows, Mac, Linux  Ex: host_info.platform_name:'Windows' Ex: host_info.platform_name:!'Linux'|
|host_info.product_type_desc|String|Yes|Type of host a sensor is running on. Supports multiple values and negation. For case-insensitive filtering, add .insensitive to the field name. Enter values with first letter capitalized. Values: Workstation, Server, Domain Controller  Ex: host_info.product_type_desc:'Workstation' Ex: host_info.product_type_desc:!'Workstation'|
|host_info.tags|String|Yes|Name of a tag assigned to a host. Supports multiple values and negation. All values must be enclosed in brackets.  Ex: host_info.tags:['ephemeral'] Ex: host_info.tags:!['search','ephemeral']|
|host_info.third_party_asset_ids|String|Yes|Asset IDs assigned to the host by third-party providers in the format: {data_provider}: {data_provider_asset_id} Supports multiple values and negation.  Ex: host_info.third_party_asset_ids:'{provider}: {asset_id}'|
|last_seen_within|Number|No|Filter for vulnerabilities based on the number of days since a host last connected to Falcon. Enter a numeric value from 3 to 45 to indicate the number of days to look back.  Ex: last_seen_within:'10'|
|services.port|String|No|Port on the host where a vulnerability was found by Falcon EASM or a third-party provider.  Ex: services.port:'443'|
|services.protocol|String|No|Network protocols recognized by Falcon EASM.  Ex: services.protocol:'pop3'|
|services.transport|String|No|Transport methods recognized by Falcon EASM.  Ex: services.transport:'tcp'|
|status|String|Yes|Status of a vulnerability. Value must be in all lowercase letters. Supports multiple values and negation. Values: open, closed, reopen, expired  Ex: status:'open' Ex: status:!'closed' Ex: status:['open','reopen']|
|suppression_info.is_suppressed|Boolean|No|Indicates if the vulnerability is suppressed by a suppression rule or not.  Ex: suppression_info.is_suppressed:true|
|suppression_info.reason|String|Yes|Attribute assigned to a suppression rule. Supports multiple values and negation. All values must be enclosed in brackets. Values: ACCEPT_RISK, COMPENSATING_CONTROL, FALSE_POSITIVE  Ex: suppression_info.reason:['ACCEPT_RISK'] Ex: suppression_info.reason:!['FALSE_POSITIVE']|
|updated_timestamp|Timestamp|Yes|UTC date and time of the last update made on a vulnerability.  Ex: updated_timestamp:<'2021-10-20T22:36' Ex: updated_timestamp:>'2021-09-15'|
|vulnerability_id|String|Yes|CVE ID of the vulnerability. If there's no CVE ID, this is the CrowdStrike or third-party ID of the vulnerability. For case-insensitive filtering, add .insensitive to the field name. Supports multiple values and negation.  Ex: vulnerability_id:['CVE-2022-1234'] Ex: vulnerability_id:['CVE-2022-1234','CVE-2023-4321']|

=== IMPORTANT NOTES ===
• Use single quotes around string values: 'value'
• Use square brackets for exact matches and multiple values: ['value1','value2']
• Date format must be UTC: 'YYYY-MM-DDTHH:MM:SSZ'
• For case-insensitive filtering, add .insensitive to field names
• Boolean values: true or false (no quotes)
• Wildcards (*) are unsupported in this API
• Some fields require specific capitalization (check individual field descriptions)

=== COMMON FILTER EXAMPLES ===
• High severity vulnerabilities: cve.severity:'HIGH'
• Recent vulnerabilities: created_timestamp:>'2024-01-01'
• Windows vulnerabilities: host_info.platform_name:'Windows'
• Open vulnerabilities with exploits: status:'open'+cve.exploit_status:!'0'
• Critical ExPRT rated vulnerabilities: cve.exprt_rating:'CRITICAL'
• CISA KEV vulnerabilities: cve.is_cisa_kev:true
```

Or markdown view

|Name|Type|Operators|Description|
|-|-|-|-|
|aid|String|No|Unique agent identifier (AID) of the sensor where the vulnerability was found. For assets without a Falcon sensor installed, this field matches the asset ID field.  Ex: aid:'abcde6b9a3427d8c4a1af416424d6231'|
|apps.remediation.ids|String|Yes|Unique identifier of a remediation. Supports multiple values and negation.  Ex: apps.remediation.ids:'7bba2e543744a92962be7afeb6484858' Ex: apps.remediation.ids:['ID1','ID2','ID3']|