### PR TITLE
refactor: standardize parameter consistency across all modules

### DIFF
--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -6,7 +6,7 @@ Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets.
 """
 
 from textwrap import dedent
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
@@ -83,23 +83,22 @@ class CloudModule(BaseModule):
 
     def search_kubernetes_containers(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://cloud/kubernetes-containers/fql-guide` resource when building this filter parameter.",
             examples={"cloud:'AWS'", "cluster_name:'prod'"},
         ),
-        limit: Optional[int] = Field(
+        limit: int = Field(
             default=10,
             ge=1,
             le=9999,
-            description="The maximum number of containers to return in this response (default: 100; max: 9999). Use with the offset parameter to manage pagination of results.",
+            description="The maximum number of containers to return in this response (default: 10; max: 9999). Use with the offset parameter to manage pagination of results.",
         ),
-        offset: Optional[int] = Field(
-            default=0,
-            ge=0,
+        offset: int | None = Field(
+            default=None,
             description="Starting index of overall result set from which to return containers.",
         ),
-        sort: Optional[str] = Field(
+        sort: str | None = Field(
             default=None,
             description=dedent(
                 """
@@ -160,7 +159,7 @@ class CloudModule(BaseModule):
 
     def count_kubernetes_containers(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://cloud/kubernetes-containers/fql-guide` resource when building this filter parameter.",
             examples={"cloud:'Azure'", "container_name:'service'"},
@@ -198,23 +197,22 @@ class CloudModule(BaseModule):
 
     def search_images_vulnerabilities(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://cloud/images-vulnerabilities/fql-guide` resource when building this filter parameter.",
             examples={"cve_id:*'*2025*'", "cvss_score:>5"},
         ),
-        limit: Optional[int] = Field(
+        limit: int = Field(
             default=10,
             ge=1,
             le=9999,
-            description="The maximum number of containers to return in this response (default: 100; max: 9999). Use with the offset parameter to manage pagination of results.",
+            description="The maximum number of containers to return in this response (default: 10; max: 9999). Use with the offset parameter to manage pagination of results.",
         ),
-        offset: Optional[int] = Field(
-            default=0,
-            ge=0,
+        offset: int | None = Field(
+            default=None,
             description="Starting index of overall result set from which to return containers.",
         ),
-        sort: Optional[str] = Field(
+        sort: str | None = Field(
             default=None,
             description=dedent(
                 """

--- a/falcon_mcp/modules/detections.py
+++ b/falcon_mcp/modules/detections.py
@@ -5,7 +5,7 @@ This module provides tools for accessing and analyzing CrowdStrike Falcon detect
 """
 
 from textwrap import dedent
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
@@ -62,27 +62,26 @@ class DetectionsModule(BaseModule):
 
     def search_detections(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://detections/search/fql-guide` resource when building this filter parameter.",
             examples={"agent_id:'77d11725xxxxxxxxxxxxxxxxxxxxc48ca19'", "status:'new'"},
         ),
-        limit: Optional[int] = Field(
-            default=100,
+        limit: int = Field(
+            default=10,
             ge=1,
             le=9999,
-            description="The maximum number of detections to return in this response (default: 100; max: 9999). Use with the offset parameter to manage pagination of results.",
+            description="The maximum number of detections to return in this response (default: 10; max: 9999). Use with the offset parameter to manage pagination of results.",
         ),
-        offset: Optional[int] = Field(
-            default=0,
-            ge=0,
-            description="The first detection to return, where 0 is the latest detection. Use with the limit parameter to manage pagination of results.",
+        offset: int | None = Field(
+            default=None,
+            description="The first detection to return, where 0 is the latest detection. Use with the offset parameter to manage pagination of results.",
         ),
-        q: Optional[str] = Field(
+        q: str | None = Field(
             default=None,
             description="Search all detection metadata for the provided string",
         ),
-        sort: Optional[str] = Field(
+        sort: str | None = Field(
             default=None,
             description=dedent("""
                 Sort detections using these options:
@@ -104,7 +103,7 @@ class DetectionsModule(BaseModule):
             """).strip(),
             examples={"severity.desc", "timestamp.desc"},
         ),
-        include_hidden: Optional[bool] = Field(default=True),
+        include_hidden: bool = Field(default=True),
     ) -> List[Dict[str, Any]]:
         """Find and analyze detections to understand malicious activity in your environment.
 
@@ -167,25 +166,22 @@ class DetectionsModule(BaseModule):
     def get_detection_details(
         self,
         ids: List[str] = Field(
-            default=None,
-            description="Detection ID(s) to retrieve details for. Specify one or more detection IDs (max 1000 per request).",
+            description="Composite ID(s) to retrieve detection details for.",
         ),
-        include_hidden: Optional[bool] = Field(
+        include_hidden: bool = Field(
             default=True,
             description="Whether to include hidden detections (default: True). When True, shows all detections including previously hidden ones for comprehensive visibility.",
         ),
     ) -> List[Dict[str, Any]] | Dict[str, Any]:
-        """Get comprehensive detection details for specific detection IDs to understand security threats.
+        """Get detection details for specific detection IDs to understand security threats.
 
-        This tool returns comprehensive detection details for one or more detection IDs.
         Use this when you already have specific detection IDs and need their full details.
         For searching/discovering detections, use the `falcon_search_detections` tool instead.
 
         Returns:
-            List of detection details with comprehensive information including host data,
-            disposition, objective/tactic/technique, adversary information, and more
+            List of detection(s) with details
         """
-        logger.debug("Getting detection details for ID: %s", ids)
+        logger.debug("Getting detection details for ID(s): %s", ids)
 
         # Use the enhanced base method - composite_ids parameter matches ids for backward compatibility
         return self._base_get_by_ids(

--- a/falcon_mcp/modules/hosts.py
+++ b/falcon_mcp/modules/hosts.py
@@ -5,7 +5,7 @@ This module provides tools for accessing and managing CrowdStrike Falcon hosts/d
 """
 
 from textwrap import dedent
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
@@ -62,21 +62,22 @@ class HostsModule(BaseModule):
 
     def search_hosts(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://hosts/search/fql-guide` resource when building this filter parameter.",
             examples={"platform_name:'Windows'", "hostname:'PC*'"},
         ),
-        limit: Optional[int] = Field(
-            default=100,
+        limit: int = Field(
+            default=10,
             ge=1,
             le=5000,
             description="The maximum records to return. [1-5000]",
         ),
-        offset: Optional[int] = Field(
-            default=0, ge=0, description="The offset to start retrieving records from."
+        offset: int | None = Field(
+            default=None,
+            description="The offset to start retrieving records from.",
         ),
-        sort: Optional[str] = Field(
+        sort: str | None = Field(
             default=None,
             description=dedent("""
                 Sort hosts using these options:
@@ -178,5 +179,7 @@ class HostsModule(BaseModule):
 
         # Use the base method to get device details
         return self._base_get_by_ids(
-            operation="PostDeviceDetailsV2", ids=ids, id_key="ids"
+            operation="PostDeviceDetailsV2",
+            ids=ids,
+            id_key="ids",
         )

--- a/falcon_mcp/modules/incidents.py
+++ b/falcon_mcp/modules/incidents.py
@@ -4,7 +4,7 @@ Incidents module for Falcon MCP Server
 This module provides tools for accessing and analyzing CrowdStrike Falcon incidents.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
@@ -102,22 +102,21 @@ class IncidentsModule(BaseModule):
 
     def show_crowd_score(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://incidents/crowd-score/fql-guide` resource when building this filter parameter.",
         ),
-        limit: Optional[int] = Field(
-            default=100,
+        limit: int = Field(
+            default=10,
             ge=1,
             le=2500,
             description="Maximum number of records to return. (Max: 2500)",
         ),
-        offset: Optional[int] = Field(
-            default=0,
-            ge=0,
+        offset: int | None = Field(
+            default=None,
             description="Starting index of overall result set from which to return ids.",
         ),
-        sort: Optional[str] = Field(
+        sort: str | None = Field(
             default=None,
             description="The property to sort by. (Ex: modified_timestamp.desc)",
             examples={"modified_timestamp.desc"},
@@ -184,22 +183,21 @@ class IncidentsModule(BaseModule):
 
     def search_incidents(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://incidents/search/fql-guide` resource when building this filter parameter.",
         ),
         limit: int = Field(
-            default=100,
+            default=10,
             ge=1,
             le=500,
             description="Maximum number of records to return. (Max: 500)",
         ),
-        offset: int = Field(
-            default=0,
-            ge=0,
+        offset: int | None = Field(
+            default=None,
             description="Starting index of overall result set from which to return ids.",
         ),
-        sort: Optional[str] = Field(
+        sort: str | None = Field(
             default=None,
             description="The property to sort by. FQL syntax. Ex: state.asc, name.desc",
         ),
@@ -254,22 +252,21 @@ class IncidentsModule(BaseModule):
 
     def search_behaviors(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://incidents/behaviors/fql-guide` resource when building this filter parameter.",
         ),
         limit: int = Field(
-            default=100,
+            default=10,
             ge=1,
             le=500,
             description="Maximum number of records to return. (Max: 500)",
         ),
-        offset: int = Field(
-            default=0,
-            ge=0,
+        offset: int | None = Field(
+            default=None,
             description="Starting index of overall result set from which to return ids.",
         ),
-        sort: Optional[str] = Field(
+        sort: str | None = Field(
             default=None,
             description="The property to sort by. (Ex: modified_timestamp.desc)",
         ),
@@ -327,10 +324,10 @@ class IncidentsModule(BaseModule):
     def _base_query(
         self,
         operation: str,
-        filter: Optional[str] = None,
+        filter: str | None = None,
         limit: int = 100,
-        offset: int = 0,
-        sort: Optional[str] = None,
+        offset: int | None = None,
+        sort: str | None = None,
     ) -> List[str] | Dict[str, Any]:
         # Prepare parameters
         params = prepare_api_parameters(

--- a/falcon_mcp/modules/intel.py
+++ b/falcon_mcp/modules/intel.py
@@ -4,7 +4,7 @@ Intel module for Falcon MCP Server
 This module provides tools for accessing and analyzing CrowdStrike Falcon intelligence data.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
@@ -93,29 +93,28 @@ class IntelModule(BaseModule):
 
     def query_actor_entities(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL query expression that should be used to limit the results. IMPORTANT: use the `falcon://intel/actors/fql-guide` resource when building this filter parameter.",
         ),
-        limit: Optional[int] = Field(
-            default=100,
+        limit: int = Field(
+            default=10,
             ge=1,
             le=5000,
             description="Maximum number of records to return. Max 5000",
             examples={10, 20, 100},
         ),
-        offset: Optional[int] = Field(
-            default=0,
-            ge=0,
+        offset: int | None = Field(
+            default=None,
             description="Starting index of overall result set from which to return ids.",
-            examples={0, 10},
+            examples=[0, 10],
         ),
-        sort: Optional[str] = Field(
+        sort: str | None = Field(
             default=None,
             description="The property to sort by. Example: 'created_date|desc'",
             examples={"created_date|desc"},
         ),
-        q: Optional[str] = Field(
+        q: str | None = Field(
             default=None,
             description="Free text search across all indexed fields.",
             examples={"BEAR"},
@@ -162,32 +161,33 @@ class IntelModule(BaseModule):
 
     def query_indicator_entities(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL query expression that should be used to limit the results. IMPORTANT: use the `falcon://intel/indicators/fql-guide` resource when building this filter parameter.",
         ),
-        limit: Optional[int] = Field(
-            default=100,
+        limit: int = Field(
+            default=10,
             ge=1,
             le=5000,
             description="Maximum number of records to return. (Max: 5000)",
         ),
-        offset: Optional[int] = Field(
-            default=0,
-            ge=0,
+        offset: int | None = Field(
+            default=None,
             description="Starting index of overall result set from which to return ids.",
         ),
-        sort: Optional[str] = Field(
-            default=None, description="The property to sort by. (Ex: created_date|desc)"
+        sort: str | None = Field(
+            default=None,
+            description="The property to sort by. (Ex: created_date|desc)",
         ),
-        q: Optional[str] = Field(
-            default=None, description="Free text search across all indexed fields."
+        q: str | None = Field(
+            default=None,
+            description="Free text search across all indexed fields.",
         ),
-        include_deleted: Optional[bool] = Field(
+        include_deleted: bool = Field(
             default=False,
             description="Flag indicating if both published and deleted indicators should be returned.",
         ),
-        include_relations: Optional[bool] = Field(
+        include_relations: bool = Field(
             default=False,
             description="Flag indicating if related indicators should be returned.",
         ),
@@ -235,26 +235,27 @@ class IntelModule(BaseModule):
 
     def query_report_entities(
         self,
-        filter: Optional[str] = Field(
+        filter: str | None = Field(
             default=None,
             description="FQL query expression that should be used to limit the results. IMPORTANT: use the `falcon://intel/reports/fql-guide` resource when building this filter parameter.",
         ),
         limit: int = Field(
-            default=100,
+            default=10,
             ge=1,
             le=5000,
             description="Maximum number of records to return. (Max: 5000)",
         ),
-        offset: int = Field(
-            default=0,
-            ge=0,
+        offset: int | None = Field(
+            default=None,
             description="Starting index of overall result set from which to return ids.",
         ),
-        sort: Optional[str] = Field(
-            default=None, description="The property to sort by. (Ex: created_date|desc)"
+        sort: str | None = Field(
+            default=None,
+            description="The property to sort by. (Ex: created_date|desc)",
         ),
-        q: Optional[str] = Field(
-            default=None, description="Free text search across all indexed fields."
+        q: str | None = Field(
+            default=None,
+            description="Free text search across all indexed fields.",
         ),
     ) -> List[Dict[str, Any]]:
         """Access CrowdStrike intelligence publications and threat reports.

--- a/falcon_mcp/modules/spotlight.py
+++ b/falcon_mcp/modules/spotlight.py
@@ -5,7 +5,7 @@ This module provides tools for accessing and managing CrowdStrike Falcon Spotlig
 """
 
 from textwrap import dedent
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
@@ -56,22 +56,22 @@ class SpotlightModule(BaseModule):
 
     def search_vulnerabilities(
         self,
-        filter: str = Field(
+        filter: str | None = Field(
+            default=None,
             description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://spotlight/vulnerabilities/fql-guide` resource when building this filter parameter.",
             examples={"status:'open'", "cve.severity:'HIGH'"},
         ),
-        limit: Optional[int] = Field(
-            default=100,
+        limit: int = Field(
+            default=10,
             ge=1,
             le=5000,
-            description="Maximum number of results to return. (Max: 5000, Default: 100)",
+            description="Maximum number of results to return. (Max: 5000, Default: 10)",
         ),
-        offset: Optional[int] = Field(
-            default=0,
-            ge=0,
+        offset: int | None = Field(
+            default=None,
             description="Starting index of overall result set from which to return results.",
         ),
-        sort: Optional[str] = Field(
+        sort: str | None = Field(
             default=None,
             description=dedent("""
                 Sort vulnerabilities using FQL syntax.
@@ -92,11 +92,11 @@ class SpotlightModule(BaseModule):
                 "closed_timestamp|asc",
             },
         ),
-        after: Optional[str] = Field(
+        after: str | None = Field(
             default=None,
             description="A pagination token used with the limit parameter to manage pagination of results. On your first request, don't provide an after token. On subsequent requests, provide the after token from the previous response to continue from that place in the results.",
         ),
-        facet: Optional[str] = Field(
+        facet: str | None = Field(
             default=None,
             description=dedent("""
                 Important: Use only one value!


### PR DESCRIPTION
Closes #104

- Make offset parameters consistently optional (int | None, default=None) across all modules
- Fix spotlight filter parameter to be optional with proper default
- Fix detections get_detection_details ids parameter to be required (remove invalid default=None)
- Update description to clarify composite_ids vs detection_ids for accuracy
- Improve API usability by making pagination truly optional while maintaining backward compatibility

Affects: detections, incidents, hosts, intel, spotlight, cloud modules