### PR TITLE
ci(release): add refactor type to changelog on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           release-type: python
           package-name: falcon-mcp
           pull-request-header: ':rocket: New Release Incoming! :rocket:'
-          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"refactor","section":"Refactoring","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"refactor","section":"Refactoring","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":true}]'
           # Add any extra files that contain version references
           # extra-files: |
           #   README.md


### PR DESCRIPTION
- All commits that start with `refactor:` will now appear in a dedicated "Refactoring" section in your generated changelogs

- The change will take effect on the next release when release-please processes commits from your main branch
