### PR TITLE
Fix pip install command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build and publish to PyPI
         run: |
           pip install uv
-          uv pip install build twine
+          uv pip install --system build twine
           python -m build
           python -m twine upload dist/* --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}
         if: ${{ steps.release-please.outputs.release_created }}


### PR DESCRIPTION
Latest version of uv requires either a venv or to add --system to the `uv pip install` command. This commit adds the --system