### PR TITLE
feat(modules/detections): improve FQL filter UX and tool descriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,4 @@ FALCON_BASE_URL=https://api.us-2.crowdstrike.com
 # Options: true, false
 # Default: false
 #FALCON_MCP_STATELESS_HTTP=false
+

--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -272,3 +272,36 @@ class BaseModule(ABC):
 
     def _is_error(self, response: Any) -> bool:
         return isinstance(response, dict) and "error" in response
+
+    def _format_fql_error_response(
+        self,
+        error_or_empty: List[Dict[str, Any]],
+        filter_used: str | None,
+        fql_documentation: str,
+    ) -> Dict[str, Any]:
+        """Format response with FQL guide for search errors or empty results ONLY.
+
+        Use this helper when the FQL filter itself may be the issue:
+        - Empty results: User may need to refine their filter
+        - Search errors: Likely FQL syntax issues
+
+        Do NOT use for downstream errors (e.g., fetching details after valid IDs)
+        or success cases - those should return results directly.
+
+        Args:
+            error_or_empty: Empty list or list containing single error dict
+            filter_used: The FQL filter string that was used (can be None)
+            fql_documentation: Module-specific FQL documentation constant
+
+        Returns:
+            Dict with results, filter_used, fql_guide, and contextual hint
+        """
+        is_error = error_or_empty and self._is_error(error_or_empty[0])
+        return {
+            "results": error_or_empty,
+            "filter_used": filter_used,
+            "fql_guide": fql_documentation,
+            "hint": "Filter error occurred. Review the FQL guide above to correct your query syntax."
+            if is_error
+            else "No results matched your filter. Review the FQL guide above to refine your query.",
+        }

--- a/falcon_mcp/resources/detections.py
+++ b/falcon_mcp/resources/detections.py
@@ -4,6 +4,35 @@ Contains Detections resources.
 
 from falcon_mcp.common.utils import generate_md_table
 
+# Concise FQL syntax for embedding in tool parameter descriptions
+EMBEDDED_FQL_SYNTAX = """FQL filter string for querying detections.
+
+SYNTAX:
+- Equals: field:'value'
+- Not equals: field:!'value'
+- Comparison: field:>50, field:>=50, field:<50, field:<=50
+- Contains (case-insensitive): field:~'partial'
+- Wildcard: field:'prefix*', field:'*suffix'
+
+COMBINING:
+- AND (all must match): field1:'value1'+field2:'value2'
+- OR (any can match): field:'value1',field:'value2'
+- Grouping: (status:'new',status:'in_progress')+severity_name:'High'
+
+COMMON FIELDS:
+- status: 'new', 'in_progress', 'closed', 'reopened'
+- severity_name: 'Informational', 'Low', 'Medium', 'High', 'Critical'
+- product: 'epp', 'idp', 'xdr', 'overwatch'
+- device.hostname: Hostname contains string
+- created_timestamp: ISO 8601 format (e.g., '2025-01-14T00:00:00Z')
+
+EXAMPLES:
+- New high/critical alerts: status:'new'+(severity_name:'High',severity_name:'Critical')
+- Last 24h endpoint detections: created_timestamp:>'2025-01-14T00:00:00Z'+product:'epp'
+- Hostname pattern: device.hostname:'DC*'+status:'new'
+- Unassigned critical: assigned_to_name:!'*'+severity_name:'Critical'
+"""
+
 # List of tuples containing filter options data: (name, type, description)
 SEARCH_DETECTIONS_FQL_FILTERS = [
     (

--- a/tests/e2e/modules/test_detections.py
+++ b/tests/e2e/modules/test_detections.py
@@ -2,7 +2,7 @@
 E2E tests for the Detections module.
 """
 
-import json
+import re
 import unittest
 
 import pytest
@@ -23,14 +23,19 @@ class TestDetectionsModuleE2E(BaseE2ETest):
             fixtures = [
                 {
                     "operation": "GetQueriesAlertsV2",
-                    "validator": lambda kwargs: "severity:"
-                    in kwargs.get("parameters", {}).get("filter", "").lower()
-                    and kwargs.get("parameters", {}).get("limit", 0) <= 10,
+                    "validator": lambda kwargs: (
+                        (
+                            "severity:>=60+severity:<80"
+                            in (
+                                filter_str := kwargs.get("parameters", {}).get("filter", "").lower()
+                            )
+                            or "severity_name:'high'" in filter_str
+                        )
+                        and kwargs.get("parameters", {}).get("limit", 0) == 3
+                    ),
                     "response": {
                         "status_code": 200,
-                        "body": {
-                            "resources": ["detection-1", "detection-2", "detection-3"]
-                        },
+                        "body": {"resources": ["detection-1", "detection-2", "detection-3"]},
                     },
                 },
                 {
@@ -45,10 +50,10 @@ class TestDetectionsModuleE2E(BaseE2ETest):
                                     "id": "detection-1",
                                     "composite_id": "detection-1",
                                     "status": "new",
-                                    "severity": 90,
-                                    "severity_name": "Critical",
+                                    "severity": 75,
+                                    "severity_name": "High",
                                     "confidence": 85,
-                                    "description": "A critical detection for E2E testing.",
+                                    "description": "A high detection for E2E testing.",
                                     "created_timestamp": "2024-01-20T10:00:00Z",
                                     "agent_id": "test-agent-001",
                                 },
@@ -80,54 +85,84 @@ class TestDetectionsModuleE2E(BaseE2ETest):
                 },
             ]
 
-            self._mock_api_instance.command.side_effect = (
-                self._create_mock_api_side_effect(fixtures)
+            self._mock_api_instance.command.side_effect = self._create_mock_api_side_effect(
+                fixtures
             )
 
-            prompt = "Give me the details of the top 3 high severity detections, return only detection id and descriptions"
+            prompt = "Give me the details of the 3 most recent detections of severity level high."
             return await self._run_agent_stream(prompt)
 
         def assertions(tools, result):
-            self.assertGreaterEqual(len(tools), 1, "Expected 1 tool call")
-            used_tool = tools[len(tools) - 1]
-            self.assertEqual(
-                used_tool["input"]["tool_name"], "falcon_search_detections"
-            )
-            # Check for severity-related filtering (numeric or text-based)
-            tool_input_str = json.dumps(used_tool["input"]["tool_input"]).lower()
-            self.assertTrue(
-                "severity:" in tool_input_str or "high" in tool_input_str,
-                f"Expected severity filtering in tool input: {tool_input_str}",
-            )
-            self.assertIn("detection-1", used_tool["output"])
-            self.assertIn("detection-2", used_tool["output"])
-            self.assertIn("detection-3", used_tool["output"])
-
-            self.assertGreaterEqual(
-                self._mock_api_instance.command.call_count, 2, "Expected 2 API calls"
-            )
-            api_call_1_params = self._mock_api_instance.command.call_args_list[0][
-                1
-            ].get("parameters", {})
-            filter_str = api_call_1_params.get("filter", "").lower()
-            # Accept either numeric severity filters or text-based filters
-            self.assertTrue(
-                "severity:" in filter_str or "high" in filter_str,
-                f"Expected severity filtering in API call: {filter_str}",
-            )
-            self.assertEqual(api_call_1_params.get("limit"), 3)
-            self.assertIn("severity.desc", api_call_1_params.get("sort", ""))
-            api_call_2_body = self._mock_api_instance.command.call_args_list[1][1].get(
-                "body", {}
-            )
-            self.assertEqual(
-                api_call_2_body.get("composite_ids"),
-                ["detection-1", "detection-2", "detection-3"],
+            # Validate tool execution - search_detections must be called (may have extra calls)
+            self.assertGreaterEqual(len(tools), 1, "Expected at least 1 tool call")
+            tool_names = [t["input"]["tool_name"] for t in tools]
+            self.assertIn(
+                "falcon_search_detections",
+                tool_names,
+                f"Expected falcon_search_detections in tool calls. Got: {tool_names}",
             )
 
-            self.assertIn("detection-1", result)
-            self.assertIn("detection-2", result)
-            self.assertIn("detection-3", result)
+            # Find the successful GetQueriesAlertsV2 call with correct parameters
+            # (LLMs may retry with corrected params, so search all calls)
+            search_call = None
+            for call in self._mock_api_instance.command.call_args_list:
+                if call[0][0] == "GetQueriesAlertsV2":
+                    params = call[1].get("parameters", {})
+                    filter_str = params.get("filter", "").lower()
+
+                    # Check if this call has valid high severity filtering
+                    is_numeric_high = ">=60" in filter_str and "<80" in filter_str
+                    is_named_high = "severity_name" in filter_str and "high" in filter_str
+
+                    if (is_numeric_high or is_named_high) and params.get("limit") == 3:
+                        search_call = call
+                        break
+
+            self.assertIsNotNone(
+                search_call,
+                "Expected GetQueriesAlertsV2 call with High severity filter and limit=3",
+            )
+
+            # Validate search API call parameters from the successful call
+            search_params = search_call[1].get("parameters", {})
+            filter_str = search_params.get("filter", "").lower()
+
+            # Validate "high severity only" filtering (accept both numeric and name-based)
+            is_numeric_high = ">=60" in filter_str and "<80" in filter_str
+            is_named_high = "severity_name" in filter_str and "high" in filter_str
+            self.assertTrue(
+                is_numeric_high or is_named_high,
+                f"Expected High severity filtering. Got: {filter_str}",
+            )
+
+            self.assertEqual(search_params.get("limit"), 3, "Expected limit of 3")
+
+            # Validate "latest" sorting (accept both timestamp options with . or | separator)
+            sort_param = search_params.get("sort", "")
+            sort_pattern = r"(timestamp|created_timestamp)[.|]desc"
+            self.assertTrue(
+                re.search(sort_pattern, sort_param, re.IGNORECASE),
+                f"Expected descending timestamp sort. Got: {sort_param}",
+            )
+
+            # Find the PostEntitiesAlertsV2 call with the expected detection IDs
+            details_call = None
+            expected_ids = ["detection-1", "detection-2", "detection-3"]
+            for call in self._mock_api_instance.command.call_args_list:
+                if call[0][0] == "PostEntitiesAlertsV2":
+                    body = call[1].get("body", {})
+                    if body.get("composite_ids") == expected_ids:
+                        details_call = call
+                        break
+
+            self.assertIsNotNone(
+                details_call,
+                "Expected PostEntitiesAlertsV2 call with detection IDs",
+            )
+
+            # Validate final result contains all expected detections
+            for detection_id in expected_ids:
+                self.assertIn(detection_id, result, f"Expected {detection_id} in final result")
 
         self.run_test_with_retries(
             "test_get_top_3_high_severity_detections",
@@ -175,41 +210,250 @@ class TestDetectionsModuleE2E(BaseE2ETest):
                 },
             ]
 
-            self._mock_api_instance.command.side_effect = (
-                self._create_mock_api_side_effect(fixtures)
+            self._mock_api_instance.command.side_effect = self._create_mock_api_side_effect(
+                fixtures
             )
 
-            prompt = "What is the highest detection for the device with local_ip 10.0.0.1? Return the detection id as well"
+            prompt = "Search for detections on the device with local_ip 10.0.0.1 and return the highest severity detection id"
             return await self._run_agent_stream(prompt)
 
         def assertions(tools, result):
-            self.assertGreaterEqual(
-                len(tools), 1, f"Expected 1 tool call, but got {len(tools)}"
+            # Validate tool execution - search_detections must be called (may have extra calls)
+            self.assertGreaterEqual(len(tools), 1, "Expected at least 1 tool call")
+            tool_names = [t["input"]["tool_name"] for t in tools]
+            self.assertIn(
+                "falcon_search_detections",
+                tool_names,
+                f"Expected falcon_search_detections in tool calls. Got: {tool_names}",
             )
-            used_tool = tools[len(tools) - 1]
-            self.assertEqual(
-                used_tool["input"]["tool_name"], "falcon_search_detections"
-            )
-            self.assertIn("10.0.0.1", json.dumps(used_tool["input"]["tool_input"]))
-            self.assertIn("detection-4", used_tool["output"])
 
+            # Validate API call sequence (at least 2 calls: search + get details)
             self.assertGreaterEqual(
-                self._mock_api_instance.command.call_count, 2, "Expected 2 API calls"
+                self._mock_api_instance.command.call_count,
+                2,
+                "Expected at least 2 API calls (search + details)",
             )
-            api_call_1_params = self._mock_api_instance.command.call_args_list[0][
-                1
-            ].get("parameters", {})
-            self.assertIn("10.0.0.1", api_call_1_params.get("filter"))
-            api_call_2_body = self._mock_api_instance.command.call_args_list[1][1].get(
-                "body", {}
-            )
-            self.assertEqual(api_call_2_body.get("composite_ids"), ["detection-4"])
 
-            self.assertIn("detection-4", result)
-            self.assertNotIn("detection-1", result)
+            # Find the successful GetQueriesAlertsV2 call with device.local_ip filter
+            search_call = None
+            for call in self._mock_api_instance.command.call_args_list:
+                if call[0][0] == "GetQueriesAlertsV2":
+                    params = call[1].get("parameters", {})
+                    filter_str = params.get("filter", "")
+                    if "device.local_ip" in filter_str and "10.0.0.1" in filter_str:
+                        search_call = call
+                        break
+
+            self.assertIsNotNone(
+                search_call, "Expected GetQueriesAlertsV2 call with device.local_ip filter"
+            )
+
+            # Validate search API call parameters
+            search_params = search_call[1].get("parameters", {})
+            filter_str = search_params.get("filter", "")
+            self.assertIn(
+                "device.local_ip",
+                filter_str,
+                "Expected 'device.local_ip' filter in search API call",
+            )
+            self.assertIn(
+                "10.0.0.1", filter_str, "Expected IP address filtering in search API call"
+            )
+
+            # Validate "highest" detection sorting (should sort by severity descending)
+            sort_param = search_params.get("sort", "")
+            if sort_param:  # Only validate if sorting is provided
+                severity_sort_pattern = r"severity[.|]desc"
+                self.assertTrue(
+                    re.search(severity_sort_pattern, sort_param, re.IGNORECASE),
+                    f"Expected severity descending sort for 'highest' detection. Got: {sort_param}",
+                )
+
+            # Find the PostEntitiesAlertsV2 call with detection-4
+            details_call = None
+            for call in self._mock_api_instance.command.call_args_list:
+                if call[0][0] == "PostEntitiesAlertsV2":
+                    body = call[1].get("body", {})
+                    if "detection-4" in body.get("composite_ids", []):
+                        details_call = call
+                        break
+
+            self.assertIsNotNone(
+                details_call, "Expected PostEntitiesAlertsV2 call with detection-4"
+            )
+
+            # Validate final result contains expected detection and excludes others
+            self.assertIn("detection-4", result, "Expected detection-4 in final result")
+            self.assertNotIn("detection-1", result, "Expected detection-1 NOT in final result")
+
+        self.run_test_with_retries("test_get_highest_detection_for_ip", test_logic, assertions)
+
+    def test_complex_fql_with_field_reference_table(self):
+        """Verify the agent can use fields from the complete field reference table with complex FQL syntax."""
+
+        async def test_logic():
+            fixtures = [
+                {
+                    "operation": "GetQueriesAlertsV2",
+                    "validator": lambda kwargs: (
+                        # Validate FQL filter uses device.product_type_desc field from field reference table
+                        (filter_str := kwargs.get("parameters", {}).get("filter", "").lower())
+                        and "device.product_type_desc" in filter_str
+                        and "workstation" in filter_str
+                    ),
+                    "response": {
+                        "status_code": 200,
+                        "body": {"resources": ["detection-5", "detection-6", "detection-7"]},
+                    },
+                },
+                {
+                    "operation": "PostEntitiesAlertsV2",
+                    "validator": lambda kwargs: "detection-5"
+                    in kwargs.get("body", {}).get("composite_ids", []),
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "resources": [
+                                {
+                                    "id": "detection-5",
+                                    "composite_id": "detection-5",
+                                    "status": "new",
+                                    "severity": 65,
+                                    "severity_name": "High",
+                                    "confidence": 85,
+                                    "description": "Malware detection on workstation.",
+                                    "created_timestamp": "2024-01-20T12:00:00Z",
+                                    "agent_id": "test-agent-005",
+                                    "device": {
+                                        "product_type_desc": "Workstation",
+                                        "hostname": "WS-001",
+                                    },
+                                },
+                                {
+                                    "id": "detection-6",
+                                    "composite_id": "detection-6",
+                                    "status": "new",
+                                    "severity": 70,
+                                    "severity_name": "High",
+                                    "confidence": 90,
+                                    "description": "Suspicious activity on workstation.",
+                                    "created_timestamp": "2024-01-20T11:45:00Z",
+                                    "agent_id": "test-agent-006",
+                                    "device": {
+                                        "product_type_desc": "Workstation",
+                                        "hostname": "WS-002",
+                                    },
+                                },
+                                {
+                                    "id": "detection-7",
+                                    "composite_id": "detection-7",
+                                    "status": "new",
+                                    "severity": 75,
+                                    "severity_name": "High",
+                                    "confidence": 80,
+                                    "description": "Threat detected on workstation endpoint.",
+                                    "created_timestamp": "2024-01-20T11:30:00Z",
+                                    "agent_id": "test-agent-007",
+                                    "device": {
+                                        "product_type_desc": "Workstation",
+                                        "hostname": "WS-003",
+                                    },
+                                },
+                            ]
+                        },
+                    },
+                },
+            ]
+
+            self._mock_api_instance.command.side_effect = self._create_mock_api_side_effect(
+                fixtures
+            )
+
+            prompt = "Find 5 endpoint detections from workstation devices only, sorted by most recent first."
+            return await self._run_agent_stream(prompt)
+
+        def assertions(tools, result):
+            # Validate tool execution - search_detections must be called (may have extra calls)
+            self.assertGreaterEqual(len(tools), 1, "Expected at least 1 tool call")
+            tool_names = [t["input"]["tool_name"] for t in tools]
+            self.assertIn(
+                "falcon_search_detections",
+                tool_names,
+                f"Expected falcon_search_detections in tool calls. Got: {tool_names}",
+            )
+
+            # Find the successful GetQueriesAlertsV2 call with correct filter
+            search_call = None
+            for call in self._mock_api_instance.command.call_args_list:
+                if call[0][0] == "GetQueriesAlertsV2":
+                    params = call[1].get("parameters", {})
+                    filter_str = params.get("filter", "").lower()
+                    if (
+                        "device.product_type_desc" in filter_str
+                        and "workstation" in filter_str
+                    ):
+                        search_call = call
+                        break
+
+            self.assertIsNotNone(
+                search_call,
+                "Expected GetQueriesAlertsV2 call with device.product_type_desc filter",
+            )
+
+            # Validate search API call parameters
+            search_params = search_call[1].get("parameters", {})
+
+            # Validate complex FQL filter construction
+            filter_str = search_params.get("filter", "").lower()
+
+            # Should use device.product_type_desc field from the field reference table
+            self.assertIn(
+                "device.product_type_desc",
+                filter_str,
+                f"Expected 'device.product_type_desc' field from field reference table. Got filter: {filter_str}",
+            )
+
+            # Should filter for Workstation product type
+            self.assertIn(
+                "workstation",
+                filter_str,
+                f"Expected 'Workstation' value for product type filtering. Got filter: {filter_str}",
+            )
+
+            # Validate parameter separation (filter vs sort vs limit)
+            # Model should use a reasonable limit for workstation query
+            limit_used = search_params.get("limit")
+            self.assertIsNotNone(
+                limit_used,
+                "Expected limit parameter to be properly separated from filter",
+            )
+
+            # Validate sort parameter properly separated from filter
+            sort_param = search_params.get("sort", "")
+            if sort_param:  # If sorting is used
+                # Should NOT be in the filter string
+                self.assertNotIn(
+                    "sort",
+                    filter_str,
+                    f"Sort syntax should NOT be in filter parameter. Filter: {filter_str}, Sort: {sort_param}",
+                )
+
+                # Should use proper timestamp sorting for "most recent first"
+                timestamp_sort_pattern = r"(timestamp|created_timestamp)[.|]desc"
+                self.assertTrue(
+                    re.search(timestamp_sort_pattern, sort_param, re.IGNORECASE),
+                    f"Expected proper timestamp sorting for 'most recent first'. Got sort: {sort_param}",
+                )
+
+            # Validate final result contains expected detections
+            expected_detections = ["detection-5", "detection-6", "detection-7"]
+            for detection_id in expected_detections:
+                self.assertIn(detection_id, result, f"Expected {detection_id} in final result")
 
         self.run_test_with_retries(
-            "test_get_highest_detection_for_ip", test_logic, assertions
+            "test_complex_fql_with_field_reference_table",
+            test_logic,
+            assertions,
         )
 
 


### PR DESCRIPTION
## Summary

This PR improves the MCP tool experience for the detections module by enhancing how LLMs interact with FQL (Falcon Query Language) filters and improving tool selection accuracy.

## Problem

When working with MCP servers, LLMs face two key challenges:

1. **FQL syntax errors are opaque** - When an LLM constructs an invalid FQL filter or gets no results, the error response doesn't help it understand what went wrong or how to fix it. This leads to repeated failures or the LLM giving up.

2. **Tool selection ambiguity** - The previous tool descriptions didn't clearly differentiate between `falcon_search_detections` (find detections by criteria) and `falcon_get_detection_details` (retrieve by known ID). LLMs would sometimes choose the wrong tool or be uncertain which to use.

## Solution

### 1. FQL Syntax Guide in Error Responses

When a search returns an error or empty results, the response now includes an embedded FQL syntax guide with:
- Common filter field names and types
- Example filter expressions
- Valid field values (severity levels, status options, etc.)

This enables the LLM to self-correct and retry with proper syntax rather than failing or asking the user for help.

**Before:**
```json
{"error": "Invalid filter syntax", "results": []}
```

**After:**
```json
{
  "error": "Invalid filter syntax",
  "results": [],
  "fql_guide": "## FQL Filter Syntax\n\nUse field:value format...",
  "filter_attempted": "severity:high"
}
```

### 2. Improved Tool Descriptions for LLM Selection

Tool descriptions are critical for MCP - they're what LLMs see when deciding which tool to use. The first sentence is especially important as it often appears in tool listings.

**`falcon_search_detections`** - Changed from:
> "Search and analyze detections across your CrowdStrike environment."

To:
> "Find detections by criteria and return their complete details."

This clarifies that:
- It's for **finding/discovering** detections (not just if you have IDs)
- It returns **full details** (not just IDs that need a second call)

**`falcon_get_detection_details`** - Changed from:
> "Get detection details for specific detection IDs to understand security threats."

To:
> "Retrieve details for detection IDs you already have."

This clarifies:
- You need IDs **already** (prerequisite is explicit)
- Directs users to `falcon_search_detections` for discovery

### 3. Reusable Error Formatting

Added `_format_fql_error_response()` helper to `BaseModule` for consistent error formatting across all modules that use FQL filters. This establishes a pattern for other modules to adopt.

## Changes

| File | Change |
|------|--------|
| `falcon_mcp/modules/base.py` | Add `_format_fql_error_response()` helper |
| `falcon_mcp/modules/detections.py` | Improve tool docstrings, use FQL error helper |
| `falcon_mcp/resources/detections.py` | Add `EMBEDDED_FQL_SYNTAX` constant |
| `tests/modules/test_detections.py` | Add unit tests for error response formatting |
| `tests/e2e/modules/test_detections.py` | Add E2E tests, fix assertion logic for LLM retries |
| `docs/plans/` | Design and implementation planning documents |

## Testing

- **Unit tests**: Validate `_format_fql_error_response` produces correct structure for both error and empty result cases
- **E2E tests**: Validate end-to-end flow where LLM receives FQL guide and successfully retries
- **E2E assertion fix**: Test assertions now search all API calls rather than just the first, accommodating LLM retry patterns (LLMs often make an initial incorrect attempt, receive error feedback, then retry with corrected parameters)