### PR TITLE
fix(modules/scheduled-reports): return full details from search tools

### DIFF
--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -77,6 +77,7 @@ class BaseModule(ABC):
         operation: str,
         ids: List[str],
         id_key: str = "ids",
+        use_params: bool = False,
         **additional_params,
     ) -> List[Dict[str, Any]] | Dict[str, Any]:
         """Helper method for API operations that retrieve entities by IDs.
@@ -84,20 +85,25 @@ class BaseModule(ABC):
         Args:
             operation: The API operation name
             ids: List of entity IDs
-            id_key: The key name for IDs in the request body (default: "ids")
-            **additional_params: Additional parameters to include in the request body
+            id_key: The key name for IDs in the request (default: "ids")
+            use_params: If True, send IDs as query parameters (GET).
+                       If False, send as request body (POST). Default: False
+            **additional_params: Additional parameters to include in the request
 
         Returns:
             List of entity details or error dict
         """
-        # Build the request body with dynamic ID key and additional parameters
-        body_params = {id_key: ids}
-        body_params.update(additional_params)
+        # Build the request params with dynamic ID key and additional parameters
+        request_params = {id_key: ids}
+        request_params.update(additional_params)
 
-        body = prepare_api_parameters(body_params)
+        prepared = prepare_api_parameters(request_params)
 
-        # Make the API request
-        response = self.client.command(operation, body=body)
+        # Make the API request using either parameters (GET) or body (POST)
+        if use_params:
+            response = self.client.command(operation, parameters=prepared)
+        else:
+            response = self.client.command(operation, body=prepared)
 
         # Handle the response
         return handle_api_response(

--- a/falcon_mcp/modules/scheduled_reports.py
+++ b/falcon_mcp/modules/scheduled_reports.py
@@ -127,7 +127,7 @@ class ScheduledReportsModule(BaseModule):
         - filter=created_on:>'2023-01-01' - Created after date
         - filter=id:'45c59557ded4413cafb8ff81e7640456' - Specific report by ID
         """
-        result = self._base_search_api_call(
+        report_ids = self._base_search_api_call(
             operation="scheduled_reports_query",
             search_params={
                 "filter": filter,
@@ -140,10 +140,23 @@ class ScheduledReportsModule(BaseModule):
             default_result=[],
         )
 
-        if self._is_error(result):
-            return [result]
+        if self._is_error(report_ids):
+            return [report_ids]
 
-        return result
+        # If we have report IDs, get the full details for each one
+        if report_ids:
+            details = self._base_get_by_ids(
+                operation="scheduled_reports_get",
+                ids=report_ids,
+                use_params=True,
+            )
+
+            if self._is_error(details):
+                return [details]
+
+            return details
+
+        return []
 
     def launch_scheduled_report(
         self,
@@ -212,8 +225,8 @@ class ScheduledReportsModule(BaseModule):
         - filter=scheduled_report_id:'abc123' - All executions for report abc123
         - filter=id:'f1984ff006a94980b352f18ee79aed77' - Specific execution by ID
         """
-        result = self._base_search_api_call(
-            operation="reports_executions_query",
+        execution_ids = self._base_search_api_call(
+            operation="report_executions_query",
             search_params={
                 "filter": filter,
                 "limit": limit,
@@ -224,10 +237,23 @@ class ScheduledReportsModule(BaseModule):
             default_result=[],
         )
 
-        if self._is_error(result):
-            return [result]
+        if self._is_error(execution_ids):
+            return [execution_ids]
 
-        return result
+        # If we have execution IDs, get the full details for each one
+        if execution_ids:
+            details = self._base_get_by_ids(
+                operation="report_executions_get",
+                ids=execution_ids,
+                use_params=True,
+            )
+
+            if self._is_error(details):
+                return [details]
+
+            return details
+
+        return []
 
     def download_report_execution(
         self,

--- a/tests/e2e/modules/test_scheduled_reports.py
+++ b/tests/e2e/modules/test_scheduled_reports.py
@@ -196,7 +196,7 @@ class TestScheduledReportsModuleE2E(BaseE2ETest):
         async def test_logic():
             fixtures = [
                 {
-                    "operation": "reports_executions_query",
+                    "operation": "report_executions_query",
                     "validator": lambda kwargs: True,
                     "response": {
                         "status_code": 200,


### PR DESCRIPTION
## Summary
- Fix `search_scheduled_reports` and `search_report_executions` tools to return full entity details instead of just IDs
- Fix incorrect operation name (`reports_executions_query` → `report_executions_query`)
- Add `use_params` option to `_base_get_by_ids()` helper for GET endpoints

## Changes
- **falcon_mcp/modules/scheduled_reports.py**: Updated both search tools to query for IDs then fetch full details (matching the `search_detections` pattern)
- **falcon_mcp/modules/base.py**: Added `use_params` parameter to `_base_get_by_ids()` to support GET endpoints that expect IDs as query parameters instead of request body
- **tests/modules/test_scheduled_reports.py**: Updated unit tests to verify two-step query+get pattern
- **tests/e2e/modules/test_scheduled_reports.py**: Fixed operation name in test fixture