### PR TITLE
feat(modules/scheduled-reports): add scheduled reports and executions module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   - [Identity Protection Module](#identity-protection-module)
   - [Incidents Module](#incidents-module)
   - [Intel Module](#intel-module)
+  - [Scheduled Reports Module](#scheduled-reports-module)
   - [Sensor Usage Module](#sensor-usage-module)
   - [Serverless Module](#serverless-module)
   - [Spotlight Module](#spotlight-module)
@@ -87,6 +88,7 @@ The Falcon MCP Server supports different modules, each requiring specific API sc
 | **Identity Protection** | `Identity Protection Entities:read`<br>`Identity Protection Timeline:read`<br>`Identity Protection Detections:read`<br>`Identity Protection Assessment:read`<br>`Identity Protection GraphQL:write` | Comprehensive entity investigation and identity protection analysis |
 | **Incidents** | `Incidents:read` | Analyze security incidents and coordinated activities |
 | **Intel** | `Actors (Falcon Intelligence):read`<br>`Indicators (Falcon Intelligence):read`<br>`Reports (Falcon Intelligence):read` | Research threat actors, IOCs, and intelligence reports |
+| **Scheduled Reports** | `Scheduled Reports:read` | Get details about scheduled reports and searches, run reports on demand, and download report files |
 | **Sensor Usage** | `Sensor Usage:read` | Access and analyze sensor usage data |
 | **Serverless** | `Falcon Container Image:read` | Search for vulnerabilities in serverless functions across cloud service providers |
 | **Spotlight** | `Vulnerabilities:read` | Manage and analyze vulnerability data and security assessments |
@@ -240,6 +242,24 @@ Provides tools for accessing and analyzing CrowdStrike Falcon sensor usage data:
 - `falcon://sensor-usage/weekly/fql-guide`: Comprehensive FQL documentation and examples for sensor usage searches
 
 **Use Cases**: Sensor deployment monitoring, license utilization analysis, sensor health tracking
+
+### Scheduled Reports Module
+
+**API Scopes Required**: `Scheduled Reports:read`
+
+Provides tools for accessing and managing CrowdStrike Falcon scheduled reports and scheduled searches:
+
+- `falcon_search_scheduled_reports`: Search for scheduled reports and searches in your CrowdStrike environment
+- `falcon_launch_scheduled_report`: Launch a scheduled report on demand outside of its recurring schedule
+- `falcon_search_report_executions`: Search for report executions to track status and results
+- `falcon_download_report_execution`: Download generated report files
+
+**Resources**:
+
+- `falcon://scheduled-reports/search/fql-guide`: Comprehensive FQL documentation for searching scheduled report entities
+- `falcon://scheduled-reports/executions/search/fql-guide`: Comprehensive FQL documentation for searching report executions
+
+**Use Cases**: Automated report management, report execution monitoring, scheduled search analysis, report download automation
 
 ### Serverless Module
 

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -52,6 +52,14 @@ API_SCOPE_REQUIREMENTS = {
     "GetSensorUsageWeekly": ["Sensor Usage:read"],
     # Serverless operations
     "GetCombinedVulnerabilitiesSARIF": ["Falcon Container Image:read"],
+    # Scheduled Reports operations
+    "scheduled_reports_query": ["Scheduled Reports:read"],
+    "scheduled_reports_get": ["Scheduled Reports:read"],
+    "scheduled_reports_launch": ["Scheduled Reports:read"],
+    # Report Executions operations (same scope as Scheduled Reports)
+    "reports_executions_query": ["Scheduled Reports:read"],
+    "report_executions_get": ["Scheduled Reports:read"],
+    "report_executions_download_get": ["Scheduled Reports:read"],
     # Add more mappings as needed
 }
 

--- a/falcon_mcp/modules/scheduled_reports.py
+++ b/falcon_mcp/modules/scheduled_reports.py
@@ -1,0 +1,253 @@
+"""
+Scheduled Reports module for Falcon MCP Server
+
+This module provides tools for accessing and managing CrowdStrike Falcon
+scheduled reports and scheduled searches.
+"""
+
+from typing import Any, List
+
+from mcp.server import FastMCP
+from mcp.server.fastmcp.resources import TextResource
+from pydantic import AnyUrl, Field
+
+from falcon_mcp.modules.base import BaseModule
+from falcon_mcp.resources.scheduled_reports import (
+    SEARCH_REPORT_EXECUTIONS_FQL_DOCUMENTATION,
+    SEARCH_SCHEDULED_REPORTS_FQL_DOCUMENTATION,
+)
+
+
+class ScheduledReportsModule(BaseModule):
+    """Module for accessing and managing CrowdStrike Falcon scheduled reports and searches."""
+
+    def register_tools(self, server: FastMCP) -> None:
+        """Register tools with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        # Register entity tools
+        self._add_tool(
+            server=server,
+            method=self.search_scheduled_reports,
+            name="search_scheduled_reports",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.launch_scheduled_report,
+            name="launch_scheduled_report",
+        )
+
+        # Register execution tools
+        self._add_tool(
+            server=server,
+            method=self.search_report_executions,
+            name="search_report_executions",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.download_report_execution,
+            name="download_report_execution",
+        )
+
+    def register_resources(self, server: FastMCP) -> None:
+        """Register resources with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        search_scheduled_reports_fql_resource = TextResource(
+            uri=AnyUrl("falcon://scheduled-reports/search/fql-guide"),
+            name="falcon_search_scheduled_reports_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_scheduled_reports` tool.",
+            text=SEARCH_SCHEDULED_REPORTS_FQL_DOCUMENTATION,
+        )
+
+        search_report_executions_fql_resource = TextResource(
+            uri=AnyUrl("falcon://scheduled-reports/executions/search/fql-guide"),
+            name="falcon_search_report_executions_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_report_executions` tool.",
+            text=SEARCH_REPORT_EXECUTIONS_FQL_DOCUMENTATION,
+        )
+
+        self._add_resource(
+            server,
+            search_scheduled_reports_fql_resource,
+        )
+        self._add_resource(
+            server,
+            search_report_executions_fql_resource,
+        )
+
+    def search_scheduled_reports(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter to limit results. Use id:'<id>' to get specific reports. IMPORTANT: use the `falcon://scheduled-reports/search/fql-guide` resource when building this filter parameter.",
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            le=5000,
+            description="Maximum number of records to return. (Max: 5000)",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index of overall result set from which to return IDs.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Property to sort by. Ex: created_on.asc, last_updated_on.desc, next_execution_on.desc",
+        ),
+        q: str | None = Field(
+            default=None,
+            description="Free-text search for terms in id, name, description, type, status fields",
+        ),
+    ) -> List[dict[str, Any]]:
+        """Search for scheduled reports and searches in your CrowdStrike environment.
+
+        Returns full details for matching scheduled report/search entities. Use the filter
+        parameter to narrow results or retrieve specific entities by ID.
+
+        IMPORTANT: You must use the `falcon://scheduled-reports/search/fql-guide` resource
+        when you need to use the `filter` parameter.
+
+        Common use cases:
+        - Get specific report by ID: filter=id:'<report-id>'
+        - Get multiple reports by ID: filter=id:['id1','id2']
+        - Find active reports: filter=status:'ACTIVE'
+        - Find scheduled searches: filter=type:'event_search'
+        - Find by creator: filter=user_id:'user@email.com'
+
+        Examples:
+        - filter=status:'ACTIVE'+type:'event_search' - Active scheduled searches
+        - filter=created_on:>'2023-01-01' - Created after date
+        - filter=id:'45c59557ded4413cafb8ff81e7640456' - Specific report by ID
+        """
+        result = self._base_search_api_call(
+            operation="scheduled_reports_query",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+                "q": q,
+            },
+            error_message="Failed to search for scheduled reports",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def launch_scheduled_report(
+        self,
+        id: str = Field(description="Scheduled report/search entity ID to execute."),
+    ) -> List[dict[str, Any]]:
+        """Launch a scheduled report on demand.
+
+        Execute a scheduled report or search immediately, outside of its recurring schedule.
+        This creates a new execution instance that can be tracked and downloaded.
+
+        Returns the execution details including the execution ID which can be used with:
+        - falcon_search_report_executions to check status (filter=id:'<execution-id>')
+        - falcon_download_report_execution to download results when ready
+
+        Note: The report will run with the same parameters as defined in the entity configuration.
+        """
+        result = self._base_query_api_call(
+            operation="scheduled_reports_launch",
+            body_params={"id": id},
+            error_message="Failed to launch scheduled report",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def search_report_executions(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter to limit results. Use id:'<id>' to get specific executions. IMPORTANT: use the `falcon://scheduled-reports/executions/search/fql-guide` resource when building this filter parameter.",
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            le=5000,
+            description="Maximum number of records to return. (Max: 5000)",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index of overall result set from which to return IDs.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Property to sort by. Ex: created_on.asc, last_updated_on.desc",
+        ),
+    ) -> List[dict[str, Any]]:
+        """Search for scheduled report/search executions in your CrowdStrike environment.
+
+        Returns full details for matching executions. Use the filter parameter to narrow
+        results or retrieve specific executions by ID.
+
+        IMPORTANT: You must use the `falcon://scheduled-reports/executions/search/fql-guide`
+        resource when you need to use the `filter` parameter.
+
+        Common use cases:
+        - Get specific execution by ID: filter=id:'<execution-id>'
+        - Get all executions for a report: filter=scheduled_report_id:'<report-id>'
+        - Find completed executions: filter=status:'DONE'
+        - Find failed executions: filter=status:'FAILED'
+
+        Examples:
+        - filter=status:'DONE'+created_on:>'2023-01-01' - Successful runs after date
+        - filter=scheduled_report_id:'abc123' - All executions for report abc123
+        - filter=id:'f1984ff006a94980b352f18ee79aed77' - Specific execution by ID
+        """
+        result = self._base_search_api_call(
+            operation="reports_executions_query",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+            },
+            error_message="Failed to search for report executions",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def download_report_execution(
+        self,
+        id: str = Field(description="Report execution ID to download."),
+    ) -> str:
+        """Download generated report file.
+
+        Download the report file for a completed execution. Only works for executions
+        with status='DONE'. The report is returned as a decoded string.
+
+        Returns:
+            The report content as a decoded UTF-8 string.
+
+        Note: Check execution status first using falcon_search_report_executions with
+        filter=id:'<execution-id>' to ensure the execution is complete (status='DONE')
+        before attempting to download.
+        """
+        return self._base_get_api_call(
+            operation="report_executions_download_get",
+            api_params={"id": id},
+            error_message="Failed to download report execution",
+            decode_binary=True,
+        )

--- a/falcon_mcp/resources/scheduled_reports.py
+++ b/falcon_mcp/resources/scheduled_reports.py
@@ -1,0 +1,478 @@
+"""
+Contains Scheduled Reports resources.
+"""
+
+from falcon_mcp.common.utils import generate_md_table
+
+# Scheduled report/search entity FQL filters
+SEARCH_SCHEDULED_REPORTS_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Operators",
+        "Description"
+    ),
+    (
+        "id",
+        "String",
+        "Yes",
+        """
+        The unique ID of a scheduled report/search entity. Use this to retrieve
+        specific entities by ID. Supports multiple values.
+
+        Ex: id:'45c59557ded4413cafb8ff81e7640456'
+        Ex: id:['id1','id2']
+        """
+    ),
+    (
+        "created_on",
+        "Timestamp",
+        "Yes",
+        """
+        The date and time a scheduled report/search entity was created.
+
+        Ex: created_on:'2021-10-12'
+        Ex: created_on:<'2021-10-12'
+        Ex: created_on:>'2021-10-12T03:00'
+        """
+    ),
+    (
+        "description",
+        "String",
+        "Yes",
+        """
+        A single term found in a scheduled report/search entity description.
+        The value must be entered in all lowercase letters. Supports multiple values and negation.
+
+        Ex: description:'process'
+        Ex: description:!'process'
+        Ex: description:['process','data']
+        """
+    ),
+    (
+        "expiration_on",
+        "Timestamp",
+        "Yes",
+        """
+        The date and time that a STOPPED scheduled report/search entity will be deleted.
+        Set at 30 days after the report is stopped.
+
+        Ex: expiration_on:'2021-12-15'
+        Ex: expiration_on:>'2021-11-15T18'
+        Ex: expiration_on:<'2021-12-03T03:30'
+        """
+    ),
+    (
+        "last_execution.last_updated_on",
+        "Timestamp",
+        "Yes",
+        """
+        The date and time of the last scheduled or manual execution.
+
+        Ex: last_execution.last_updated_on:'2021-09-22'
+        Ex: last_execution.last_updated_on:>'2021-09-22T11:30'
+        """
+    ),
+    (
+        "last_execution.status",
+        "String",
+        "Yes",
+        """
+        The status of the last execution. Supports multiple values and negation.
+        Values must be in all capital letters.
+
+        Values: PENDING, PROCESSING, DONE, FAILED, FAILED_NOTIFICATION, NO_DATA
+
+        Ex: last_execution.status:'FAILED'
+        Ex: last_execution.status:['PENDING','DONE']
+        Ex: last_execution.status:!'PENDING'
+        """
+    ),
+    (
+        "last_updated_on",
+        "Timestamp",
+        "Yes",
+        """
+        The date and time of the last update made to a scheduled report/search entity.
+
+        Ex: last_updated_on:'2021-10-12'
+        Ex: last_updated_on:>'2021-10-12'
+        Ex: last_updated_on:<'2021-10-12T03:00'
+        """
+    ),
+    (
+        "name",
+        "String",
+        "Yes",
+        """
+        Filters on exact matches to the full scheduled report/search entity name.
+        Case-sensitive. Supports multiple values and negation.
+
+        Ex: name:'My Test Report'
+        Ex: name:['My Test scheduled Report','My test scheduled search']
+        Ex: name:!'My Test scheduled Report'
+        """
+    ),
+    (
+        "next_execution_on",
+        "Timestamp",
+        "Yes",
+        """
+        The date and time of the next scheduled execution.
+
+        Ex: next_execution_on:<'2021-11-01'
+        """
+    ),
+    (
+        "shared_with",
+        "String",
+        "Yes",
+        """
+        The unique ID of a user who the scheduled report has been shared with.
+        (Scheduled searches cannot be shared.) Supports multiple values and negation.
+
+        Ex: shared_with:'26eab16d-0b73-452d-b807-afc58f097aad'
+        Ex: shared_with:!'26eab16d-0b73-452d-b807-afc58f097aad'
+        """
+    ),
+    (
+        "start_on",
+        "Timestamp",
+        "Yes",
+        """
+        The date and time to begin generating executions. Set to the Start date
+        defined in the entity configuration.
+
+        Ex: start_on:<'2021-10-01'
+        """
+    ),
+    (
+        "status",
+        "String",
+        "Yes",
+        """
+        The current status of a scheduled report/search entity.
+        Supports multiple values and negation. Values must be in all capital letters.
+
+        Values: ACTIVE, PENDING, STOPPED, UPDATING
+
+        Ex: status:'PENDING'
+        Ex: status:!'ACTIVE'
+        Ex: status:['STOPPED','UPDATING']
+        Ex: status:!['STOPPED','UPDATING']
+        """
+    ),
+    (
+        "stop_on",
+        "Timestamp",
+        "Yes",
+        """
+        The date and time to stop generating executions. Set to the End date
+        defined in the entity configuration.
+
+        Ex: stop_on:'2021-12-31'
+        """
+    ),
+    (
+        "type",
+        "String",
+        "Yes",
+        """
+        The type of entity (scheduled report or scheduled search).
+        Supports multiple values and negation. Values must be in all lowercase letters.
+
+        Values: event_search (scheduled searches), cloud_security_posture_detections_ioa,
+        cloud_security_posture_detections_iom, cloud_security_image_vulnerabilities,
+        cloud_security_container_vulnerabilities, cloud_security_container_details,
+        cloud_security_image_detections, dashboard, discover_applications, filevantage,
+        hosts, spotlight_installed_patches, spotlight_remediations, spotlight_vulnerabilities,
+        spotlight_vulnerability_logic
+
+        Ex: type:'event_search' (scheduled searches only)
+        Ex: type:!'event_search' (scheduled reports only)
+        Ex: type:['hosts','spotlight_remediations']
+        """
+    ),
+    (
+        "user_id",
+        "String",
+        "Yes",
+        """
+        The username (typically an email address) who created the scheduled report/search entity.
+
+        Ex: user_id:'diana.hudson@email.com'
+        Ex: user_id:!'diana.hudson@email.com'
+        Ex: user_id:['diana.hudson@email.com','aiden.dean@email.com']
+        """
+    ),
+]
+
+SEARCH_SCHEDULED_REPORTS_FQL_DOCUMENTATION = """Falcon Query Language (FQL) - Search Scheduled Reports Guide
+
+=== BASIC SYNTAX ===
+property_name:[operator]'value'
+
+=== AVAILABLE OPERATORS ===
+• No operator = equals (default)
+• ! = not equal to
+• > = greater than
+• >= = greater than or equal
+• < = less than
+• <= = less than or equal
+• ~ = text match (ignores case, spaces, punctuation)
+• !~ = does not text match
+• * = wildcard matching (one or more characters)
+
+=== DATA TYPES & SYNTAX ===
+• Strings: 'value' or ['exact_value'] for exact match
+• Dates: 'YYYY-MM-DDTHH:MM:SSZ' (UTC format)
+• Booleans: true or false (no quotes)
+• Numbers: 123 (no quotes)
+• Wildcards: 'partial*' or '*partial' or '*partial*'
+
+=== COMBINING CONDITIONS ===
+• + = AND condition
+• , = OR condition
+• ( ) = Group expressions
+
+=== MULTIPLE VALUES ===
+Use brackets for OR logic: filter=type:['hosts','filevantage']
+Or repeat filter name: filter=type:'hosts',type:'filevantage'
+
+=== MULTIPLE FILTERS ===
+Use URL-encoded + (%2B) between filters:
+filter=status:'ACTIVE'%2Bfilter=type:'event_search'
+
+=== falcon_search_scheduled_reports FQL filter options ===
+
+""" + generate_md_table(SEARCH_SCHEDULED_REPORTS_FQL_FILTERS) + """
+
+=== EXAMPLE USAGE ===
+
+• id:'45c59557ded4413cafb8ff81e7640456' - Get specific report by ID
+• id:['id1','id2'] - Get multiple reports by ID
+• status:'ACTIVE' - Active reports/searches
+• type:'event_search' - Scheduled searches only
+• type:!'event_search' - Scheduled reports only
+• status:'ACTIVE'+type:'event_search' - Active scheduled searches
+• created_on:>'2023-01-01' - Created after date
+• user_id:'user@email.com' - Created by specific user
+• last_execution.status:'FAILED' - Last execution failed
+• status:'ACTIVE'+created_on:<'2021-09-15' - Active reports created before date
+• type:['hosts','spotlight_remediations'] - Specific report types
+
+=== IMPORTANT NOTES ===
+• Use single quotes around string values: 'value'
+• Use square brackets for exact matches: ['exact_value']
+• Date format must be UTC: 'YYYY-MM-DDTHH:MM:SSZ'
+• Status values are case-sensitive (use ALL CAPS)
+• Type values must be lowercase
+"""
+
+# Scheduled report/search execution FQL filters
+SEARCH_REPORT_EXECUTIONS_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Operators",
+        "Description"
+    ),
+    (
+        "id",
+        "String",
+        "Yes",
+        """
+        The unique ID of an execution. Use this to retrieve specific executions
+        by ID. Supports multiple values.
+
+        Ex: id:'f1984ff006a94980b352f18ee79aed77'
+        Ex: id:['id1','id2']
+        """
+    ),
+    (
+        "created_on",
+        "Timestamp",
+        "Yes",
+        """
+        The date and time an execution was generated.
+
+        Ex: created_on:'2021-10-12'
+        Ex: created_on:<'2021-10-12'
+        Ex: created_on:>'2021-10-12T03:00'
+        """
+    ),
+    (
+        "expiration_on",
+        "Timestamp",
+        "Yes",
+        """
+        The date and time that an execution will be deleted from the system.
+        Set at 30 days after the execution is generated.
+
+        Ex: expiration_on:'2021-12-15'
+        Ex: expiration_on:>'2021-11-15T18'
+        Ex: expiration_on:<'2021-12-03T03:30'
+        """
+    ),
+    (
+        "last_updated_on",
+        "Timestamp",
+        "Yes",
+        """
+        The date and time of the last update made to a scheduled report/search execution.
+        Execution updates refer to a change in status.
+
+        Ex: last_updated_on:'2021-10-12'
+        Ex: last_updated_on:>'2021-10-12'
+        Ex: last_updated_on:<'2021-10-12T03:00'
+        """
+    ),
+    (
+        "result_metadata.*",
+        "Various",
+        "Yes",
+        """
+        Scheduled search result details. Fields: execution_start, execution_duration,
+        execution_finish, report_file_name, report_finish, result_count, result_id,
+        search_window_start, search_window_end, queue_duration, queue_start
+
+        Ex: result_metadata.execution_start:<'2021-10-12'
+        Ex: result_metadata.result_count:>100
+        """
+    ),
+    (
+        "scheduled_report_id",
+        "String",
+        "Yes",
+        """
+        The unique ID of the scheduled report/search entity. Use this to get all
+        executions for a specific entity. Supports multiple values and negation.
+
+        Ex: scheduled_report_id:'e163544433ab1020b1a4117d1a8421b5'
+        Ex: scheduled_report_id:['id1','id2']
+        Ex: scheduled_report_id:!'e163544433ab1020b1a4117d1a8421b5'
+        """
+    ),
+    (
+        "shared_with",
+        "String",
+        "Yes",
+        """
+        The unique ID of a user who has been shared on the scheduled report that
+        generated the execution. Supports multiple values and negation.
+
+        Ex: shared_with:'ae6b126d-0b73-452d-b807-afc58f097aad'
+        Ex: shared_with:!'ae6b126d-0b73-452d-b807-afc58f097aad'
+        """
+    ),
+    (
+        "status",
+        "String",
+        "Yes",
+        """
+        The current status of an execution. Supports multiple values and negation.
+        Values must be in all capital letters.
+
+        Values: PENDING, PROCESSING, DONE, FAILED, FAILED_NOTIFICATION, NO_DATA
+
+        Ex: status:'PENDING'
+        Ex: status:['FAILED','NO_DATA']
+        Ex: status:!['FAILED','FAILED_NOTIFICATION']
+        Ex: status:!'NO_DATA'
+        """
+    ),
+    (
+        "type",
+        "String",
+        "Yes",
+        """
+        The type of entity (scheduled report or scheduled search). Supports multiple
+        values and negation. Values must be in all lowercase letters.
+
+        Values: event_search (scheduled searches), cloud_security_posture_detections_ioa,
+        cloud_security_posture_detections_iom, cloud_security_image_vulnerabilities,
+        cloud_security_container_vulnerabilities, cloud_security_container_details,
+        cloud_security_image_detections, dashboard, discover_applications, filevantage,
+        hosts, spotlight_installed_patches, spotlight_remediations, spotlight_vulnerabilities,
+        spotlight_vulnerability_logic
+
+        Ex: type:'event_search' (scheduled search executions only)
+        Ex: type:!'event_search' (scheduled report executions only)
+        Ex: type:['hosts','spotlight_remediations']
+        """
+    ),
+    (
+        "user_id",
+        "String",
+        "Yes",
+        """
+        The ID of the user who created the scheduled report/search entity that
+        generated the execution.
+
+        Ex: user_id:'diana.hudson@email.com'
+        Ex: user_id:!'diana.hudson@email.com'
+        Ex: user_id:['diana.hudson@email.com','jack.evans@email.com']
+        """
+    ),
+]
+
+SEARCH_REPORT_EXECUTIONS_FQL_DOCUMENTATION = """Falcon Query Language (FQL) - Search Report Executions Guide
+
+=== BASIC SYNTAX ===
+property_name:[operator]'value'
+
+=== AVAILABLE OPERATORS ===
+• No operator = equals (default)
+• ! = not equal to
+• > = greater than
+• >= = greater than or equal
+• < = less than
+• <= = less than or equal
+• ~ = text match (ignores case, spaces, punctuation)
+• !~ = does not text match
+• * = wildcard matching (one or more characters)
+
+=== DATA TYPES & SYNTAX ===
+• Strings: 'value' or ['exact_value'] for exact match
+• Dates: 'YYYY-MM-DDTHH:MM:SSZ' (UTC format)
+• Booleans: true or false (no quotes)
+• Numbers: 123 (no quotes)
+• Wildcards: 'partial*' or '*partial' or '*partial*'
+
+=== COMBINING CONDITIONS ===
+• + = AND condition
+• , = OR condition
+• ( ) = Group expressions
+
+=== MULTIPLE VALUES ===
+Use brackets for OR logic: filter=status:['FAILED','NO_DATA']
+Or repeat filter name: filter=status:'FAILED',status:'NO_DATA'
+
+=== MULTIPLE FILTERS ===
+Use URL-encoded + (%2B) between filters:
+filter=status:'DONE'%2Bfilter=created_on:>'2023-01-01'
+
+=== falcon_search_report_executions FQL filter options ===
+
+""" + generate_md_table(SEARCH_REPORT_EXECUTIONS_FQL_FILTERS) + """
+
+=== EXAMPLE USAGE ===
+
+• id:'f1984ff006a94980b352f18ee79aed77' - Get specific execution by ID
+• id:['id1','id2'] - Get multiple executions by ID
+• status:'DONE' - Completed successfully
+• status:'FAILED' - Failed executions
+• status:'PROCESSING' - Currently running
+• status:'PENDING' - Queued
+• scheduled_report_id:'abc123' - All executions for entity abc123
+• status:'DONE'+created_on:>'2023-01-01' - Successful runs after date
+• type:'event_search'+status:'DONE' - Completed scheduled search executions
+• result_metadata.result_count:>100 - Executions with more than 100 results
+
+=== IMPORTANT NOTES ===
+• Use single quotes around string values: 'value'
+• Use square brackets for exact matches: ['exact_value']
+• Date format must be UTC: 'YYYY-MM-DDTHH:MM:SSZ'
+• Status values are case-sensitive (use ALL CAPS)
+• Type values must be lowercase
+"""

--- a/tests/e2e/modules/test_scheduled_reports.py
+++ b/tests/e2e/modules/test_scheduled_reports.py
@@ -1,0 +1,278 @@
+"""
+E2E tests for the Scheduled Reports module.
+"""
+
+import unittest
+
+import pytest
+
+from tests.e2e.utils.base_e2e_test import BaseE2ETest
+
+
+@pytest.mark.e2e
+class TestScheduledReportsModuleE2E(BaseE2ETest):
+    """
+    End-to-end test suite for the Falcon MCP Server Scheduled Reports Module.
+    """
+
+    def test_query_active_scheduled_reports(self):
+        """Verify the agent can query for active scheduled reports."""
+
+        async def test_logic():
+            fixtures = [
+                {
+                    "operation": "scheduled_reports_query",
+                    "validator": lambda kwargs: "ACTIVE"
+                    in kwargs.get("parameters", {}).get("filter", ""),
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "resources": [
+                                "report-id-001",
+                                "report-id-002",
+                            ]
+                        },
+                    },
+                },
+                {
+                    "operation": "scheduled_reports_get",
+                    "validator": lambda kwargs: True,
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "resources": [
+                                {
+                                    "id": "report-id-001",
+                                    "name": "Weekly Host Report",
+                                    "description": "Weekly summary of host activity",
+                                    "status": "ACTIVE",
+                                    "type": "hosts",
+                                    "user_id": "admin@company.com",
+                                    "created_on": "2024-01-01T00:00:00Z",
+                                    "next_execution_on": "2024-01-22T08:00:00Z",
+                                    "schedule": {
+                                        "definition": "0 8 * * 1",
+                                        "display": "Every Monday at 8:00 AM",
+                                    },
+                                    "last_execution": {
+                                        "id": "exec-001",
+                                        "status": "DONE",
+                                        "last_updated_on": "2024-01-15T08:05:00Z",
+                                    },
+                                },
+                                {
+                                    "id": "report-id-002",
+                                    "name": "Daily Vulnerability Scan",
+                                    "description": "Daily spotlight vulnerabilities report",
+                                    "status": "ACTIVE",
+                                    "type": "spotlight_vulnerabilities",
+                                    "user_id": "security@company.com",
+                                    "created_on": "2024-01-05T00:00:00Z",
+                                    "next_execution_on": "2024-01-21T06:00:00Z",
+                                    "schedule": {
+                                        "definition": "0 6 * * *",
+                                        "display": "Daily at 6:00 AM",
+                                    },
+                                    "last_execution": {
+                                        "id": "exec-002",
+                                        "status": "DONE",
+                                        "last_updated_on": "2024-01-20T06:03:00Z",
+                                    },
+                                },
+                            ]
+                        },
+                    },
+                },
+            ]
+
+            self._mock_api_instance.command.side_effect = (
+                self._create_mock_api_side_effect(fixtures)
+            )
+
+            prompt = "Show me all active scheduled reports and their details"
+            return await self._run_agent_stream(prompt)
+
+        def assertions(tools, result):
+            self.assertGreaterEqual(len(tools), 1, "Expected at least 1 tool call")
+
+            # Check that query tool was called
+            tool_names = [t["input"]["tool_name"] for t in tools]
+            self.assertTrue(
+                any("scheduled_reports" in name for name in tool_names),
+                f"Expected scheduled reports tool to be called, got: {tool_names}",
+            )
+
+            # Verify API calls were made
+            self.assertGreaterEqual(
+                self._mock_api_instance.command.call_count,
+                1,
+                "Expected at least 1 API call",
+            )
+
+            # Verify result contains expected report information
+            self.assertIn("Weekly Host Report", result)
+            self.assertIn("Daily Vulnerability Scan", result)
+            self.assertIn("ACTIVE", result)
+
+        self.run_test_with_retries(
+            "test_query_active_scheduled_reports", test_logic, assertions
+        )
+
+    def test_query_scheduled_searches(self):
+        """Verify the agent can query for scheduled searches (event_search type)."""
+
+        async def test_logic():
+            fixtures = [
+                {
+                    "operation": "scheduled_reports_query",
+                    "validator": lambda kwargs: "event_search"
+                    in kwargs.get("parameters", {}).get("filter", ""),
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "resources": [
+                                "search-id-001",
+                            ]
+                        },
+                    },
+                },
+                {
+                    "operation": "scheduled_reports_get",
+                    "validator": lambda kwargs: True,
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "resources": [
+                                {
+                                    "id": "search-id-001",
+                                    "name": "Suspicious Process Search",
+                                    "description": "Search for suspicious process executions",
+                                    "status": "ACTIVE",
+                                    "type": "event_search",
+                                    "user_id": "analyst@company.com",
+                                    "created_on": "2024-01-10T00:00:00Z",
+                                    "next_execution_on": "2024-01-21T12:00:00Z",
+                                    "schedule": {
+                                        "definition": "0 */4 * * *",
+                                        "display": "Every 4 hours",
+                                    },
+                                    "last_execution": {
+                                        "id": "exec-search-001",
+                                        "status": "DONE",
+                                        "last_updated_on": "2024-01-20T16:02:00Z",
+                                        "result_metadata": {
+                                            "result_count": 15,
+                                            "execution_duration": 3500,
+                                        },
+                                    },
+                                },
+                            ]
+                        },
+                    },
+                },
+            ]
+
+            self._mock_api_instance.command.side_effect = (
+                self._create_mock_api_side_effect(fixtures)
+            )
+
+            prompt = "Search for all scheduled searches in the system"
+            return await self._run_agent_stream(prompt)
+
+        def assertions(tools, result):
+            self.assertGreaterEqual(len(tools), 1, "Expected at least 1 tool call")
+
+            # Verify result contains scheduled search information
+            self.assertIn("Suspicious Process Search", result)
+            self.assertIn("event_search", result.lower())
+
+        self.run_test_with_retries(
+            "test_query_scheduled_searches", test_logic, assertions
+        )
+
+    def test_query_report_executions(self):
+        """Verify the agent can query for report executions."""
+
+        async def test_logic():
+            fixtures = [
+                {
+                    "operation": "reports_executions_query",
+                    "validator": lambda kwargs: True,
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "resources": [
+                                "exec-001",
+                                "exec-002",
+                            ]
+                        },
+                    },
+                },
+                {
+                    "operation": "report_executions_get",
+                    "validator": lambda kwargs: True,
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "resources": [
+                                {
+                                    "id": "exec-001",
+                                    "scheduled_report_id": "report-id-001",
+                                    "status": "DONE",
+                                    "type": "hosts",
+                                    "created_on": "2024-01-20T08:00:00Z",
+                                    "last_updated_on": "2024-01-20T08:05:00Z",
+                                    "expiration_on": "2024-02-19T08:05:00Z",
+                                    "result_metadata": {
+                                        "result_count": 150,
+                                        "execution_duration": 5000,
+                                        "report_file_name": "weekly_host_report_20240120.csv",
+                                    },
+                                },
+                                {
+                                    "id": "exec-002",
+                                    "scheduled_report_id": "report-id-002",
+                                    "status": "FAILED",
+                                    "type": "spotlight_vulnerabilities",
+                                    "created_on": "2024-01-20T06:00:00Z",
+                                    "last_updated_on": "2024-01-20T06:10:00Z",
+                                    "status_msg": "Timeout while processing data",
+                                },
+                            ]
+                        },
+                    },
+                },
+            ]
+
+            self._mock_api_instance.command.side_effect = (
+                self._create_mock_api_side_effect(fixtures)
+            )
+
+            prompt = "Show me recent report executions and their status"
+            return await self._run_agent_stream(prompt)
+
+        def assertions(tools, result):
+            self.assertGreaterEqual(len(tools), 1, "Expected at least 1 tool call")
+
+            # Check that execution query tool was called
+            tool_names = [t["input"]["tool_name"] for t in tools]
+            self.assertTrue(
+                any("execution" in name.lower() for name in tool_names),
+                f"Expected report execution tool to be called, got: {tool_names}",
+            )
+
+            # Verify result contains execution information
+            self.assertIn("DONE", result)
+            # Check for either FAILED status or timeout message
+            self.assertTrue(
+                "FAILED" in result or "Timeout" in result,
+                "Expected FAILED status or timeout message in result",
+            )
+
+        self.run_test_with_retries(
+            "test_query_report_executions", test_logic, assertions
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/modules/test_scheduled_reports.py
+++ b/tests/modules/test_scheduled_reports.py
@@ -1,0 +1,280 @@
+"""
+Tests for the Scheduled Reports module.
+"""
+
+import unittest
+
+from falcon_mcp.modules.scheduled_reports import ScheduledReportsModule
+from tests.modules.utils.test_modules import TestModules
+
+
+class TestScheduledReportsModule(TestModules):
+    """Test cases for the Scheduled Reports module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(ScheduledReportsModule)
+
+    def test_register_tools(self):
+        """Test registering tools with the server."""
+        expected_tools = [
+            "falcon_search_scheduled_reports",
+            "falcon_launch_scheduled_report",
+            "falcon_search_report_executions",
+            "falcon_download_report_execution",
+        ]
+        self.assert_tools_registered(expected_tools)
+
+    def test_register_resources(self):
+        """Test registering resources with the server."""
+        expected_resources = [
+            "falcon_search_scheduled_reports_fql_guide",
+            "falcon_search_report_executions_fql_guide",
+        ]
+        self.assert_resources_registered(expected_resources)
+
+    def test_search_scheduled_reports_success(self):
+        """Test searching scheduled reports with successful response."""
+        # Setup mock response with sample IDs
+        mock_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    "report-id-1",
+                    "report-id-2",
+                ]
+            },
+        }
+        self.mock_client.command.return_value = mock_response
+
+        # Call search_scheduled_reports with test parameters
+        result = self.module.search_scheduled_reports(
+            filter="status:'ACTIVE'",
+            limit=100,
+            offset=0,
+            sort="created_on.desc",
+            q="test",
+        )
+
+        # Verify client command was called correctly
+        self.mock_client.command.assert_called_once_with(
+            "scheduled_reports_query",
+            parameters={
+                "filter": "status:'ACTIVE'",
+                "limit": 100,
+                "offset": 0,
+                "sort": "created_on.desc",
+                "q": "test",
+            },
+        )
+
+        # Verify result contains expected values
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], "report-id-1")
+        self.assertEqual(result[1], "report-id-2")
+
+    def test_search_scheduled_reports_empty(self):
+        """Test searching scheduled reports with empty response."""
+        # Setup mock response with empty resources
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = mock_response
+
+        # Call search_scheduled_reports
+        result = self.module.search_scheduled_reports()
+
+        # Verify result is empty list
+        self.assertEqual(result, [])
+
+    def test_search_scheduled_reports_error(self):
+        """Test searching scheduled reports with API error."""
+        # Setup mock response with error
+        mock_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid filter"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        # Call search_scheduled_reports
+        result = self.module.search_scheduled_reports(filter="invalid")
+
+        # Verify result contains error (wrapped in list for consistent return type)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+        self.assertTrue(result[0]["error"].startswith("Failed to search for scheduled reports"))
+
+    def test_launch_scheduled_report_success(self):
+        """Test launching scheduled report with successful response."""
+        # Setup mock response
+        mock_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "id": "execution-id-1",
+                        "scheduled_report_id": "report-id-1",
+                        "status": "PENDING",
+                    }
+                ]
+            },
+        }
+        self.mock_client.command.return_value = mock_response
+
+        # Call launch_scheduled_report
+        result = self.module.launch_scheduled_report(id="report-id-1")
+
+        # Verify client command was called correctly
+        self.mock_client.command.assert_called_once_with(
+            "scheduled_reports_launch",
+            body={"id": "report-id-1"},
+        )
+
+        # Verify result
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "execution-id-1")
+        self.assertEqual(result[0]["status"], "PENDING")
+
+    def test_search_report_executions_success(self):
+        """Test searching report executions with successful response."""
+        # Setup mock response
+        mock_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    "execution-id-1",
+                    "execution-id-2",
+                ]
+            },
+        }
+        self.mock_client.command.return_value = mock_response
+
+        # Call search_report_executions
+        result = self.module.search_report_executions(
+            filter="status:'DONE'",
+            limit=50,
+            offset=10,
+            sort="created_on.desc",
+        )
+
+        # Verify client command was called correctly
+        self.mock_client.command.assert_called_once_with(
+            "reports_executions_query",
+            parameters={
+                "filter": "status:'DONE'",
+                "limit": 50,
+                "offset": 10,
+                "sort": "created_on.desc",
+            },
+        )
+
+        # Verify result
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], "execution-id-1")
+
+    def test_download_report_execution_success(self):
+        """Test downloading report execution with successful response."""
+        # Setup mock response with binary content
+        mock_content = b"Report,Data\nRow1,Value1\nRow2,Value2"
+        mock_response = {
+            "status_code": 200,
+            "body": mock_content,
+        }
+        self.mock_client.command.return_value = mock_response
+
+        # Call download_report_execution
+        result = self.module.download_report_execution(id="execution-id-1")
+
+        # Verify client command was called correctly
+        self.mock_client.command.assert_called_once_with(
+            "report_executions_download_get",
+            parameters={"id": "execution-id-1"},
+        )
+
+        # Verify result is decoded string
+        self.assertIsInstance(result, str)
+        self.assertIn("Report,Data", result)
+        self.assertIn("Row1,Value1", result)
+
+    def test_download_report_execution_error(self):
+        """Test downloading report execution with API error."""
+        # Setup mock response with error (execution not ready)
+        mock_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Execution not complete"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        # Call download_report_execution
+        result = self.module.download_report_execution(id="execution-id-1")
+
+        # Verify result contains error
+        self.assertIn("error", result)
+        self.assertTrue(result["error"].startswith("Failed to download report execution"))
+
+    # Security validation tests
+
+    def test_search_scheduled_reports_with_special_characters_in_filter(self):
+        """Test that special characters in filter are passed through safely."""
+        # Setup mock response
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = mock_response
+
+        # Test with filter containing special characters (FQL syntax)
+        filter_with_special = "status:'ACTIVE'+type:'event_search'"
+        self.module.search_scheduled_reports(filter=filter_with_special)
+
+        # Verify the filter was passed through unchanged
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["parameters"]["filter"], filter_with_special)
+
+    def test_launch_scheduled_report_with_invalid_id(self):
+        """Test launching report with invalid ID returns error from API."""
+        # Setup mock response with 404 error
+        mock_response = {
+            "status_code": 404,
+            "body": {"errors": [{"message": "Scheduled report not found"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        # Call with invalid ID
+        result = self.module.launch_scheduled_report(id="nonexistent-id")
+
+        # Verify error is returned (wrapped in list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    def test_search_report_executions_error(self):
+        """Test searching report executions with API error."""
+        # Setup mock response with error
+        mock_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid filter syntax"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        # Call search_report_executions
+        result = self.module.search_report_executions(filter="invalid[syntax")
+
+        # Verify error is returned (wrapped in list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+        self.assertTrue(result[0]["error"].startswith("Failed to search for report executions"))
+
+    def test_download_report_execution_not_complete(self):
+        """Test downloading report when execution is not complete."""
+        # Setup mock response for trying to download a PENDING execution
+        mock_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Cannot download report: execution status is PENDING"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        # Call download_report_execution
+        result = self.module.download_report_execution(id="pending-execution-id")
+
+        # Verify error is returned
+        self.assertIn("error", result)
+        self.assertIn("Failed to download report execution", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add new module for managing CrowdStrike Falcon scheduled reports and scheduled searches
- Provides tools for searching, launching, and downloading scheduled reports and executions

## Changes
- **New module**: `falcon_mcp/modules/scheduled_reports.py` with 4 tools:
  - `falcon_search_scheduled_reports`: Search for scheduled reports and searches
  - `falcon_launch_scheduled_report`: Launch a scheduled report on demand
  - `falcon_search_report_executions`: Search for report executions
  - `falcon_download_report_execution`: Download generated report files
- **New resources**: `falcon_mcp/resources/scheduled_reports.py` with FQL documentation
- **New tests**: Unit tests and E2E tests for the module
- **Updated docs**: README.md with module documentation and API scope requirements
- **Updated scopes**: Added `Scheduled Reports:read` scope mapping

Closes #82 