### PR TITLE
chore(ci): harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -8,11 +8,15 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   docker-build-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: release
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   docker-build-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -27,7 +28,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@39eb6c9dde236bbc368681611e63120a6eb4afac
         with:
-          version: "latest"
+          version: "0.7.13"
           activate-environment: true
 
       - name: Install dependencies

--- a/.github/workflows/python-test-e2e.yml
+++ b/.github/workflows/python-test-e2e.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -24,6 +25,20 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Validate inputs
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const models = '${{ inputs.models }}';
+            console.log('Validating models input:', models);
+
+            if (!/^[a-zA-Z0-9,.\-_]+$/.test(models)) {
+              core.setFailed('Models input contains invalid characters. Only alphanumeric, hyphens, commas, periods, and underscores are allowed.');
+              return;
+            }
+            console.log('Input validation passed');
+
       - name: Set up Python 3.12
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -32,7 +47,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@39eb6c9dde236bbc368681611e63120a6eb4afac
         with:
-          version: "latest"
+          version: "0.7.13"
           activate-environment: true
 
       - name: Install dependencies

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
@@ -31,7 +32,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@39eb6c9dde236bbc368681611e63120a6eb4afac
         with:
-          version: "latest"
+          version: "0.7.13"
           activate-environment: true
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,17 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read  # Default to read-only at workflow level
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write       # Required for creating releases
+      pull-requests: write  # Required for release PRs
+      issues: write         # Required by release-please
+      id-token: write       # Required for OIDC PyPI publishing
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -38,10 +42,13 @@ jobs:
           python-version: '3.11'
         if: ${{ steps.release-please.outputs.release_created }}
 
-      - name: Build and publish to PyPI
+      - name: Build package
         run: |
-          pip install uv
-          uv pip install --system build twine
+          pip install uv==0.9.21
+          uv pip install --system build==1.3.0
           python -m build
-          python -m twine upload dist/* --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}
+        if: ${{ steps.release-please.outputs.release_created }}
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         if: ${{ steps.release-please.outputs.release_created }}


### PR DESCRIPTION
## Summary
- Add timeout-minutes to all workflow jobs
- Pin uv version instead of using latest
- Pin build dependencies in release workflow
- Add input validation for workflow_dispatch inputs
- Add environment protection for docker publishing