### PR TITLE
Allow setting of the credentials through init when using in library mode.

### DIFF
--- a/falcon_mcp/client.py
+++ b/falcon_mcp/client.py
@@ -35,6 +35,8 @@ class FalconClient:
             base_url: Falcon API base URL (defaults to FALCON_BASE_URL env var)
             debug: Enable debug logging
             user_agent_comment: Additional information to include in the User-Agent comment section
+            client_id: Falcon API Client ID
+            client_secret: Falcon API Client Secret
         """
         # Get credentials from environment variables
         self.client_id = client_id or os.environ.get("FALCON_CLIENT_ID")

--- a/falcon_mcp/client.py
+++ b/falcon_mcp/client.py
@@ -26,6 +26,8 @@ class FalconClient:
         base_url: Optional[str] = None,
         debug: bool = False,
         user_agent_comment: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
     ):
         """Initialize the Falcon client.
 
@@ -35,8 +37,8 @@ class FalconClient:
             user_agent_comment: Additional information to include in the User-Agent comment section
         """
         # Get credentials from environment variables
-        self.client_id = os.environ.get("FALCON_CLIENT_ID")
-        self.client_secret = os.environ.get("FALCON_CLIENT_SECRET")
+        self.client_id = client_id or os.environ.get("FALCON_CLIENT_ID")
+        self.client_secret = client_secret or os.environ.get("FALCON_CLIENT_SECRET")
         self.base_url = base_url or os.environ.get(
             "FALCON_BASE_URL", "https://api.crowdstrike.com"
         )

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -30,6 +30,8 @@ class FalconMCPServer:
         debug: bool = False,
         enabled_modules: Optional[Set[str]] = None,
         user_agent_comment: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None
     ):
         """Initialize the Falcon MCP server.
 
@@ -38,6 +40,8 @@ class FalconMCPServer:
             debug: Enable debug logging
             enabled_modules: Set of module names to enable (defaults to all modules)
             user_agent_comment: Additional information to include in the User-Agent comment section
+            client_id: Falcon API Client ID
+            client_secret: Falcon API Client Secret
         """
         # Store configuration
         self.base_url = base_url
@@ -55,6 +59,8 @@ class FalconMCPServer:
             base_url=self.base_url,
             debug=self.debug,
             user_agent_comment=self.user_agent_comment,
+            client_id=client_id,
+            client_secret=client_secret
         )
 
         # Authenticate with the Falcon API


### PR DESCRIPTION

Reasoning: 
Not all use-cases have credentials set in the environment necessarily, especially when used as a library. Credentials can also come from secret files, vaults, etc and may not be exposed in the environment. 

Some practices even discourage putting credentials in the environment as various crash dumps may include them, potentially causing credential leaks. 

This is a fully backwards compatible minor change, exposing the credentials (`client_id` and `client_secret` in the `__init__` functions of both the `FalconClient` and the FalconMCPServer, with a default of None. 