### PR TITLE
refactor(examples/adk): simplify agent.py and clean up documentation

### DIFF
--- a/examples/adk/README.md
+++ b/examples/adk/README.md
@@ -12,8 +12,8 @@ The goal is to provide customers an opinionated and validated set of instruction
 4. [Deploying to Vertex AI Agent Engine and registering on Agentspace](#deploying-to-vertex-ai-agent-engine-and-registering-on-agentspace)
 5. [Securing access, Evaluating, Optimizing performance and costs](#securing-access-evaluating-optimizing-performance-and-costs)
 
-
 ### Setting up and running locally (5 minutes)
+
 You can run the following commands locally on Linux / Mac or in Google Cloud Shell.
 If you plan to deploy the agent, it is recommended to run in Google Cloud Shell.
 
@@ -38,10 +38,10 @@ chmod +x adk_agent_operations.sh
 
 ```
 
-
-
 The script will create `.env` file in `falcon_agent/` directory and prompt you to update it. At a minimum update the `General Agent Configuration` section.
 
+> [!WARNING]
+> **Do not use curly braces** (`{variable}`) in the `FALCON_AGENT_PROMPT` value. Google ADK interprets `{name}` patterns as context variables that must exist in session state, which causes `Context variable not found` errors at runtime. Use square brackets or plain text instead.
 
 <details>
 
@@ -55,6 +55,7 @@ SUCCESS: './falcon_agent/env.properties' copied to './falcon_agent/.env'.
 ACTION REQUIRED: Please update the variables in './falcon_agent/.env' before running this script with an operation mode.
 
 ```
+
 </details>
 
 <br>
@@ -64,16 +65,12 @@ ACTION REQUIRED: Please update the variables in './falcon_agent/.env' before run
 
 Now run the script with `local_run` parameter.
 
-
 ```bash
 # local run
 ./adk_agent_operations.sh local_run
 ```
 
-
-
 Here is the sample output
-
 
 <details>
 
@@ -107,18 +104,19 @@ INFO:     Application startup complete.
 INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
 
 ```
+
 </details>
 
 <br>
 
-You can access the agent on http://localhost:8000 🚀
+You can access the agent on <http://localhost:8000> 🚀
 
 > If running in the Google Cloud Shell - please use the web preview with port 8000.
 
 You can stop the agent with `ctrl+C`
 
-
 ### Deployment - Why Deploy?
+
 You may want to deploy the agent (with the `falcon-mcp` server) for following reasons
 
 1. You do not want to hand out credentials to everyone to run MCP server locally
@@ -126,6 +124,7 @@ You may want to deploy the agent (with the `falcon-mcp` server) for following re
 3. Use it for demos without any setup
 
 You have two distinct paths to deployment:
+
 1. Deploy on Cloud Run
 2. Deploy on Vertex AI Agent Engine (and access through Agentspace after registration)
 
@@ -147,7 +146,6 @@ In the sample output below, note the lines marked with ➡️
 
 1. You will have to provide input for `Allow unauthenticated invocations?` (say N)
 2. Once deployment is completed you get a URL to access your agent.
-
 
 <details>
 
@@ -206,14 +204,13 @@ INFO: Restoring .env file from backup: './falcon_agent/.env.bak'.
 > [!NOTE]
 > By default the service has IAM authentication enabled for it. Please follow steps below to enable access to yourself and your team.
 
-
 1. Cloud Run - Services - select `falcon-agent-service`, by clicking the checkbox next to it.
 2. At the top click `permissions`, a pane `Permissions for falcon-agent-service` should open on the right hand side.
 3. Click `Add principal`
 4. Add the users you want to provide access to and provide them `Cloud Run Invoker` role.
 5. Wait for some time.
 
-**Accessing the service**
+#### Accessing the service
 
 1. Ask your users to run the following command (replace project id and region with the project id & region in which you have deployed the service)
 
@@ -225,7 +222,6 @@ gcloud run services proxy falcon-agent-service --project PROJECT-ID --region YOU
 
 <summary><b>Sample Output Accessing Cloud Run service through local proxy</b></summary>
 
-
 ```bash
 # You might be asked to install a component, for the proxy to work locally
 This command requires the `cloud-run-proxy` component to be installed. Would
@@ -236,9 +232,10 @@ Proxying to Cloud Run service [falcon-agent-service] in project [crowdstrike-xxx
 http://127.0.0.1:8080 proxies to https://falcon-agent-service-abc1234-uc.a.run.app
 
 ```
+
 </details>
 
-2. Now they can access the Cloud Run Service locally on `http://localhost:8080`
+1. Now they can access the Cloud Run Service locally on `http://localhost:8080`
 
 ### Deploying to Vertex AI Agent Engine and registering on Agentspace
 
@@ -318,7 +315,6 @@ INFO: Restoring .env file from backup: './falcon_agent/.env.bak'.
 
 ```
 
-
 </details>
 
 <br>
@@ -326,7 +322,6 @@ INFO: Restoring .env file from backup: './falcon_agent/.env.bak'.
 Once the agent is deployed on Agent Engine, you can register it on Agentspace to work with an Agent Engine Application.
 
 Make sure you have the Agent Engine Number from the previous step
-
 
 1. Go to the Agentspace [page](https://console.cloud.google.com/gen-app-builder/engines) in Google Cloud Console.
 2. Create an App (Type - Agentspace)
@@ -350,7 +345,6 @@ cd examples/adk/
 <details>
 
 <summary><b>Sample Output - Agentspace Registration</b></summary>
-
 
 ```bash
 INFO: Operation mode selected: 'agentspace_register'.
@@ -407,14 +401,14 @@ SUCCESS: cURL command completed successfully for AgentSpace registration.
 --- Operation 'agentspace_register' complete. ---
 
 ```
+
 </details>
 
 <br>
 
-> You can find more about Agentspace registration [here](https://cloud.google.com/agentspace/agentspace-enterprise/docs/assistant#create-assistant-existing-app).
+> You can find more about [Agentspace registration](https://cloud.google.com/agentspace/agentspace-enterprise/docs/assistant#create-assistant-existing-app).
 
 Now you can access the agent in the Agentspace application you created earlier.
-
 
 In case you want to delete the agent from the Agentspace application, use the following set of commands (replace the variables as needed).
 
@@ -439,17 +433,33 @@ https://discoveryengine.googleapis.com/v1alpha/projects/$PROJECT_ID/locations/gl
 
 
 ```
+
 </details>
 
 ### Securing access, Evaluating, Optimizing performance and costs
 
 #### Securing access
+
   1. For local runs make sure that you are not using a shared machine
   2. For Cloud Run deployment you can use - [Control access on an individual service or job](https://cloud.google.com/run/docs/securing/managing-access#control-service-or-job-access) - that is the default behavior for this deployment.
   3. For agent running in Agentspace - you can provide access (Predefined role - `Discovery Engine User`) selectively by navigating to Agentspace-Apps-Your App -Integration-Grant Permissions.
 
 #### Evaluating
+
 It is advised to evaluate the agent for the trajectory it takes and the output it produces - you can use [ADK documentation](https://google.github.io/adk-docs/evaluate/) to evaluate this agent. You can also test with different models.
 
 #### Optimizing performance and costs
+
 Various native performance improvements are already part of the codebase. You can further optimize the performance and reduce the LLM costs by controlling the value of the environment variable `MAX_PREV_USER_INTERACTIONS`. You can test how many previous conversations (instead of ALL conversations by default) work for your use case (recommended 5). You can also use the appropriate [Gemini Model](https://ai.google.dev/gemini-api/docs/models#model-variations) for both cost and performance optimizations.
+
+### FQL Guide Resources
+
+The agent is configured with `use_mcp_resources=True`, which enables ADK's MCP resource support. The falcon-mcp server exposes FQL (Falcon Query Language) guide resources (e.g., `falcon://detections/search/fql-guide`) that the agent can fetch on demand via the auto-discovered `load_mcp_resource` tool. This gives the LLM access to field names, filter syntax, and query examples — resulting in more accurate Falcon queries without needing to embed all FQL documentation in the system prompt.
+
+### Troubleshooting
+
+#### `Context variable not found: 'user_name'`
+
+Google ADK interprets `{variable_name}` patterns in agent instruction strings as template variables that must be resolved from session state. If your `FALCON_AGENT_PROMPT` contains curly braces, you will see this error when sending messages.
+
+**Fix:** Remove all curly braces from your prompt. The default prompt in `env.properties` is safe to use as-is.

--- a/examples/adk/falcon_agent/agent.py
+++ b/examples/adk/falcon_agent/agent.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Any
 
 from google.adk.agents import LlmAgent  # type: ignore[import-untyped]
 from google.adk.agents.callback_context import CallbackContext  # type: ignore[import-untyped]
@@ -18,7 +19,7 @@ tools_cache: dict[str, list[BaseTool]] = {}
 class CachedMCPToolset(MCPToolset):
     """Adds tool caching on top of MCPToolset to avoid repeated MCP server round-trips."""
 
-    def __init__(self, *, tool_set_name: str, **kwargs):
+    def __init__(self, *, tool_set_name: str, **kwargs: Any):
         super().__init__(**kwargs)
         self.tool_set_name = tool_set_name
         logging.info(f"CachedMCPToolset initialized: '{self.tool_set_name}'")

--- a/examples/adk/falcon_agent/agent.py
+++ b/examples/adk/falcon_agent/agent.py
@@ -1,139 +1,53 @@
 import logging
 import os
-import sys
-from typing import Optional, TextIO, Union
 
 from google.adk.agents import LlmAgent  # type: ignore[import-untyped]
 from google.adk.agents.callback_context import CallbackContext  # type: ignore[import-untyped]
 from google.adk.agents.readonly_context import ReadonlyContext  # type: ignore[import-untyped]
 from google.adk.models import LlmRequest, LlmResponse  # type: ignore[import-untyped]
 from google.adk.tools.base_tool import BaseTool  # type: ignore[import-untyped]
-from google.adk.tools.base_toolset import ToolPredicate  # type: ignore[import-untyped]
-from google.adk.tools.mcp_tool import MCPTool  # type: ignore[import-untyped]
 from google.adk.tools.mcp_tool.mcp_session_manager import (  # type: ignore[import-untyped]
-  SseConnectionParams,
-  StdioConnectionParams,
-  StreamableHTTPConnectionParams,
-  retry_on_closed_resource,
+    StdioConnectionParams,
 )
 from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset  # type: ignore[import-untyped]
 from mcp import StdioServerParameters
-from mcp.types import ListToolsResult
 
 tools_cache: dict[str, list[BaseTool]] = {}
 
 
-def make_tools_compatible(tools: list[BaseTool]) -> list[BaseTool]:
-  """
-  This function makes the schema compatible with Gemini/Vertex AI API
-  It is only needed when API used is Gemini and model is other than 2.5 models
-  It is however needed for ALL models when API used is VertexAI
-  """
-  for tool in tools:
-    for key in tool._mcp_tool.inputSchema.keys():
-      if key == "properties":
-          for prop_name in tool._mcp_tool.inputSchema["properties"].keys():
-            if "anyOf" in tool._mcp_tool.inputSchema["properties"][prop_name].keys():
-              if (tool._mcp_tool.inputSchema["properties"][prop_name]["anyOf"][0]["type"] == "array"):
-                tool._mcp_tool.inputSchema["properties"][prop_name]["type"] = tool._mcp_tool.inputSchema["properties"][prop_name]["anyOf"][0]["items"]["type"]
-              else:
-                 tool._mcp_tool.inputSchema["properties"][prop_name]["type"] = tool._mcp_tool.inputSchema["properties"][prop_name]["anyOf"][0]["type"]
-              tool._mcp_tool.inputSchema["properties"][prop_name].pop("anyOf")
+class CachedMCPToolset(MCPToolset):
+    """Adds tool caching on top of MCPToolset to avoid repeated MCP server round-trips."""
 
-  return tools
+    def __init__(self, *, tool_set_name: str, **kwargs):
+        super().__init__(**kwargs)
+        self.tool_set_name = tool_set_name
+        logging.info(f"CachedMCPToolset initialized: '{self.tool_set_name}'")
 
+    async def get_tools(
+        self,
+        readonly_context: ReadonlyContext | None = None,
+    ) -> list[BaseTool]:
+        if self.tool_set_name in tools_cache:
+            logging.info(f"Returning cached tools for '{self.tool_set_name}'")
+            return tools_cache[self.tool_set_name]
 
-class MCPToolSetWithSchemaAccess(MCPToolset):
-  """
-    Added to make the MCP tools schema compatible with Vertext AI API and also older Gemini models.
-    Also introduced a small performance improvement with tools caching.
-  """
+        logging.info(f"Fetching tools for '{self.tool_set_name}' from MCP server")
+        tools = await super().get_tools(readonly_context)
+        tools_cache[self.tool_set_name] = tools
+        logging.info(f"Cached {len(tools)} tools for '{self.tool_set_name}'")
+        return tools
 
-  def __init__(
-      self,
-      *,
-      tool_set_name: str, # <-- new parameter
-      connection_params: Union[
-          StdioServerParameters,
-          StdioConnectionParams,
-          SseConnectionParams,
-          StreamableHTTPConnectionParams,
-      ],
-      tool_filter: Optional[Union[ToolPredicate, list[str]]] = None,
-      errlog: TextIO = sys.stderr,
-  ):
-    super().__init__(
-        connection_params=connection_params,
-        tool_filter=tool_filter,
-        errlog=errlog
-    )
-    self.tool_set_name = tool_set_name
-    logging.info(f"MCPToolSetWithSchemaAccess initialized with tool_set_name: '{self.tool_set_name}'")
-    self._session = None
-
-  @retry_on_closed_resource
-  async def get_tools(
-      self,
-      readonly_context: Optional[ReadonlyContext] = None,
-  ) -> list[BaseTool]:
-    """Return all tools in the toolset based on the provided context.
-
-    Args:
-        readonly_context: Context used to filter tools available to the agent.
-            If None, all tools in the toolset are returned.
-
-    Returns:
-        List[BaseTool]: A list of tools available under the specified context.
-    """
-    # Get session from session manager
-    session = await self._mcp_session_manager.create_session()
-
-    if self.tool_set_name in tools_cache.keys():
-      logging.info(f"Tools found in cache for toolset {self.tool_set_name}, returning them")
-      return tools_cache[self.tool_set_name]
-    else:
-      logging.info(f"No tools found in cache for toolset {self.tool_set_name}, loading")
-
-    # Fetch available tools from the MCP server
-    tools_response: ListToolsResult = await session.list_tools()
-
-    # Apply filtering based on context and tool_filter
-    tools = []
-    for tool in tools_response.tools:
-      mcp_tool = MCPTool(
-          mcp_tool=tool,
-          mcp_session_manager=self._mcp_session_manager,
-          auth_scheme=self._auth_scheme,
-          auth_credential=self._auth_credential,
-      )
-
-      if self._is_tool_selected(mcp_tool, readonly_context):
-        tools.append(mcp_tool)
-
-    model_env = os.environ.get("GOOGLE_MODEL")
-    if model_env is None:
-      raise ValueError("GOOGLE_MODEL environment variable is not set")
-    model_version = model_env.split("-")[1]
-    vertexai_env = os.environ.get("GOOGLE_GENAI_USE_VERTEXAI")
-    if float(model_version) < 2.5 or (vertexai_env is not None and vertexai_env.upper() == "TRUE"):
-      logging.error(f"Model - {model_env} needs Gemini compatible tools, updating schema ...")
-      tools = make_tools_compatible(tools)
-    else:
-      logging.info(f"Model - {model_env} does not need updating schema")
-
-    tools_cache[self.tool_set_name] = tools
-
-    return tools
 
 # Controlling context size to improve Model response time and for cost optimization
 # https://github.com/google/adk-python/issues/752#issuecomment-2948152979
 def bmc_trim_llm_request(
     callback_context: CallbackContext, llm_request: LlmRequest
-) -> Optional[LlmResponse]:
+) -> LlmResponse | None:
+    max_prev_user_interactions = int(os.environ.get("MAX_PREV_USER_INTERACTIONS", "-1"))
 
-    max_prev_user_interactions = int(os.environ.get("MAX_PREV_USER_INTERACTIONS","-1"))
-
-    logging.info(f"Number of contents going to LLM - {len(llm_request.contents)}, MAX_PREV_USER_INTERACTIONS = {max_prev_user_interactions}")
+    logging.info(
+        f"Number of contents going to LLM - {len(llm_request.contents)}, MAX_PREV_USER_INTERACTIONS = {max_prev_user_interactions}"
+    )
 
     temp_processed_list = []
 
@@ -144,7 +58,12 @@ def bmc_trim_llm_request(
         for i in range(len(llm_request.contents) - 1, -1, -1):
             item = llm_request.contents[i]
 
-            if item.role == "user" and item.parts[0] and item.parts[0].text and item.parts[0].text != "For context:":
+            if (
+                item.role == "user"
+                and item.parts[0]
+                and item.parts[0].text
+                and item.parts[0].text != "For context:"
+            ):
                 logging.info(f"Encountered a user message => {item.parts[0].text}")
                 user_message_count += 1
 
@@ -158,9 +77,13 @@ def bmc_trim_llm_request(
         final_list = temp_processed_list[::-1]
 
         if user_message_count < max_prev_user_interactions:
-            logging.info("User message count did not reach the allowed limit. List remains unchanged.")
+            logging.info(
+                "User message count did not reach the allowed limit. List remains unchanged."
+            )
         else:
-            logging.info(f"User message count reached {max_prev_user_interactions}. List truncated.")
+            logging.info(
+                f"User message count reached {max_prev_user_interactions}. List truncated."
+            )
             llm_request.contents = final_list
 
     return None
@@ -175,21 +98,23 @@ _falcon_base_url = os.environ.get("FALCON_BASE_URL", "")
 
 root_agent = LlmAgent(
     model=_google_model,
-    name='falcon_agent',
+    name="falcon_agent",
     instruction=_falcon_agent_prompt,
+    before_model_callback=bmc_trim_llm_request,
     tools=[
-        MCPToolSetWithSchemaAccess(
-          tool_set_name="falcon-tools",
+        CachedMCPToolset(
+            tool_set_name="falcon-tools",
             connection_params=StdioConnectionParams(
-                    server_params=StdioServerParameters(
-                      command='falcon-mcp',
-                      env={
-                      "FALCON_CLIENT_ID": _falcon_client_id,
-                      "FALCON_CLIENT_SECRET": _falcon_client_secret,
-                      "FALCON_BASE_URL": _falcon_base_url,
-                      }
-                    )
-                    )
+                server_params=StdioServerParameters(
+                    command="falcon-mcp",
+                    env={
+                        "FALCON_CLIENT_ID": _falcon_client_id,
+                        "FALCON_CLIENT_SECRET": _falcon_client_secret,
+                        "FALCON_BASE_URL": _falcon_base_url,
+                    },
+                )
             ),
+            use_mcp_resources=True,
+        ),
     ],
 )

--- a/examples/adk/falcon_agent/env.properties
+++ b/examples/adk/falcon_agent/env.properties
@@ -1,12 +1,15 @@
 # General Agent Configuration
 GOOGLE_GENAI_USE_VERTEXAI=False
 GOOGLE_API_KEY=NOT_SET
-GOOGLE_MODEL=NOT_SET
+GOOGLE_MODEL=gemini-2.5-flash
 FALCON_CLIENT_ID=NOT_SET
 FALCON_CLIENT_SECRET=NOT_SET
 FALCON_BASE_URL=NOT_SET
 # Should be single line and only use single quotes.
-FALCON_AGENT_PROMPT=NOT_SET
+# WARNING: Do NOT use curly braces ({variable}) in the prompt. Google ADK interprets
+# them as context variables and will throw "Context variable not found" errors.
+# Use square brackets or plain text instead.
+FALCON_AGENT_PROMPT=You are a helpful cybersecurity analyst assistant with access to CrowdStrike Falcon. Help users investigate threats, search for detections, and manage incidents. Always explain your findings clearly and suggest next steps when appropriate.
 
 # Cloud Run Specific
 PROJECT_ID=NOT_SET

--- a/examples/adk/falcon_agent/requirements.txt
+++ b/examples/adk/falcon_agent/requirements.txt
@@ -1,5 +1,5 @@
-google-adk[eval]==1.8.0
-falcon-mcp
-google-cloud-aiplatform[agent_engines]==1.105.0
+google-adk[eval]>=1.26.0,<2.0.0
+falcon-mcp>=0.7.0,<1.0.0
+google-cloud-aiplatform[agent_engines]>=1.132.0
 cloudpickle==3.1.1
 pydantic==2.11.7


### PR DESCRIPTION
## Summary

- Replace `MCPToolSetWithSchemaAccess` with a minimal `CachedMCPToolset` that delegates to `MCPToolset`, removing manual schema patching and model version parsing logic
- Enable `use_mcp_resources=True` for FQL guide resource support
- Update dependency pins from exact versions to version ranges (`google-adk>=1.26.0,<2.0.0`, `falcon-mcp>=0.7.0,<1.0.0`)
- Add sensible defaults to `env.properties` (model, prompt with curly-brace warning)
- Remove stale "Model version parsing errors" troubleshooting section from README
- Fix markdown lint issues (emphasis-as-heading, non-descriptive link text, whitespace)
- Apply ruff formatting to `agent.py`