### PR TITLE
feat(module/discover): Add unmanaged assets search tool to Discover module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.vscode/
 
 # Abstra
 # Abstra is an AI-powered process automation framework.

--- a/README.md
+++ b/README.md
@@ -143,15 +143,17 @@ Provides tools for accessing and analyzing CrowdStrike Falcon detections:
 
 **API Scopes Required**: `Assets:read`
 
-Provides tools for accessing and managing CrowdStrike Falcon Discover applications:
+Provides tools for accessing and managing CrowdStrike Falcon Discover applications and unmanaged assets:
 
 - `falcon_search_applications`: Search for applications in your CrowdStrike environment
+- `falcon_search_unmanaged_assets`: Search for unmanaged assets (systems without Falcon sensor installed) that have been discovered by managed systems
 
 **Resources**:
 
 - `falcon://discover/applications/fql-guide`: Comprehensive FQL documentation and examples for application searches
+- `falcon://discover/hosts/fql-guide`: Comprehensive FQL documentation and examples for unmanaged assets searches
 
-**Use Cases**: Application inventory management, software asset management, license compliance, vulnerability assessment
+**Use Cases**: Application inventory management, software asset management, license compliance, vulnerability assessment, unmanaged asset discovery, security gap analysis
 
 ### Hosts Module
 

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -34,6 +34,7 @@ API_SCOPE_REQUIREMENTS = {
     "combinedQueryVulnerabilities": ["Vulnerabilities:read"],
     # Discover operations
     "combined_applications": ["Assets:read"],
+    "combined_hosts": ["Assets:read"],
     # Cloud operations
     "ReadContainerCombined": ["Falcon Container Image:read"],
     "ReadContainerCount": ["Falcon Container Image:read"],

--- a/falcon_mcp/modules/discover.py
+++ b/falcon_mcp/modules/discover.py
@@ -1,7 +1,7 @@
 """
 Discover module for Falcon MCP Server
 
-This module provides tools for accessing and managing CrowdStrike Falcon Discover applications.
+This module provides tools for accessing and managing CrowdStrike Falcon Discover applications and unmanaged assets.
 """
 
 from textwrap import dedent
@@ -15,13 +15,16 @@ from falcon_mcp.common.errors import handle_api_response
 from falcon_mcp.common.logging import get_logger
 from falcon_mcp.common.utils import prepare_api_parameters
 from falcon_mcp.modules.base import BaseModule
-from falcon_mcp.resources.discover import SEARCH_APPLICATIONS_FQL_DOCUMENTATION
+from falcon_mcp.resources.discover import (
+    SEARCH_APPLICATIONS_FQL_DOCUMENTATION,
+    SEARCH_UNMANAGED_ASSETS_FQL_DOCUMENTATION,
+)
 
 logger = get_logger(__name__)
 
 
 class DiscoverModule(BaseModule):
-    """Module for accessing and managing CrowdStrike Falcon Discover applications."""
+    """Module for accessing and managing CrowdStrike Falcon Discover applications and unmanaged assets."""
 
     def register_tools(self, server: FastMCP) -> None:
         """Register tools with the MCP server.
@@ -34,6 +37,12 @@ class DiscoverModule(BaseModule):
             server=server,
             method=self.search_applications,
             name="search_applications",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.search_unmanaged_assets,
+            name="search_unmanaged_assets",
         )
 
     def register_resources(self, server: FastMCP) -> None:
@@ -49,9 +58,21 @@ class DiscoverModule(BaseModule):
             text=SEARCH_APPLICATIONS_FQL_DOCUMENTATION,
         )
 
+        search_unmanaged_assets_fql_resource = TextResource(
+            uri=AnyUrl("falcon://discover/hosts/fql-guide"),
+            name="falcon_search_unmanaged_assets_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_unmanaged_assets` tool.",
+            text=SEARCH_UNMANAGED_ASSETS_FQL_DOCUMENTATION,
+        )
+
         self._add_resource(
             server,
             search_applications_fql_resource,
+        )
+
+        self._add_resource(
+            server,
+            search_unmanaged_assets_fql_resource,
         )
 
     def search_applications(
@@ -64,12 +85,12 @@ class DiscoverModule(BaseModule):
             default=None,
             description=dedent("""
                 Type of data to be returned for each application entity. The facet filter allows you to limit the response to just the information you want.
-                
+
                 Possible values:
                 • browser_extension
                 • host_info
                 • install_usage
-                
+
                 Note: Requests that do not include the host_info or browser_extension facets still return host.ID, browser_extension.ID, and browser_extension.enabled in the response.
             """).strip(),
             examples={"browser_extension", "host_info", "install_usage"},
@@ -123,3 +144,95 @@ class DiscoverModule(BaseModule):
             return [applications]
 
         return applications
+
+    def search_unmanaged_assets(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter expression used to limit the results. IMPORTANT: use the `falcon://discover/hosts/fql-guide` resource when building this filter parameter. Note: entity_type:'unmanaged' is automatically applied.",
+            examples={"platform_name:'Windows'", "criticality:'Critical'"},
+        ),
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=5000,
+            description="Maximum number of items to return: 1-5000. Default is 100.",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index of overall result set from which to return results.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description=dedent("""
+                Sort unmanaged assets using these options:
+
+                hostname: Host name/computer name
+                last_seen_timestamp: Timestamp when the asset was last seen
+                first_seen_timestamp: Timestamp when the asset was first seen
+                platform_name: Operating system platform
+                os_version: Operating system version
+                external_ip: External IP address
+                country: Country location
+                criticality: Criticality level
+
+                Sort either asc (ascending) or desc (descending).
+                Both formats are supported: 'hostname.desc' or 'hostname|desc'
+
+                Examples: 'hostname.asc', 'last_seen_timestamp.desc', 'criticality.desc'
+            """).strip(),
+            examples={"hostname.asc", "last_seen_timestamp.desc", "criticality.desc"},
+        ),
+    ) -> List[Dict[str, Any]]:
+        """Search for unmanaged assets (hosts) in your CrowdStrike environment.
+
+        These are systems that do not have the Falcon sensor installed but have been
+        discovered by systems that do have a Falcon sensor installed.
+
+        IMPORTANT: You must use the `falcon://discover/hosts/fql-guide` resource when you need to use the `filter` parameter.
+        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_unmanaged_assets` tool.
+
+        The tool automatically filters for unmanaged assets only by adding entity_type:'unmanaged' to all queries.
+        You do not need to (and cannot) specify entity_type in your filter - it is always set to 'unmanaged'.
+        """
+        # Always enforce entity_type:'unmanaged' filter
+        base_filter = "entity_type:'unmanaged'"
+
+        # Combine with user filter if provided
+        if filter:
+            combined_filter = f"{base_filter}+{filter}"
+        else:
+            combined_filter = base_filter
+
+        # Prepare parameters for combined_hosts
+        params = prepare_api_parameters(
+            {
+                "filter": combined_filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+            }
+        )
+
+        # Define the operation name
+        operation = "combined_hosts"
+
+        logger.debug("Searching unmanaged assets with params: %s", params)
+
+        # Make the API request
+        response = self.client.command(operation, parameters=params)
+
+        # Use handle_api_response to get unmanaged asset data
+        assets = handle_api_response(
+            response,
+            operation=operation,
+            error_message="Failed to search unmanaged assets",
+            default_result=[],
+        )
+
+        # If handle_api_response returns an error dict instead of a list,
+        # it means there was an error, so we return it wrapped in a list
+        if self._is_error(assets):
+            return [assets]
+
+        return assets

--- a/falcon_mcp/resources/discover.py
+++ b/falcon_mcp/resources/discover.py
@@ -549,6 +549,20 @@ SEARCH_UNMANAGED_ASSETS_FQL_FILTERS = [
         Ex: discovering_by:['Passive','Active']
         """
     ),
+    (
+        "confidence",
+        "Number",
+        "Yes",
+        """
+        Confidence level of the unmanaged asset discovery (0-100).
+        Higher values indicate higher confidence that the asset is real.
+
+        Ex: confidence:>80
+        Ex: confidence:>=90
+        Ex: confidence:<50
+        Ex: confidence:[80,90,95]
+        """
+    ),
 ]
 
 SEARCH_UNMANAGED_ASSETS_FQL_DOCUMENTATION = """Falcon Query Language (FQL) - Search Unmanaged Assets Guide
@@ -595,6 +609,7 @@ You do not need to (and cannot) specify entity_type in your filter - it is alway
 
 === COMMON FILTER EXAMPLES ===
 • Find Windows unmanaged assets: platform_name:'Windows'
+• Find high-confidence unmanaged assets: confidence:>80
 • Find recently discovered assets: first_seen_timestamp:>'now-7d'
 • Find assets by hostname pattern: hostname:*'PC-*'
 • Find critical unmanaged assets: criticality:'Critical'

--- a/falcon_mcp/resources/discover.py
+++ b/falcon_mcp/resources/discover.py
@@ -1,5 +1,5 @@
 """
-Contains Discover Applications resources.
+Contains Discover resources for applications and unmanaged assets.
 """
 
 from falcon_mcp.common.utils import generate_md_table
@@ -327,4 +327,285 @@ property_name:[operator]'value'
 • Find suspicious applications: is_suspicious:true
 • Find browser extensions: software_type:'browser_extension'
 • Find applications used by a specific user: last_used_user_name:'Administrator'
+"""
+
+# List of tuples containing filter options for unmanaged assets
+SEARCH_UNMANAGED_ASSETS_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Operators",
+        "Description"
+    ),
+    (
+        "platform_name",
+        "String",
+        "Yes",
+        """
+        Operating system platform of the unmanaged asset.
+
+        Ex: platform_name:'Windows'
+        Ex: platform_name:'Linux'
+        Ex: platform_name:'Mac'
+        Ex: platform_name:['Windows','Linux']
+        """
+    ),
+    (
+        "os_version",
+        "String",
+        "Yes",
+        """
+        Operating system version of the unmanaged asset.
+
+        Ex: os_version:'Windows 10'
+        Ex: os_version:'Ubuntu 20.04'
+        Ex: os_version:'macOS 12.3'
+        Ex: os_version:*'Windows*'
+        """
+    ),
+    (
+        "hostname",
+        "String",
+        "Yes",
+        """
+        Hostname of the unmanaged asset.
+
+        Ex: hostname:'PC-001'
+        Ex: hostname:*'PC-*'
+        Ex: hostname:['PC-001','PC-002']
+        """
+    ),
+    (
+        "country",
+        "String",
+        "Yes",
+        """
+        Country where the unmanaged asset is located.
+
+        Ex: country:'United States of America'
+        Ex: country:'Germany'
+        Ex: country:['United States of America','Canada']
+        """
+    ),
+    (
+        "city",
+        "String",
+        "Yes",
+        """
+        City where the unmanaged asset is located.
+
+        Ex: city:'New York'
+        Ex: city:'London'
+        Ex: city:['New York','Los Angeles']
+        """
+    ),
+    (
+        "product_type_desc",
+        "String",
+        "Yes",
+        """
+        Product type description of the unmanaged asset.
+
+        Ex: product_type_desc:'Workstation'
+        Ex: product_type_desc:'Server'
+        Ex: product_type_desc:'Domain Controller'
+        Ex: product_type_desc:['Workstation','Server']
+        """
+    ),
+    (
+        "external_ip",
+        "String",
+        "Yes",
+        """
+        External IP address of the unmanaged asset.
+
+        Ex: external_ip:'192.0.2.1'
+        Ex: external_ip:'192.0.2.0/24'
+        Ex: external_ip:['192.0.2.1','203.0.113.1']
+        """
+    ),
+    (
+        "local_ip_addresses",
+        "String",
+        "Yes",
+        """
+        Local IP addresses of the unmanaged asset.
+
+        Ex: local_ip_addresses:'10.0.1.100'
+        Ex: local_ip_addresses:'192.168.1.0/24'
+        Ex: local_ip_addresses:['10.0.1.100','192.168.1.50']
+        """
+    ),
+    (
+        "mac_addresses",
+        "String",
+        "Yes",
+        """
+        MAC addresses of the unmanaged asset.
+
+        Ex: mac_addresses:'AA-BB-CC-DD-EE-FF'
+        Ex: mac_addresses:*'AA-BB-CC*'
+        Ex: mac_addresses:['AA-BB-CC-DD-EE-FF','11-22-33-44-55-66']
+        """
+    ),
+    (
+        "first_seen_timestamp",
+        "Timestamp",
+        "Yes",
+        """
+        Date and time when the unmanaged asset was first discovered.
+
+        Ex: first_seen_timestamp:'2024-01-01T00:00:00Z'
+        Ex: first_seen_timestamp:>'2024-01-01T00:00:00Z'
+        Ex: first_seen_timestamp:>'now-7d'
+        """
+    ),
+    (
+        "last_seen_timestamp",
+        "Timestamp",
+        "Yes",
+        """
+        Date and time when the unmanaged asset was last seen.
+
+        Ex: last_seen_timestamp:'2024-06-15T12:00:00Z'
+        Ex: last_seen_timestamp:>'now-24h'
+        Ex: last_seen_timestamp:<'now-30d'
+        """
+    ),
+    (
+        "kernel_version",
+        "String",
+        "Yes",
+        """
+        Kernel version of the unmanaged asset.
+        Linux and Mac: The major version, minor version, and patch version.
+        Windows: The build number.
+
+        Ex: kernel_version:'5.4.0'
+        Ex: kernel_version:'19041'
+        Ex: kernel_version:*'5.4*'
+        """
+    ),
+    (
+        "system_manufacturer",
+        "String",
+        "Yes",
+        """
+        System manufacturer of the unmanaged asset.
+
+        Ex: system_manufacturer:'Dell Inc.'
+        Ex: system_manufacturer:'VMware, Inc.'
+        Ex: system_manufacturer:*'Dell*'
+        """
+    ),
+    (
+        "system_product_name",
+        "String",
+        "Yes",
+        """
+        System product name of the unmanaged asset.
+
+        Ex: system_product_name:'OptiPlex 7090'
+        Ex: system_product_name:'VMware Virtual Platform'
+        Ex: system_product_name:*'OptiPlex*'
+        """
+    ),
+    (
+        "criticality",
+        "String",
+        "Yes",
+        """
+        Criticality level assigned to the unmanaged asset.
+
+        Ex: criticality:'Critical'
+        Ex: criticality:'High'
+        Ex: criticality:'Medium'
+        Ex: criticality:'Low'
+        Ex: criticality:'Unassigned'
+        """
+    ),
+    (
+        "internet_exposure",
+        "String",
+        "Yes",
+        """
+        Whether the unmanaged asset is exposed to the internet.
+
+        Ex: internet_exposure:'Yes'
+        Ex: internet_exposure:'No'
+        Ex: internet_exposure:'Pending'
+        Ex: internet_exposure:['Yes','Pending']
+        """
+    ),
+    (
+        "discovering_by",
+        "String",
+        "Yes",
+        """
+        Method by which the unmanaged asset was discovered.
+
+        Ex: discovering_by:'Passive'
+        Ex: discovering_by:'Active'
+        Ex: discovering_by:['Passive','Active']
+        """
+    ),
+]
+
+SEARCH_UNMANAGED_ASSETS_FQL_DOCUMENTATION = """Falcon Query Language (FQL) - Search Unmanaged Assets Guide
+
+=== BASIC SYNTAX ===
+property_name:[operator]'value'
+
+=== AVAILABLE OPERATORS ===
+• No operator = equals (default)
+• ! = not equal to
+• > = greater than
+• >= = greater than or equal
+• < = less than
+• <= = less than or equal
+• ~ = text match (ignores case, spaces, punctuation)
+• !~ = does not text match
+
+=== DATA TYPES & SYNTAX ===
+• Strings: 'value' or ['exact_value'] for exact match
+• Dates: 'YYYY-MM-DDTHH:MM:SSZ' (UTC format)
+• Booleans: true or false (no quotes)
+• Numbers: 123 (no quotes)
+
+=== COMBINING CONDITIONS ===
+• + = AND condition
+• , = OR condition
+• ( ) = Group expressions
+
+=== AUTOMATIC FILTERING ===
+This tool automatically filters for unmanaged assets only by adding entity_type:'unmanaged' to all queries.
+You do not need to (and cannot) specify entity_type in your filter - it is always set to 'unmanaged'.
+
+=== falcon_search_unmanaged_assets FQL filter options ===
+
+""" + generate_md_table(SEARCH_UNMANAGED_ASSETS_FQL_FILTERS) + """
+
+=== IMPORTANT NOTES ===
+• entity_type:'unmanaged' is automatically applied - do not include in your filter
+• Use single quotes around string values: 'value'
+• Use square brackets for exact matches and multiple values: ['value1','value2']
+• Date format must be UTC: 'YYYY-MM-DDTHH:MM:SSZ'
+• Boolean values: true or false (no quotes)
+• Some fields require specific capitalization (check individual field descriptions)
+
+=== COMMON FILTER EXAMPLES ===
+• Find Windows unmanaged assets: platform_name:'Windows'
+• Find recently discovered assets: first_seen_timestamp:>'now-7d'
+• Find assets by hostname pattern: hostname:*'PC-*'
+• Find critical unmanaged assets: criticality:'Critical'
+• Find servers: product_type_desc:'Server'
+• Find internet-exposed assets: internet_exposure:'Yes'
+• Find assets in specific network: external_ip:'192.168.1.0/24'
+• Find assets by manufacturer: system_manufacturer:*'Dell*'
+• Find recently seen assets: last_seen_timestamp:>'now-24h'
+
+=== COMPLEX QUERY EXAMPLES ===
+• Windows workstations seen recently: platform_name:'Windows'+product_type_desc:'Workstation'+last_seen_timestamp:>'now-7d'
+• Critical servers with internet exposure: criticality:'Critical'+product_type_desc:'Server'+internet_exposure:'Yes'
+• Dell systems discovered this month: system_manufacturer:*'Dell*'+first_seen_timestamp:>'now-30d'
 """

--- a/tests/e2e/modules/test_discover.py
+++ b/tests/e2e/modules/test_discover.py
@@ -148,7 +148,10 @@ class TestDiscoverModuleE2E(BaseE2ETest):
                 {
                     "operation": "combined_hosts",
                     "validator": lambda kwargs: "entity_type:'unmanaged'"
-                    in kwargs.get("parameters", {}).get("filter", ""),
+                    in kwargs.get("parameters", {}).get("filter", "")
+                    and (
+                        "platform_name:'Windows'" in kwargs.get("parameters", {}).get("filter", "")
+                    ),
                     "response": {
                         "status_code": 200,
                         "body": {
@@ -240,7 +243,8 @@ class TestDiscoverModuleE2E(BaseE2ETest):
 
         def assertions(tools, result):
             tool_names_called = [tool["input"]["tool_name"] for tool in tools]
-            # Agent may or may not consult the FQL guide - both approaches are valid
+            # Agent must consult the FQL guide to learn proper platform filtering syntax
+            self.assertIn("falcon_search_unmanaged_assets_fql_guide", tool_names_called)
             self.assertIn("falcon_search_unmanaged_assets", tool_names_called)
 
             used_tool = tools[len(tools) - 1]
@@ -296,7 +300,8 @@ class TestDiscoverModuleE2E(BaseE2ETest):
                 {
                     "operation": "combined_hosts",
                     "validator": lambda kwargs: "entity_type:'unmanaged'"
-                    in kwargs.get("parameters", {}).get("filter", ""),
+                    in kwargs.get("parameters", {}).get("filter", "")
+                    and ("confidence:" in kwargs.get("parameters", {}).get("filter", "")),
                     "response": {
                         "status_code": 200,
                         "body": {

--- a/tests/e2e/modules/test_discover.py
+++ b/tests/e2e/modules/test_discover.py
@@ -23,7 +23,8 @@ class TestDiscoverModuleE2E(BaseE2ETest):
             fixtures = [
                 {
                     "operation": "combined_applications",
-                    "validator": lambda kwargs: "category:'Web Browsers'" in kwargs.get("parameters", {}).get("filter", ""),
+                    "validator": lambda kwargs: "category:'Web Browsers'"
+                    in kwargs.get("parameters", {}).get("filter", ""),
                     "response": {
                         "status_code": 200,
                         "body": {
@@ -41,19 +42,19 @@ class TestDiscoverModuleE2E(BaseE2ETest):
                                     "groups": [
                                         "group1",
                                         "group2",
-                                        "group3"
+                                        "group3",
                                     ],
                                     "category": "Web Browsers",
                                     "architectures": [
-                                        "x64"
+                                        "x64",
                                     ],
                                     "first_seen_timestamp": "2025-02-15T10:30:00Z",
                                     "last_updated_timestamp": "2025-03-01T14:45:22Z",
                                     "is_suspicious": False,
                                     "is_normalized": True,
                                     "host": {
-                                        "id": "abc123_xyz789"
-                                    }
+                                        "id": "abc123_xyz789",
+                                    },
                                 },
                                 {
                                     "id": "def456_123456789abcdef123456789abcdef123456789abcdef123456789abcdef",
@@ -67,28 +68,28 @@ class TestDiscoverModuleE2E(BaseE2ETest):
                                     "versioning_scheme": "semver",
                                     "groups": [
                                         "group4",
-                                        "group5"
+                                        "group5",
                                     ],
                                     "category": "Web Browsers",
                                     "architectures": [
-                                        "x64"
+                                        "x64",
                                     ],
                                     "first_seen_timestamp": "2025-01-10T08:15:30Z",
                                     "last_updated_timestamp": "2025-02-20T11:22:45Z",
                                     "is_suspicious": False,
                                     "is_normalized": True,
                                     "host": {
-                                        "id": "def456_abc123"
-                                    }
-                                }
+                                        "id": "def456_abc123",
+                                    },
+                                },
                             ]
                         },
                     },
                 }
             ]
 
-            self._mock_api_instance.command.side_effect = (
-                self._create_mock_api_side_effect(fixtures)
+            self._mock_api_instance.command.side_effect = self._create_mock_api_side_effect(
+                fixtures
             )
 
             prompt = "Search for all applications categorized as Web Browsers in our environment and show me their details"
@@ -98,11 +99,9 @@ class TestDiscoverModuleE2E(BaseE2ETest):
             tool_names_called = [tool["input"]["tool_name"] for tool in tools]
             self.assertIn("falcon_search_applications_fql_guide", tool_names_called)
             self.assertIn("falcon_search_applications", tool_names_called)
-        
+
             used_tool = tools[len(tools) - 1]
-            self.assertEqual(
-                used_tool["input"]["tool_name"], "falcon_search_applications"
-            )
+            self.assertEqual(used_tool["input"]["tool_name"], "falcon_search_applications")
 
             # Check for name filtering
             tool_input_str = json.dumps(used_tool["input"]["tool_input"]).lower()
@@ -139,8 +138,262 @@ class TestDiscoverModuleE2E(BaseE2ETest):
             self.assertIn("119.0.6045.199", result)
             self.assertIn("Web Browsers", result)
 
+        self.run_test_with_retries("test_search_applications_by_category", test_logic, assertions)
+
+    def test_search_unmanaged_assets_by_platform(self):
+        """Verify the agent can search for unmanaged assets by platform."""
+
+        async def test_logic():
+            fixtures = [
+                {
+                    "operation": "combined_hosts",
+                    "validator": lambda kwargs: "entity_type:'unmanaged'"
+                    in kwargs.get("parameters", {}).get("filter", ""),
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "resources": [
+                                {
+                                    "id": "abc123def456789_1234567890abcdef1234567890abcdef1234567890abcdef",
+                                    "cid": "abc123def456789",
+                                    "entity_type": "unmanaged",
+                                    "first_seen_timestamp": "2025-05-16T04:00:00Z",
+                                    "last_seen_timestamp": "2025-08-12T23:00:00Z",
+                                    "system_manufacturer": "VMware, Inc.",
+                                    "hostname": "PC-FINANCE-W11",
+                                    "local_ips_count": 1,
+                                    "network_interfaces": [
+                                        {
+                                            "local_ip": "192.168.1.100",
+                                            "mac_address": "AA-BB-CC-DD-EE-01",
+                                            "network_prefix": "192.168",
+                                        }
+                                    ],
+                                    "os_security": {},
+                                    "current_local_ip": "192.168.1.100",
+                                    "data_providers": ["Falcon passive discovery"],
+                                    "data_providers_count": 1,
+                                    "first_discoverer_aid": "abc123456789def0123456789abcdef01",
+                                    "last_discoverer_aid": "abc123456789def0123456789abcdef01",
+                                    "discoverer_count": 1,
+                                    "discoverer_aids": ["abc123456789def0123456789abcdef01"],
+                                    "discoverer_tags": [
+                                        "FalconGroupingTags/Finance",
+                                        "FalconGroupingTags/Workstation",
+                                        "FalconGroupingTags/Windows11",
+                                    ],
+                                    "discoverer_platform_names": ["Windows"],
+                                    "discoverer_product_type_descs": ["Workstation"],
+                                    "discoverer_hostnames": ["WIN-MGMT-001"],
+                                    "last_discoverer_hostname": "WIN-MGMT-001",
+                                    "confidence": 75,
+                                    "active_discovery": {},
+                                },
+                                {
+                                    "id": "abc123def456789_fedcba0987654321fedcba0987654321fedcba0987654321",
+                                    "cid": "abc123def456789",
+                                    "entity_type": "unmanaged",
+                                    "first_seen_timestamp": "2025-07-16T10:00:00Z",
+                                    "last_seen_timestamp": "2025-08-12T23:00:00Z",
+                                    "system_manufacturer": "Dell Inc.",
+                                    "hostname": "SERVER-HR-002",
+                                    "local_ips_count": 1,
+                                    "network_interfaces": [
+                                        {
+                                            "local_ip": "192.168.2.50",
+                                            "mac_address": "AA-BB-CC-DD-EE-02",
+                                            "network_prefix": "192.168",
+                                        }
+                                    ],
+                                    "os_security": {},
+                                    "current_local_ip": "192.168.2.50",
+                                    "data_providers": ["Falcon passive discovery"],
+                                    "data_providers_count": 1,
+                                    "first_discoverer_aid": "def456789abc012def456789abc012de",
+                                    "last_discoverer_aid": "def456789abc012def456789abc012de",
+                                    "discoverer_count": 1,
+                                    "discoverer_aids": ["def456789abc012def456789abc012de"],
+                                    "discoverer_tags": [
+                                        "FalconGroupingTags/HR",
+                                        "FalconGroupingTags/Server",
+                                        "FalconGroupingTags/WindowsServer2019",
+                                    ],
+                                    "discoverer_platform_names": ["Windows"],
+                                    "discoverer_product_type_descs": ["Server"],
+                                    "discoverer_hostnames": ["WIN-DC-001"],
+                                    "last_discoverer_hostname": "WIN-DC-001",
+                                    "confidence": 85,
+                                    "active_discovery": {},
+                                },
+                            ]
+                        },
+                    },
+                }
+            ]
+
+            self._mock_api_instance.command.side_effect = self._create_mock_api_side_effect(
+                fixtures
+            )
+
+            prompt = "Search for all unmanaged Windows assets in our environment and show me their details"
+            return await self._run_agent_stream(prompt)
+
+        def assertions(tools, result):
+            tool_names_called = [tool["input"]["tool_name"] for tool in tools]
+            # Agent may or may not consult the FQL guide - both approaches are valid
+            self.assertIn("falcon_search_unmanaged_assets", tool_names_called)
+
+            used_tool = tools[len(tools) - 1]
+            self.assertEqual(used_tool["input"]["tool_name"], "falcon_search_unmanaged_assets")
+
+            # Note: Agent may interpret platform filtering differently
+            # The key behavior is that it successfully finds and returns unmanaged assets
+
+            # Verify both unmanaged assets are in the output
+            self.assertIn("PC-FINANCE-W11", used_tool["output"])
+            self.assertIn("SERVER-HR-002", used_tool["output"])
+            self.assertIn("VMware, Inc.", used_tool["output"])
+            self.assertIn("Dell Inc.", used_tool["output"])
+            self.assertIn("unmanaged", used_tool["output"])
+
+            # Verify API call was made correctly
+            self.assertGreaterEqual(
+                self._mock_api_instance.command.call_count, 1, "Expected 1 API call"
+            )
+
+            # Check API call (combined_hosts)
+            api_call_params = self._mock_api_instance.command.call_args_list[0][1].get(
+                "parameters", {}
+            )
+            filter_str = api_call_params.get("filter", "").lower()
+
+            # Verify entity_type:'unmanaged' is automatically added
+            self.assertTrue(
+                "entity_type:'unmanaged'" in filter_str,
+                f"Expected entity_type:'unmanaged' in API call filter: {filter_str}",
+            )
+
+            # Note: Platform filtering may vary based on agent interpretation
+            # The core requirement is that entity_type:'unmanaged' is enforced
+
+            # Verify result contains expected information
+            self.assertIn("PC-FINANCE-W11", result)
+            self.assertIn("SERVER-HR-002", result)
+            self.assertIn("Windows", result)
+            self.assertIn("unmanaged", result)
+            self.assertIn("Workstation", result)
+            self.assertIn("Server", result)
+
         self.run_test_with_retries(
-            "test_search_applications_by_category", test_logic, assertions
+            "test_search_unmanaged_assets_by_platform", test_logic, assertions
+        )
+
+    def test_search_unmanaged_assets_by_confidence(self):
+        """Verify the agent can search for unmanaged assets by confidence level."""
+
+        async def test_logic():
+            fixtures = [
+                {
+                    "operation": "combined_hosts",
+                    "validator": lambda kwargs: "entity_type:'unmanaged'"
+                    in kwargs.get("parameters", {}).get("filter", ""),
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "resources": [
+                                {
+                                    "id": "def789ghi012345_abcdef123456789abcdef123456789abcdef123456789abcdef",
+                                    "cid": "def789ghi012345",
+                                    "entity_type": "unmanaged",
+                                    "first_seen_timestamp": "2025-07-17T08:00:00Z",
+                                    "last_seen_timestamp": "2025-08-12T23:00:00Z",
+                                    "system_manufacturer": "VMware, Inc.",
+                                    "hostname": "PROD-DB-LINUX",
+                                    "local_ips_count": 1,
+                                    "network_interfaces": [
+                                        {
+                                            "local_ip": "10.0.1.200",
+                                            "mac_address": "AA-BB-CC-DD-EE-03",
+                                            "network_prefix": "10.0",
+                                        }
+                                    ],
+                                    "os_security": {},
+                                    "current_local_ip": "10.0.1.200",
+                                    "data_providers": ["Falcon passive discovery"],
+                                    "data_providers_count": 1,
+                                    "first_discoverer_aid": "123456789def012345678901234567ab",
+                                    "last_discoverer_aid": "123456789def012345678901234567ab",
+                                    "discoverer_count": 1,
+                                    "discoverer_aids": ["123456789def012345678901234567ab"],
+                                    "discoverer_tags": [
+                                        "FalconGroupingTags/Production",
+                                        "FalconGroupingTags/Database",
+                                        "FalconGroupingTags/Linux",
+                                        "FalconGroupingTags/Critical-Infrastructure",
+                                    ],
+                                    "discoverer_platform_names": ["Linux"],
+                                    "discoverer_product_type_descs": ["Server"],
+                                    "discoverer_hostnames": ["LNX-MGMT-001"],
+                                    "last_discoverer_hostname": "LNX-MGMT-001",
+                                    "confidence": 95,
+                                    "active_discovery": {},
+                                }
+                            ]
+                        },
+                    },
+                }
+            ]
+
+            self._mock_api_instance.command.side_effect = self._create_mock_api_side_effect(
+                fixtures
+            )
+
+            prompt = "Find all unmanaged assets with high confidence levels (above 80) that are likely real systems"
+            return await self._run_agent_stream(prompt)
+
+        def assertions(tools, result):
+            tool_names_called = [tool["input"]["tool_name"] for tool in tools]
+            self.assertIn("falcon_search_unmanaged_assets", tool_names_called)
+
+            used_tool = tools[len(tools) - 1]
+            self.assertEqual(used_tool["input"]["tool_name"], "falcon_search_unmanaged_assets")
+
+            # Note: Agent may interpret confidence filtering differently
+            # The key behavior is that it successfully finds and returns unmanaged assets
+
+            # Verify high confidence asset is in the output
+            self.assertIn("PROD-DB-LINUX", used_tool["output"])
+            self.assertIn("95", used_tool["output"])
+            self.assertIn("unmanaged", used_tool["output"])
+
+            # Verify API call was made correctly
+            self.assertGreaterEqual(
+                self._mock_api_instance.command.call_count, 1, "Expected 1 API call"
+            )
+
+            # Check API call (combined_hosts)
+            api_call_params = self._mock_api_instance.command.call_args_list[0][1].get(
+                "parameters", {}
+            )
+            filter_str = api_call_params.get("filter", "").lower()
+
+            # Verify entity_type:'unmanaged' is automatically added
+            self.assertTrue(
+                "entity_type:'unmanaged'" in filter_str,
+                f"Expected entity_type:'unmanaged' in API call filter: {filter_str}",
+            )
+
+            # Note: Confidence filtering may vary based on agent interpretation
+            # The core requirement is that entity_type:'unmanaged' is enforced
+
+            # Verify result contains expected information
+            self.assertIn("PROD-DB-LINUX", result)
+            self.assertIn("95", result)
+            self.assertIn("unmanaged", result)
+            self.assertIn("Linux", result)
+
+        self.run_test_with_retries(
+            "test_search_unmanaged_assets_by_confidence", test_logic, assertions
         )
 
 

--- a/tests/modules/test_discover.py
+++ b/tests/modules/test_discover.py
@@ -23,17 +23,21 @@ class TestDiscoverModule(unittest.TestCase):
     def test_register_tools(self):
         """Test that tools are registered correctly."""
         self.module.register_tools(self.server)
-        self.server.add_tool.assert_called_once()
-        self.assertEqual(len(self.module.tools), 1)
+        self.assertEqual(self.server.add_tool.call_count, 2)
+        self.assertEqual(len(self.module.tools), 2)
         self.assertEqual(self.module.tools[0], "falcon_search_applications")
+        self.assertEqual(self.module.tools[1], "falcon_search_unmanaged_assets")
 
     def test_register_resources(self):
         """Test that resources are registered correctly."""
         self.module.register_resources(self.server)
-        self.server.add_resource.assert_called_once()
-        self.assertEqual(len(self.module.resources), 1)
+        self.assertEqual(self.server.add_resource.call_count, 2)
+        self.assertEqual(len(self.module.resources), 2)
         self.assertEqual(
             str(self.module.resources[0]), "falcon://discover/applications/fql-guide"
+        )
+        self.assertEqual(
+            str(self.module.resources[1]), "falcon://discover/hosts/fql-guide"
         )
 
     @patch("falcon_mcp.modules.discover.prepare_api_parameters")
@@ -116,6 +120,108 @@ class TestDiscoverModule(unittest.TestCase):
             },
         )
         self.assertEqual(result, [{"id": "app1", "name": "Chrome"}])
+
+    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
+    @patch("falcon_mcp.modules.discover.handle_api_response")
+    def test_search_unmanaged_assets(self, mock_handle_response, mock_prepare_params):
+        """Test search_unmanaged_assets method."""
+        # Setup mocks
+        mock_prepare_params.return_value = {"filter": "entity_type:'unmanaged'+platform_name:'Windows'"}
+        mock_response = MagicMock()
+        self.client.command.return_value = mock_response
+        mock_handle_response.return_value = [{"device_id": "host1", "hostname": "PC-001"}]
+
+        # Call the method
+        result = self.module.search_unmanaged_assets(filter="platform_name:'Windows'")
+
+        # Assertions
+        # Don't check the exact arguments, just verify it was called once
+        self.assertEqual(mock_prepare_params.call_count, 1)
+        self.client.command.assert_called_once_with(
+            "combined_hosts", parameters={"filter": "entity_type:'unmanaged'+platform_name:'Windows'"}
+        )
+        mock_handle_response.assert_called_once_with(
+            mock_response,
+            operation="combined_hosts",
+            error_message="Failed to search unmanaged assets",
+            default_result=[],
+        )
+        self.assertEqual(result, [{"device_id": "host1", "hostname": "PC-001"}])
+
+    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
+    @patch("falcon_mcp.modules.discover.handle_api_response")
+    def test_search_unmanaged_assets_without_filter(self, mock_handle_response, mock_prepare_params):
+        """Test search_unmanaged_assets method without user filter."""
+        # Setup mocks
+        mock_prepare_params.return_value = {"filter": "entity_type:'unmanaged'"}
+        mock_response = MagicMock()
+        self.client.command.return_value = mock_response
+        mock_handle_response.return_value = [{"device_id": "host1", "hostname": "PC-001"}]
+
+        # Call the method with no filter
+        result = self.module.search_unmanaged_assets()
+
+        # Assertions
+        # Don't check the exact arguments, just verify it was called once
+        self.assertEqual(mock_prepare_params.call_count, 1)
+        self.client.command.assert_called_once_with(
+            "combined_hosts", parameters={"filter": "entity_type:'unmanaged'"}
+        )
+        self.assertEqual(result, [{"device_id": "host1", "hostname": "PC-001"}])
+
+    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
+    @patch("falcon_mcp.modules.discover.handle_api_response")
+    def test_search_unmanaged_assets_with_error(self, mock_handle_response, mock_prepare_params):
+        """Test search_unmanaged_assets method when an error occurs."""
+        # Setup mocks
+        mock_prepare_params.return_value = {"filter": "entity_type:'unmanaged'+platform_name:'Windows'"}
+        mock_response = MagicMock()
+        self.client.command.return_value = mock_response
+        error_response = {"error": "API Error", "message": "Something went wrong"}
+        mock_handle_response.return_value = error_response
+
+        # Call the method
+        result = self.module.search_unmanaged_assets(filter="platform_name:'Windows'")
+
+        # Assertions
+        self.assertEqual(result, [error_response])
+
+    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
+    @patch("falcon_mcp.modules.discover.handle_api_response")
+    def test_search_unmanaged_assets_with_all_params(self, mock_handle_response, mock_prepare_params):
+        """Test search_unmanaged_assets method with all parameters."""
+        # Setup mocks
+        mock_prepare_params.return_value = {
+            "filter": "entity_type:'unmanaged'+criticality:'Critical'",
+            "limit": 50,
+            "offset": 10,
+            "sort": "hostname.asc",
+        }
+        mock_response = MagicMock()
+        self.client.command.return_value = mock_response
+        mock_handle_response.return_value = [{"device_id": "host1", "hostname": "PC-001"}]
+
+        # Call the method
+        result = self.module.search_unmanaged_assets(
+            filter="criticality:'Critical'",
+            limit=50,
+            offset=10,
+            sort="hostname.asc",
+        )
+
+        # Assertions
+        # Don't check the exact arguments, just verify it was called once
+        self.assertEqual(mock_prepare_params.call_count, 1)
+        self.client.command.assert_called_once_with(
+            "combined_hosts",
+            parameters={
+                "filter": "entity_type:'unmanaged'+criticality:'Critical'",
+                "limit": 50,
+                "offset": 10,
+                "sort": "hostname.asc",
+            },
+        )
+        self.assertEqual(result, [{"device_id": "host1", "hostname": "PC-001"}])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a new tool for finding unmanaged assets (systems without the Falcon sensor installed) that have been discovered by managed systems. The tool automatically filters for unmanaged assets only while allowing additional filtering for things like platform, confidence level, and timestamps.

What's included:
- New `falcon_search_unmanaged_assets` tool in the Discover module
- Complete FQL resource documentation with 18+ filterable fields and examples
- Additional unit and end-to-end tests
- Automatic enforcement of `entity_type:'unmanaged'` filtering
- Support for advanced filtering like confidence levels, platform types, and discovery timestamps