### PR TITLE
Fix logging to use stderr instead of stdout for MCP compatibility

### DIFF
--- a/falcon_mcp/common/logging.py
+++ b/falcon_mcp/common/logging.py
@@ -25,7 +25,7 @@ def configure_logging(debug: bool = False, name: str = "falcon_mcp") -> logging.
     logging.basicConfig(
         level=log_level,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=[logging.StreamHandler(sys.stdout)],
+        handlers=[logging.StreamHandler(sys.stderr)],
     )
 
     # Set third-party loggers to a higher level to reduce noise


### PR DESCRIPTION
## Problem
The Falcon MCP server outputs log messages to stdout, which interferes with JSON-RPC protocol communication when using stdio transport. This causes MCP clients to fail with "connection closed: initialize response" errors due to malformed JSON parsing.

## Solution
Changed `logging.StreamHandler(sys.stdout)` to `logging.StreamHandler(sys.stderr)` in `falcon_mcp/common/logging.py`. This ensures:
- Log messages go to stderr (visible for debugging)
- JSON-RPC responses go to stdout (clean protocol communication)
- MCP clients can properly parse responses

## Testing
- Tested with Q CLI and confirmed successful initialization
- Verified log messages still visible via stderr
- Confirmed JSON-RPC responses are clean on stdout

This is a minimal, non-breaking change that maintains all existing functionality while fixing MCP compatibility.