### PR TITLE
feat(server): add distinct tools for active vs available modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ The Falcon MCP Server supports different modules, each requiring specific API sc
 The server provides core tools for interacting with the Falcon API:
 
 - `falcon_check_connectivity`: Check connectivity to the Falcon API
-- `falcon_get_available_modules`: Get information about available modules
+- `falcon_get_active_modules`: Show active modules
+- `falcon_get_available_modules`: Show available modules
 
 ### Detections Module
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,7 @@ The server provides core tools for interacting with the Falcon API:
 
 - `falcon_check_connectivity`: Check connectivity to the Falcon API
 - `falcon_list_enabled_modules`: Lists enabled modules in the falcon-mcp server
-
     > These modules are controlled by the --modules flag when starting the server. If no modules are specified, all available modules are enabled.
-
 - `falcon_list_modules`: Lists all available modules in the falcon-mcp server
 
 ### Detections Module

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The server provides core tools for interacting with the Falcon API:
 
 - `falcon_check_connectivity`: Check connectivity to the Falcon API
 - `falcon_list_enabled_modules`: Lists enabled modules in the falcon-mcp server
-    > These modules are controlled by the --modules flag when starting the server. If no modules are specified, all available modules are enabled.
+    > These modules are determined by the `--modules` [flag](#module-configuration) when starting the server. If no modules are specified, all available modules are enabled.
 - `falcon_list_modules`: Lists all available modules in the falcon-mcp server
 
 ### Detections Module

--- a/README.md
+++ b/README.md
@@ -95,8 +95,11 @@ The Falcon MCP Server supports different modules, each requiring specific API sc
 The server provides core tools for interacting with the Falcon API:
 
 - `falcon_check_connectivity`: Check connectivity to the Falcon API
-- `falcon_list_enabled_modules`: Lists modules that are currently enabled and available for use
-- `falcon_list_modules`: Lists all available modules
+- `falcon_list_enabled_modules`: Lists enabled modules in the falcon-mcp server
+
+    > These modules are controlled by the --modules flag when starting the server. If no modules are specified, all available modules are enabled.
+
+- `falcon_list_modules`: Lists all available modules in the falcon-mcp server
 
 ### Detections Module
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ The Falcon MCP Server supports different modules, each requiring specific API sc
 The server provides core tools for interacting with the Falcon API:
 
 - `falcon_check_connectivity`: Check connectivity to the Falcon API
-- `falcon_get_active_modules`: Show active modules
-- `falcon_get_available_modules`: Show available modules
+- `falcon_list_enabled_modules`: Lists modules that are currently enabled and available for use
+- `falcon_list_modules`: Lists all available modules
 
 ### Detections Module
 

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -110,19 +110,16 @@ class FalconMCPServer:
         self.server.add_tool(
             self.falcon_check_connectivity,
             name="falcon_check_connectivity",
-            description="Check connectivity to the Falcon API.",
         )
 
         self.server.add_tool(
             self.list_enabled_modules,
             name="falcon_list_enabled_modules",
-            description="Lists enabled modules in the falcon-mcp server.",
         )
 
         self.server.add_tool(
             self.list_modules,
             name="falcon_list_modules",
-            description="Lists all available modules in the falcon-mcp server.",
         )
 
         tool_count = 3  # the tools added above
@@ -144,9 +141,7 @@ class FalconMCPServer:
         # Register resources from modules
         for module in self.modules.values():
             # Check if the module has a register_resources method
-            if hasattr(module, "register_resources") and callable(
-                module.register_resources
-            ):
+            if hasattr(module, "register_resources") and callable(module.register_resources):
                 module.register_resources(self.server)
 
         return sum(len(getattr(m, "resources", [])) for m in self.modules.values())

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -162,7 +162,7 @@ class FalconMCPServer:
     def list_enabled_modules(self) -> Dict[str, List[str]]:
         """Lists enabled modules in the falcon-mcp server.
 
-        These modules are controlled by the --modules flag when starting the server.
+        These modules are determined by the --modules flag when starting the server.
         If no modules are specified, all available modules are enabled.
 
         Returns:

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -114,12 +114,18 @@ class FalconMCPServer:
         )
 
         self.server.add_tool(
-            self.get_available_modules,
-            name="falcon_get_available_modules",
-            description="Get information about available modules.",
+            self.get_active_modules,
+            name="falcon_get_active_modules",
+            description="Show active modules.",
         )
 
-        tool_count = 2  # the tools added above
+        self.server.add_tool(
+            self.get_available_modules,
+            name="falcon_get_available_modules",
+            description="Show available modules.",
+        )
+
+        tool_count = 3  # the tools added above
 
         # Register tools from modules
         for module in self.modules.values():
@@ -153,8 +159,16 @@ class FalconMCPServer:
         """
         return {"connected": self.falcon_client.is_authenticated()}
 
+    def get_active_modules(self) -> Dict[str, List[str]]:
+        """Show active modules.
+
+        Returns:
+            Dict[str, List[str]]: Active modules
+        """
+        return {"modules": list(self.modules.keys())}
+
     def get_available_modules(self) -> Dict[str, List[str]]:
-        """Get information about available modules.
+        """Show available modules.
 
         Returns:
             Dict[str, List[str]]: Available modules

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -114,15 +114,15 @@ class FalconMCPServer:
         )
 
         self.server.add_tool(
-            self.get_active_modules,
-            name="falcon_get_active_modules",
-            description="Show active modules.",
+            self.list_enabled_modules,
+            name="falcon_list_enabled_modules",
+            description="Lists modules that are currently enabled and available for use.",
         )
 
         self.server.add_tool(
-            self.get_available_modules,
-            name="falcon_get_available_modules",
-            description="Show available modules.",
+            self.list_modules,
+            name="falcon_list_modules",
+            description="Lists all available modules.",
         )
 
         tool_count = 3  # the tools added above
@@ -159,16 +159,19 @@ class FalconMCPServer:
         """
         return {"connected": self.falcon_client.is_authenticated()}
 
-    def get_active_modules(self) -> Dict[str, List[str]]:
-        """Show active modules.
+    def list_enabled_modules(self) -> Dict[str, List[str]]:
+        """Lists modules that are currently enabled and available for use.
+
+        These modules are controlled by the --modules flag when starting the server.
+        If no modules are specified, all available modules are enabled.
 
         Returns:
-            Dict[str, List[str]]: Active modules
+            Dict[str, List[str]]: Enabled modules
         """
         return {"modules": list(self.modules.keys())}
 
-    def get_available_modules(self) -> Dict[str, List[str]]:
-        """Show available modules.
+    def list_modules(self) -> Dict[str, List[str]]:
+        """Lists all available modules.
 
         Returns:
             Dict[str, List[str]]: Available modules

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -116,13 +116,13 @@ class FalconMCPServer:
         self.server.add_tool(
             self.list_enabled_modules,
             name="falcon_list_enabled_modules",
-            description="Lists modules that are currently enabled and available for use.",
+            description="Lists enabled modules in the falcon-mcp server.",
         )
 
         self.server.add_tool(
             self.list_modules,
             name="falcon_list_modules",
-            description="Lists all available modules.",
+            description="Lists all available modules in the falcon-mcp server.",
         )
 
         tool_count = 3  # the tools added above
@@ -160,7 +160,7 @@ class FalconMCPServer:
         return {"connected": self.falcon_client.is_authenticated()}
 
     def list_enabled_modules(self) -> Dict[str, List[str]]:
-        """Lists modules that are currently enabled and available for use.
+        """Lists enabled modules in the falcon-mcp server.
 
         These modules are controlled by the --modules flag when starting the server.
         If no modules are specified, all available modules are enabled.
@@ -171,7 +171,7 @@ class FalconMCPServer:
         return {"modules": list(self.modules.keys())}
 
     def list_modules(self) -> Dict[str, List[str]]:
-        """Lists all available modules.
+        """Lists all available modules in the falcon-mcp server.
 
         Returns:
             Dict[str, List[str]]: Available modules

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -113,8 +113,8 @@ class TestFalconMCPServer(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     @patch("falcon_mcp.server.FalconClient")
-    def test_get_available_modules(self, mock_client):
-        """Test getting available modules."""
+    def test_get_active_modules(self, mock_client):
+        """Test getting active modules."""
         # Setup mock
         mock_client_instance = MagicMock()
         mock_client_instance.authenticate.return_value = True
@@ -123,14 +123,85 @@ class TestFalconMCPServer(unittest.TestCase):
         # Create server
         server = FalconMCPServer()
 
-        # Call get_available_modules
-        result = server.get_available_modules()
+        # Call get_active_modules
+        result = server.get_active_modules()
 
         # Get the actual module names from the registry
         expected_modules = registry.get_module_names()
 
-        # Verify result matches registry
+        # Verify result matches registry (since all modules are enabled by default)
         self.assertEqual(set(result["modules"]), set(expected_modules))
+
+    @patch("falcon_mcp.server.FalconClient")
+    def test_get_active_modules_with_limited_modules(self, mock_client):
+        """Test getting active modules with limited module set."""
+        # Setup mock
+        mock_client_instance = MagicMock()
+        mock_client_instance.authenticate.return_value = True
+        mock_client.return_value = mock_client_instance
+
+        # Create server with only specific modules
+        server = FalconMCPServer(enabled_modules={"detections", "cloud"})
+
+        # Call get_active_modules
+        result = server.get_active_modules()
+
+        # Should only return enabled modules
+        self.assertEqual(set(result["modules"]), {"detections", "cloud"})
+
+        # Verify return type is correct
+        self.assertIsInstance(result["modules"], list)
+
+        # Verify each module name is a string
+        for module_name in result["modules"]:
+            self.assertIsInstance(module_name, str)
+
+    @patch("falcon_mcp.server.FalconClient")
+    def test_get_available_modules(self, mock_client):
+        """Test getting all available modules."""
+        # Setup mock
+        mock_client_instance = MagicMock()
+        mock_client_instance.authenticate.return_value = True
+        mock_client.return_value = mock_client_instance
+
+        # Create server with limited modules
+        server = FalconMCPServer(enabled_modules={"detections", "cloud"})
+
+        # Call get_available_modules
+        result = server.get_available_modules()
+
+        # Should return ALL modules from registry regardless of what's enabled
+        expected_modules = registry.get_module_names()
+        self.assertEqual(set(result["modules"]), set(expected_modules))
+
+        # Verify return type is correct
+        self.assertIsInstance(result["modules"], list)
+
+        # Verify each module name is a string
+        for module_name in result["modules"]:
+            self.assertIsInstance(module_name, str)
+
+    @patch("falcon_mcp.server.FalconClient")
+    def test_get_available_modules_consistency(self, mock_client):
+        """Test that get_available_modules always returns the same result."""
+        # Setup mock
+        mock_client_instance = MagicMock()
+        mock_client_instance.authenticate.return_value = True
+        mock_client.return_value = mock_client_instance
+
+        # Create two servers with different enabled modules
+        server1 = FalconMCPServer(enabled_modules={"detections"})
+        server2 = FalconMCPServer(enabled_modules={"cloud", "intel"})
+
+        # Both should return the same available modules
+        result1 = server1.get_available_modules()
+        result2 = server2.get_available_modules()
+
+        self.assertEqual(set(result1["modules"]), set(result2["modules"]))
+
+        # And both should match the registry
+        expected_modules = registry.get_module_names()
+        self.assertEqual(set(result1["modules"]), set(expected_modules))
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -113,8 +113,8 @@ class TestFalconMCPServer(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     @patch("falcon_mcp.server.FalconClient")
-    def test_get_active_modules(self, mock_client):
-        """Test getting active modules."""
+    def test_list_enabled_modules(self, mock_client):
+        """Test listing enabled modules."""
         # Setup mock
         mock_client_instance = MagicMock()
         mock_client_instance.authenticate.return_value = True
@@ -123,8 +123,8 @@ class TestFalconMCPServer(unittest.TestCase):
         # Create server
         server = FalconMCPServer()
 
-        # Call get_active_modules
-        result = server.get_active_modules()
+        # Call list_enabled_modules
+        result = server.list_enabled_modules()
 
         # Get the actual module names from the registry
         expected_modules = registry.get_module_names()
@@ -133,8 +133,8 @@ class TestFalconMCPServer(unittest.TestCase):
         self.assertEqual(set(result["modules"]), set(expected_modules))
 
     @patch("falcon_mcp.server.FalconClient")
-    def test_get_active_modules_with_limited_modules(self, mock_client):
-        """Test getting active modules with limited module set."""
+    def test_list_enabled_modules_with_limited_modules(self, mock_client):
+        """Test listing enabled modules with limited module set."""
         # Setup mock
         mock_client_instance = MagicMock()
         mock_client_instance.authenticate.return_value = True
@@ -143,8 +143,8 @@ class TestFalconMCPServer(unittest.TestCase):
         # Create server with only specific modules
         server = FalconMCPServer(enabled_modules={"detections", "cloud"})
 
-        # Call get_active_modules
-        result = server.get_active_modules()
+        # Call list_enabled_modules
+        result = server.list_enabled_modules()
 
         # Should only return enabled modules
         self.assertEqual(set(result["modules"]), {"detections", "cloud"})
@@ -157,8 +157,8 @@ class TestFalconMCPServer(unittest.TestCase):
             self.assertIsInstance(module_name, str)
 
     @patch("falcon_mcp.server.FalconClient")
-    def test_get_available_modules(self, mock_client):
-        """Test getting all available modules."""
+    def test_list_modules(self, mock_client):
+        """Test listing all available modules."""
         # Setup mock
         mock_client_instance = MagicMock()
         mock_client_instance.authenticate.return_value = True
@@ -167,8 +167,8 @@ class TestFalconMCPServer(unittest.TestCase):
         # Create server with limited modules
         server = FalconMCPServer(enabled_modules={"detections", "cloud"})
 
-        # Call get_available_modules
-        result = server.get_available_modules()
+        # Call list_modules
+        result = server.list_modules()
 
         # Should return ALL modules from registry regardless of what's enabled
         expected_modules = registry.get_module_names()
@@ -182,8 +182,8 @@ class TestFalconMCPServer(unittest.TestCase):
             self.assertIsInstance(module_name, str)
 
     @patch("falcon_mcp.server.FalconClient")
-    def test_get_available_modules_consistency(self, mock_client):
-        """Test that get_available_modules always returns the same result."""
+    def test_list_modules_consistency(self, mock_client):
+        """Test that list_modules always returns the same result."""
         # Setup mock
         mock_client_instance = MagicMock()
         mock_client_instance.authenticate.return_value = True
@@ -194,8 +194,8 @@ class TestFalconMCPServer(unittest.TestCase):
         server2 = FalconMCPServer(enabled_modules={"cloud", "intel"})
 
         # Both should return the same available modules
-        result1 = server1.get_available_modules()
-        result2 = server2.get_available_modules()
+        result1 = server1.list_modules()
+        result2 = server2.list_modules()
 
         self.assertEqual(set(result1["modules"]), set(result2["modules"]))
 


### PR DESCRIPTION
## Summary

Resolves confusion around module visibility by implementing a clear two-tool approach that separates "what modules are currently active" from "what modules are available for configuration." 

This started because @luckb0x and I were testing ADK and noticed that even if we provided `--modules` it would list all modules. This makes it clearer to the end user.

## Changes

### Core Changes
- **Added** `falcon_list_enabled_modules` - Lists currently enabled/running modules based on `--modules` configuration
- **Change** `falcon_list_modules` - Lists all discoverable modules that can be enabled

### Testing & Quality
- Added 4 new comprehensive test cases covering both tools and edge cases
- All 8 tests passing with maintained code quality
- Updated tool count and method implementations

### Documentation
- Updated README.md Core Functionality section to document both tools
- Clear descriptions:"List enabled modules" vs "List available modules"

## User Value

- **Clear Intent**: Tool names make purpose immediately obvious
- **Complete Coverage**: Users can answer both "what do I have?" and "what could I have?"
- **AI Assistant Friendly**: AI can suggest additional modules based on available options
- **Configuration Discovery**: Users can explore modules without restarting or checking docs

## Example Behavior

When running `falcon-mcp --modules detections,cloud`:

- `falcon_list_enabled_modules()` → `{"modules": ["detections", "cloud"]}`
- `falcon_list_modules()` → `{"modules": ["detections", "cloud", "hosts", "idp", "incidents", "intel", "spotlight"]}`

## Testing

```bash
pytest tests/test_server.py -v  # All 8 tests pass
```