### PR TITLE
Add GitHub issue templates for improved issue management 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,5 +1,6 @@
 name: 🐛 Bug Report
 description: Report a bug or unexpected behavior in falcon-mcp
+title: "[Bug]: "
 labels: ["bug", "triage"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: 🔒 Security Vulnerability
-    url: https://github.com/CrowdStrike/falcon-mcp/tree/main/docs/SECURITY.md
-    about: Report security vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,5 +1,6 @@
 name: 🚀 Feature Request
 description: Suggest a new feature for falcon-mcp
+title: "[Feature Request]: "
 labels: ["enhancement"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,5 +1,6 @@
 name: ❓ Question or Discussion
 description: Ask questions or start discussions about falcon-mcp
+title: "[Question]: "
 labels: ["question"]
 
 body:


### PR DESCRIPTION
closes #120 
Add three comprehensive issue templates:
- Bug report template with falcon-mcp specific fields
- Feature request template with module categorization
- Question/discussion template for support

Includes configuration to disable blank issues and provide
helpful contact links for security.

---
Example images:
<img width="1682" height="654" alt="CleanShot 2025-08-15 at 10 47 16@2x" src="https://github.com/user-attachments/assets/246e1a1e-b7d6-4413-8377-721b84dcfbf0" />
<img width="1626" height="1536" alt="CleanShot 2025-08-15 at 10 47 41@2x" src="https://github.com/user-attachments/assets/5b7c9f90-8fe7-4349-8d63-04ff846f7609" />
