### PR TITLE
feat(modules/discover): add new discover module

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -21,7 +21,7 @@ FALCON_BASE_URL=https://api.us-2.crowdstrike.com
 # Modules to enable (comma-separated list)
 # Options: detections,incidents,intel,hosts,spotlight,cloud,idp,sensorusage
 # Default: all modules enabled if not specified
-#FALCON_MCP_MODULES=detections,incidents,intel,hosts,spotlight,cloud,idp,sensorusage,serverless
+#FALCON_MCP_MODULES=detections,incidents,intel,hosts,spotlight,cloud,idp,sensorusage,serverless,discover
 
 # Transport method to use
 # Options: stdio, sse, streamable-http

--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ FALCON_BASE_URL=https://api.us-2.crowdstrike.com
 # Modules to enable (comma-separated list)
 # Options: detections,incidents,intel,hosts,spotlight,cloud,idp,sensorusage
 # Default: all modules enabled if not specified
-#FALCON_MCP_MODULES=detections,incidents,intel,hosts,spotlight,cloud,idp,sensorusage,serverless
+#FALCON_MCP_MODULES=detections,incidents,intel,hosts,spotlight,cloud,idp,sensorusage,serverless,discover
 
 # Transport method to use
 # Options: stdio, sse, streamable-http

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The Falcon MCP Server supports different modules, each requiring specific API sc
 | **Sensor Usage**        | `Sensor Usage:read`                                                                                                                                            | Access and analyze sensor usage data                                                 |
 | **Serverless**          | `Falcon Container Image:read`                                                                                                                                  | Search for vulnerabilities in serverless functions across cloud service providers    |
 | **Spotlight**           | `Vulnerabilities:read`                                                                                                                                         | Manage and analyze vulnerability data and security assessments                       |
+| **Discover**            | `Assets:read`                                                                                                                                                  | Search and analyze application inventory across your environment                     |
 | **Identity Protection** | `Identity Protection Entities:read`<br>`Identity Protection Timeline:read`<br>`Identity Protection Detections:read` <br> `Identity Protection Assessment:read` | Comprehensive entity investigation and identity protection analysis                  |
 
 ## Available Modules, Tools & Resources
@@ -188,6 +189,20 @@ Provides tools for accessing and managing CrowdStrike Spotlight vulnerabilities:
 - `falcon://spotlight/vulnerabilities/fql-guide`: Comprehensive FQL documentation and examples for vulnerability searches
 
 **Use Cases**: Vulnerability management, security assessments, compliance reporting, risk analysis, patch prioritization
+
+### Discover Module
+
+**API Scopes Required**: `Assets:read`
+
+Provides tools for accessing and managing CrowdStrike Falcon Discover applications:
+
+- `falcon_search_applications`: Search for applications in your CrowdStrike environment
+
+**Resources**:
+
+- `falcon://discover/applications/fql-guide`: Comprehensive FQL documentation and examples for application searches
+
+**Use Cases**: Application inventory management, software asset management, license compliance, vulnerability assessment
 
 ### Cloud Security Module
 

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -32,6 +32,8 @@ API_SCOPE_REQUIREMENTS = {
     "QueryIntelReportEntities": ["Reports (Falcon Intelligence):read"],
     # Spotlight operations
     "combinedQueryVulnerabilities": ["Vulnerabilities:read"],
+    # Discover operations
+    "combined_applications": ["Assets:read"],
     # Cloud operations
     "ReadContainerCombined": ["Falcon Container Image:read"],
     "ReadContainerCount": ["Falcon Container Image:read"],

--- a/falcon_mcp/modules/__init__.py
+++ b/falcon_mcp/modules/__init__.py
@@ -5,6 +5,7 @@ Modules package for Falcon MCP Server
 
 # Import all module classes so they're available for auto-discovery
 from .detections import DetectionsModule
+from .discover import DiscoverModule
 from .hosts import HostsModule
 from .incidents import IncidentsModule
 from .intel import IntelModule

--- a/falcon_mcp/modules/discover.py
+++ b/falcon_mcp/modules/discover.py
@@ -78,11 +78,7 @@ class DiscoverModule(BaseModule):
             default=100,
             ge=1,
             le=1000,
-            description="Maximum number of items to return: 1-1000. Default is 100. Use with the after parameter to manage pagination of results.",
-        ),
-        after: str | None = Field(
-            default=None,
-            description="Token used with the limit parameter to manage pagination of results. On your first request, don't provide an after token. On subsequent requests, provide the after token from the previous response to continue from that place in the results. Tokens expire 120 seconds after a call is made.",
+            description="Maximum number of items to return: 1-1000. Default is 100.",
         ),
         sort: str | None = Field(
             default=None,
@@ -101,7 +97,6 @@ class DiscoverModule(BaseModule):
                 "filter": filter,
                 "facet": facet,
                 "limit": limit,
-                "after": after,
                 "sort": sort,
             }
         )

--- a/falcon_mcp/modules/discover.py
+++ b/falcon_mcp/modules/discover.py
@@ -1,0 +1,130 @@
+"""
+Discover module for Falcon MCP Server
+
+This module provides tools for accessing and managing CrowdStrike Falcon Discover applications.
+"""
+
+from textwrap import dedent
+from typing import Any, Dict, List
+
+from mcp.server import FastMCP
+from mcp.server.fastmcp.resources import TextResource
+from pydantic import AnyUrl, Field
+
+from falcon_mcp.common.errors import handle_api_response
+from falcon_mcp.common.logging import get_logger
+from falcon_mcp.common.utils import prepare_api_parameters
+from falcon_mcp.modules.base import BaseModule
+from falcon_mcp.resources.discover import SEARCH_APPLICATIONS_FQL_DOCUMENTATION
+
+logger = get_logger(__name__)
+
+
+class DiscoverModule(BaseModule):
+    """Module for accessing and managing CrowdStrike Falcon Discover applications."""
+
+    def register_tools(self, server: FastMCP) -> None:
+        """Register tools with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        # Register tools
+        self._add_tool(
+            server=server,
+            method=self.search_applications,
+            name="search_applications",
+        )
+
+    def register_resources(self, server: FastMCP) -> None:
+        """Register resources with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        search_applications_fql_resource = TextResource(
+            uri=AnyUrl("falcon://discover/applications/fql-guide"),
+            name="falcon_search_applications_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_applications` tool.",
+            text=SEARCH_APPLICATIONS_FQL_DOCUMENTATION,
+        )
+
+        self._add_resource(
+            server,
+            search_applications_fql_resource,
+        )
+
+    def search_applications(
+        self,
+        filter: str = Field(
+            description="FQL filter expression used to limit the results. IMPORTANT: use the `falcon://discover/applications/fql-guide` resource when building this filter parameter.",
+            examples={"name:'Chrome'", "vendor:'Microsoft Corporation'"},
+        ),
+        facet: str | None = Field(
+            default=None,
+            description=dedent("""
+                Type of data to be returned for each application entity. The facet filter allows you to limit the response to just the information you want.
+                
+                Possible values:
+                • browser_extension
+                • host_info
+                • install_usage
+                
+                Note: Requests that do not include the host_info or browser_extension facets still return host.ID, browser_extension.ID, and browser_extension.enabled in the response.
+            """).strip(),
+            examples={"browser_extension", "host_info", "install_usage"},
+        ),
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=1000,
+            description="Maximum number of items to return: 1-1000. Default is 100. Use with the after parameter to manage pagination of results.",
+        ),
+        after: str | None = Field(
+            default=None,
+            description="Token used with the limit parameter to manage pagination of results. On your first request, don't provide an after token. On subsequent requests, provide the after token from the previous response to continue from that place in the results. Tokens expire 120 seconds after a call is made.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Property used to sort the results. All properties can be used to sort unless otherwise noted in their property descriptions.",
+            examples={"name.asc", "vendor.desc", "last_updated_timestamp.desc"},
+        ),
+    ) -> List[Dict[str, Any]]:
+        """Search for applications in your CrowdStrike environment.
+
+        IMPORTANT: You must use the `falcon://discover/applications/fql-guide` resource when you need to use the `filter` parameter.
+        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_applications` tool.
+        """
+        # Prepare parameters for combined_applications
+        params = prepare_api_parameters(
+            {
+                "filter": filter,
+                "facet": facet,
+                "limit": limit,
+                "after": after,
+                "sort": sort,
+            }
+        )
+
+        # Define the operation name
+        operation = "combined_applications"
+
+        logger.debug("Searching applications with params: %s", params)
+
+        # Make the API request
+        response = self.client.command(operation, parameters=params)
+
+        # Use handle_api_response to get application data
+        applications = handle_api_response(
+            response,
+            operation=operation,
+            error_message="Failed to search applications",
+            default_result=[],
+        )
+
+        # If handle_api_response returns an error dict instead of a list,
+        # it means there was an error, so we return it wrapped in a list
+        if self._is_error(applications):
+            return [applications]
+
+        return applications

--- a/falcon_mcp/resources/discover.py
+++ b/falcon_mcp/resources/discover.py
@@ -1,0 +1,330 @@
+"""
+Contains Discover Applications resources.
+"""
+
+from falcon_mcp.common.utils import generate_md_table
+
+# List of tuples containing filter options data: (name, type, operators, description)
+SEARCH_APPLICATIONS_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Operators",
+        "Description"
+    ),
+    (
+        "architectures",
+        "String",
+        "Yes",
+        """
+        Application architecture. Unavailable for browser extensions.
+
+        Ex: architectures:'x86'
+        Ex: architectures:!'x64'
+        Ex: architectures:['x86','x64']
+        """
+    ),
+    (
+        "category",
+        "String",
+        "Yes",
+        """
+        Category the application is in. Unavailable for browser extensions.
+
+        Ex: category:'IT/Security Apps'
+        Ex: category:'Web Browsers'
+        Ex: category:'Back up and Recovery'
+        Ex: category:['IT/Security Apps','Web Browsers']
+        """
+    ),
+    (
+        "cid",
+        "String",
+        "Yes",
+        """
+        The application's customer ID. In multi-CID environments:
+        - You can filter on both parent and child CIDs.
+        - If you're in a parent CID and leave this filter empty, the response includes data about the parent CID and all its child CIDs.
+        - If you're in a parent CID and use this filter, the response includes data for only the CIDs you filtered on.
+        - If you're in a child CID, this property will only show data for that CID.
+
+        Ex: cid:'cxxx4'
+        Ex: cid:!'cxxx4'
+        Ex: cid:'cxxx4',cid:'dxxx5'
+        """
+    ),
+    (
+        "first_seen_timestamp",
+        "Timestamp",
+        "Yes",
+        """
+        Date and time the application was first seen.
+
+        Ex: first_seen_timestamp:'2022-12-22T12:41:47.417Z'
+        """
+    ),
+    (
+        "groups",
+        "String",
+        "Yes",
+        """
+        All application groups the application is assigned to.
+
+        Ex: groups:'ExampleAppGroup'
+        Ex: groups:['AppGroup1','AppGroup2']
+        """
+    ),
+    (
+        "id",
+        "String",
+        "Yes",
+        """
+        Unique ID of the application. Each application ID represents a particular instance of an application on a particular asset.
+
+        Ex: id:'a89xxxxx191'
+        Ex: id:'a89xxxxx191',id:'a89xxxxx192'
+        """
+    ),
+    (
+        "installation_paths",
+        "String",
+        "Yes",
+        """
+        File paths of the application or executable file to the folder on the asset.
+
+        Ex: installation_paths:'C:\\Program Files\\Internet Explorer\\iexplore.exe'
+        Ex: installation_paths:'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe'
+        Ex: installation_paths:['C:\\Program Files (x86)\\Google*','C:\\Program Files (x86)\\Adobe*']
+        """
+    ),
+    (
+        "installation_timestamp",
+        "Timestamp",
+        "Yes",
+        """
+        Date and time the application was installed, if available.
+
+        Ex: installation_timestamp:'2023-01-11T00:00:00.000Z'
+        """
+    ),
+    (
+        "is_normalized",
+        "Boolean",
+        "Yes",
+        """
+        Windows: Whether the application name is normalized (true/false).
+        Applications can have different naming variations that result in different records for each variation.
+        To avoid this duplication, the most common applications are listed under a single normalized application name.
+        Unavailable for browser extensions.
+
+        Ex: is_normalized:true
+        """
+    ),
+    (
+        "is_suspicious",
+        "Boolean",
+        "Yes",
+        """
+        Whether the application is suspicious based on how often it's been seen in a detection on that asset (true/false).
+        Unavailable for browser extensions. See browser_extension.permission_severity instead.
+
+        Ex: is_suspicious:true
+        Ex: is_suspicious:!false
+        """
+    ),
+    (
+        "last_updated_timestamp",
+        "Timestamp",
+        "Yes",
+        """
+        Date and time the installation fields of the application instance most recently changed.
+
+        Ex: last_updated_timestamp:'2022-12-22T12:41:47.417Z'
+        """
+    ),
+    (
+        "last_used_file_hash",
+        "String",
+        "Yes",
+        """
+        Windows and macOS: Most recent file hash used for the application.
+
+        Ex: last_used_file_hash:'0xxxa'
+        Ex: last_used_file_hash:['0xxxa','7xxxx9']
+        """
+    ),
+    (
+        "last_used_file_name",
+        "String",
+        "Yes",
+        """
+        Windows and macOS: Most recent file name used for the application.
+
+        Ex: last_used_file_name:'setup.exe'
+        Ex: last_used_file_name:'putty.exe'
+        Ex: last_used_file_name:['setup.exe','putty.exe']
+        """
+    ),
+    (
+        "last_used_timestamp",
+        "Timestamp",
+        "Yes",
+        """
+        Windows and macOS: Date and time the application was most recently used.
+
+        Ex: last_used_timestamp:'2023-01-10T23:00:00.000Z'
+        """
+    ),
+    (
+        "last_used_user_name",
+        "String",
+        "Yes",
+        """
+        Windows and macOS: Username of the account that most recently used the application.
+
+        Ex: last_used_user_name:'Administrator'
+        Ex: last_used_user_name:'xiany'
+        Ex: last_used_user_name:['xiany','dursti']
+        """
+    ),
+    (
+        "last_used_user_sid",
+        "String",
+        "Yes",
+        """
+        Windows and macOS: Security identifier of the account that most recently used the application.
+
+        Ex: last_used_user_sid:'S-1-x-x-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxx1'
+        Ex: last_used_user_sid:['S-x-x-x-x-1','S-x-x-x-7']
+        """
+    ),
+    (
+        "name",
+        "String",
+        "Yes",
+        """
+        Name of the application.
+
+        Ex: name:'Chrome'
+        Ex: name:'Falcon Sensor'
+        Ex: name:['Chrome','Edge']
+        """
+    ),
+    (
+        "name_vendor",
+        "String",
+        "Yes",
+        """
+        To group results by application: The app name and vendor name for all application IDs with this application name.
+
+        Ex: name_vendor:'Chrome-Google'
+        Ex: name_vendor:'Tools-VMware'
+        Ex: name_vendor:['Chrome-Google','Tools-VMware']
+        """
+    ),
+    (
+        "name_vendor_version",
+        "String",
+        "Yes",
+        """
+        To group results by application version: The app name, vendor name, and vendor version for all application IDs with this application name.
+
+        Ex: name_vendor_version:'Chrome-Google-108.0.5359.99'
+        Ex: name_vendor_version:'Flash Player-Adobe-32.0.0.387'
+        Ex: name_vendor_version:['Chrome-Google-108*','Flash Player-Adobe-32*']
+        """
+    ),
+    (
+        "software_type",
+        "String",
+        "Yes",
+        """
+        The type of software: 'application' or 'browser_extension'.
+
+        Ex: software_type:'application'
+        """
+    ),
+    (
+        "vendor",
+        "String",
+        "Yes",
+        """
+        Name of the application vendor.
+
+        Ex: vendor:'Microsoft Corporation'
+        Ex: vendor:'Google'
+        Ex: vendor:'CrowdStrike'
+        Ex: vendor:['Microsoft*','Google']
+        """
+    ),
+    (
+        "version",
+        "String",
+        "Yes",
+        """
+        Application version.
+
+        Ex: version:'4.8.4320.0'
+        Ex: version:'108.0.5359.99'
+        Ex: version:'6.50.16403.0'
+        Ex: version:['6.50.16403.0','6.50.16403.1']
+        """
+    ),
+    (
+        "versioning_scheme",
+        "String",
+        "Yes",
+        """
+        Versioning scheme of the application. Unavailable for browser extensions.
+
+        Ex: versioning_scheme:'semver'
+        Ex: versioning_scheme:['semver','calver']
+        """
+    ),
+]
+
+SEARCH_APPLICATIONS_FQL_DOCUMENTATION = """Falcon Query Language (FQL) - Search Applications Guide
+
+=== BASIC SYNTAX ===
+property_name:[operator]'value'
+
+=== AVAILABLE OPERATORS ===
+• No operator = equals (default)
+• ! = not equal to
+• > = greater than
+• >= = greater than or equal
+• < = less than
+• <= = less than or equal
+• ~ = text match (ignores case, spaces, punctuation)
+• !~ = does not text match
+
+=== DATA TYPES & SYNTAX ===
+• Strings: 'value' or ['exact_value'] for exact match
+• Dates: 'YYYY-MM-DDTHH:MM:SSZ' (UTC format)
+• Booleans: true or false (no quotes)
+• Numbers: 123 (no quotes)
+
+=== COMBINING CONDITIONS ===
+• + = AND condition
+• , = OR condition
+• ( ) = Group expressions
+
+=== falcon_search_applications FQL filter options ===
+
+""" + generate_md_table(SEARCH_APPLICATIONS_FQL_FILTERS) + """
+
+=== IMPORTANT NOTES ===
+• Use single quotes around string values: 'value'
+• Use square brackets for exact matches and multiple values: ['value1','value2']
+• Date format must be UTC: 'YYYY-MM-DDTHH:MM:SSZ'
+• Boolean values: true or false (no quotes)
+• Some fields require specific capitalization (check individual field descriptions)
+
+=== COMMON FILTER EXAMPLES ===
+• Find Chrome applications: name:'Chrome'
+• Find applications from Microsoft: vendor:'Microsoft Corporation'
+• Find recently installed applications: installation_timestamp:>'2024-01-01'
+• Find suspicious applications: is_suspicious:true
+• Find browser extensions: software_type:'browser_extension'
+• Find applications used by a specific user: last_used_user_name:'Administrator'
+"""

--- a/tests/e2e/modules/test_discover.py
+++ b/tests/e2e/modules/test_discover.py
@@ -1,0 +1,148 @@
+"""
+E2E tests for the Discover module.
+"""
+
+import json
+import unittest
+
+import pytest
+
+from tests.e2e.utils.base_e2e_test import BaseE2ETest
+
+
+@pytest.mark.e2e
+class TestDiscoverModuleE2E(BaseE2ETest):
+    """
+    End-to-end test suite for the Falcon MCP Server Discover Module.
+    """
+
+    def test_search_applications_by_category(self):
+        """Verify the agent can search for applications by name."""
+
+        async def test_logic():
+            fixtures = [
+                {
+                    "operation": "combined_applications",
+                    "validator": lambda kwargs: "category:'Web Browsers'" in kwargs.get("parameters", {}).get("filter", ""),
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "resources": [
+                                {
+                                    "id": "abc123_def456789abcdef123456789abcdef123456789abcdef123456789abcdef",
+                                    "cid": "abc123",
+                                    "name": "Chrome Browser",
+                                    "vendor": "Google",
+                                    "version": "120.0.6099.130",
+                                    "software_type": "application",
+                                    "name_vendor": "Chrome Browser-Google",
+                                    "name_vendor_version": "Chrome Browser-Google-120.0.6099.130",
+                                    "versioning_scheme": "semver",
+                                    "groups": [
+                                        "group1",
+                                        "group2",
+                                        "group3"
+                                    ],
+                                    "category": "Web Browsers",
+                                    "architectures": [
+                                        "x64"
+                                    ],
+                                    "first_seen_timestamp": "2025-02-15T10:30:00Z",
+                                    "last_updated_timestamp": "2025-03-01T14:45:22Z",
+                                    "is_suspicious": False,
+                                    "is_normalized": True,
+                                    "host": {
+                                        "id": "abc123_xyz789"
+                                    }
+                                },
+                                {
+                                    "id": "def456_123456789abcdef123456789abcdef123456789abcdef123456789abcdef",
+                                    "cid": "def456",
+                                    "name": "Chrome Browser",
+                                    "vendor": "Google",
+                                    "version": "119.0.6045.199",
+                                    "software_type": "application",
+                                    "name_vendor": "Chrome Browser-Google",
+                                    "name_vendor_version": "Chrome Browser-Google-119.0.6045.199",
+                                    "versioning_scheme": "semver",
+                                    "groups": [
+                                        "group4",
+                                        "group5"
+                                    ],
+                                    "category": "Web Browsers",
+                                    "architectures": [
+                                        "x64"
+                                    ],
+                                    "first_seen_timestamp": "2025-01-10T08:15:30Z",
+                                    "last_updated_timestamp": "2025-02-20T11:22:45Z",
+                                    "is_suspicious": False,
+                                    "is_normalized": True,
+                                    "host": {
+                                        "id": "def456_abc123"
+                                    }
+                                }
+                            ]
+                        },
+                    },
+                }
+            ]
+
+            self._mock_api_instance.command.side_effect = (
+                self._create_mock_api_side_effect(fixtures)
+            )
+
+            prompt = "Search for all applications categorized as Web Browsers in our environment and show me their details"
+            return await self._run_agent_stream(prompt)
+
+        def assertions(tools, result):
+            tool_names_called = [tool["input"]["tool_name"] for tool in tools]
+            self.assertIn("falcon_search_applications_fql_guide", tool_names_called)
+            self.assertIn("falcon_search_applications", tool_names_called)
+        
+            used_tool = tools[len(tools) - 1]
+            self.assertEqual(
+                used_tool["input"]["tool_name"], "falcon_search_applications"
+            )
+
+            # Check for name filtering
+            tool_input_str = json.dumps(used_tool["input"]["tool_input"]).lower()
+            self.assertTrue(
+                "web browsers" in tool_input_str,
+                f"Expected web browsers category filtering in tool input: {tool_input_str}",
+            )
+
+            # Verify both applications are in the output
+            self.assertIn("Chrome Browser", used_tool["output"])
+            self.assertIn("Google", used_tool["output"])
+            self.assertIn("120.0.6099.130", used_tool["output"])
+            self.assertIn("119.0.6045.199", used_tool["output"])
+
+            # Verify API call was made correctly
+            self.assertGreaterEqual(
+                self._mock_api_instance.command.call_count, 1, "Expected 1 API call"
+            )
+
+            # Check API call (combined_applications)
+            api_call_params = self._mock_api_instance.command.call_args_list[0][1].get(
+                "parameters", {}
+            )
+            filter_str = api_call_params.get("filter", "").lower()
+            self.assertTrue(
+                "category" in filter_str and "web browsers" in filter_str,
+                f"Expected category:Web Browsers filtering in API call: {filter_str}",
+            )
+
+            # Verify result contains expected information
+            self.assertIn("Chrome Browser", result)
+            self.assertIn("Google", result)
+            self.assertIn("120.0.6099.130", result)
+            self.assertIn("119.0.6045.199", result)
+            self.assertIn("Web Browsers", result)
+
+        self.run_test_with_retries(
+            "test_search_applications_by_category", test_logic, assertions
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/modules/test_discover.py
+++ b/tests/modules/test_discover.py
@@ -1,0 +1,125 @@
+"""
+Unit tests for the Discover module.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from mcp.server import FastMCP
+
+from falcon_mcp.client import FalconClient
+from falcon_mcp.modules.discover import DiscoverModule
+
+
+class TestDiscoverModule(unittest.TestCase):
+    """Test cases for the Discover module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = MagicMock(spec=FalconClient)
+        self.module = DiscoverModule(self.client)
+        self.server = MagicMock(spec=FastMCP)
+
+    def test_register_tools(self):
+        """Test that tools are registered correctly."""
+        self.module.register_tools(self.server)
+        self.server.add_tool.assert_called_once()
+        self.assertEqual(len(self.module.tools), 1)
+        self.assertEqual(self.module.tools[0], "falcon_search_applications")
+
+    def test_register_resources(self):
+        """Test that resources are registered correctly."""
+        self.module.register_resources(self.server)
+        self.server.add_resource.assert_called_once()
+        self.assertEqual(len(self.module.resources), 1)
+        self.assertEqual(
+            str(self.module.resources[0]), "falcon://discover/applications/fql-guide"
+        )
+
+    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
+    @patch("falcon_mcp.modules.discover.handle_api_response")
+    def test_search_applications(self, mock_handle_response, mock_prepare_params):
+        """Test search_applications method."""
+        # Setup mocks
+        mock_prepare_params.return_value = {"filter": "name:'Chrome'"}
+        mock_response = MagicMock()
+        self.client.command.return_value = mock_response
+        mock_handle_response.return_value = [{"id": "app1", "name": "Chrome"}]
+
+        # Call the method
+        result = self.module.search_applications(filter="name:'Chrome'")
+
+        # Assertions
+        # Don't check the exact arguments, just verify it was called once
+        self.assertEqual(mock_prepare_params.call_count, 1)
+        self.client.command.assert_called_once_with(
+            "combined_applications", parameters={"filter": "name:'Chrome'"}
+        )
+        mock_handle_response.assert_called_once_with(
+            mock_response,
+            operation="combined_applications",
+            error_message="Failed to search applications",
+            default_result=[],
+        )
+        self.assertEqual(result, [{"id": "app1", "name": "Chrome"}])
+
+    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
+    @patch("falcon_mcp.modules.discover.handle_api_response")
+    def test_search_applications_with_error(self, mock_handle_response, mock_prepare_params):
+        """Test search_applications method when an error occurs."""
+        # Setup mocks
+        mock_prepare_params.return_value = {"filter": "name:'Chrome'"}
+        mock_response = MagicMock()
+        self.client.command.return_value = mock_response
+        error_response = {"error": "API Error", "message": "Something went wrong"}
+        mock_handle_response.return_value = error_response
+
+        # Call the method
+        result = self.module.search_applications(filter="name:'Chrome'")
+
+        # Assertions
+        self.assertEqual(result, [error_response])
+
+    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
+    @patch("falcon_mcp.modules.discover.handle_api_response")
+    def test_search_applications_with_all_params(self, mock_handle_response, mock_prepare_params):
+        """Test search_applications method with all parameters."""
+        # Setup mocks
+        mock_prepare_params.return_value = {
+            "filter": "name:'Chrome'",
+            "facet": "host_info",
+            "limit": 50,
+            "after": "token123",
+            "sort": "name.asc",
+        }
+        mock_response = MagicMock()
+        self.client.command.return_value = mock_response
+        mock_handle_response.return_value = [{"id": "app1", "name": "Chrome"}]
+
+        # Call the method
+        result = self.module.search_applications(
+            filter="name:'Chrome'",
+            facet="host_info",
+            limit=50,
+            after="token123",
+            sort="name.asc",
+        )
+
+        # Assertions
+        # Don't check the exact arguments, just verify it was called once
+        self.assertEqual(mock_prepare_params.call_count, 1)
+        self.client.command.assert_called_once_with(
+            "combined_applications",
+            parameters={
+                "filter": "name:'Chrome'",
+                "facet": "host_info",
+                "limit": 50,
+                "after": "token123",
+                "sort": "name.asc",
+            },
+        )
+        self.assertEqual(result, [{"id": "app1", "name": "Chrome"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add Discover module for application inventory management

Introduces a new Discover module that enables searching and analyzing application inventory across CrowdStrike environments. The module provides the falcon_search_applications tool with comprehensive FQL filtering capabilities and requires the Assets:read API scope.