### PR TITLE
feat(modules): add Custom IOA behavioral rules module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [Available Modules, Tools \& Resources](#available-modules-tools--resources)
   - [Cloud Security Module](#cloud-security-module)
   - [Core Functionality (Built into Server)](#core-functionality-built-into-server)
+  - [Custom IOA Module](#custom-ioa-module)
   - [Detections Module](#detections-module)
   - [Discover Module](#discover-module)
   - [Hosts Module](#hosts-module)
@@ -84,6 +85,7 @@ The Falcon MCP Server supports different modules, each requiring specific API sc
 | - | - | - |
 | **Cloud Security** | `Falcon Container Image:read` | Find and analyze kubernetes containers inventory and container imges vulnerabilities |
 | **Core** | _No additional scopes_ | Basic connectivity and system information |
+| **Custom IOA** | `Custom IOA Rules:read`<br>`Custom IOA Rules:write` | Create and manage Custom IOA behavioral detection rules and rule groups |
 | **Detections** | `Alerts:read` | Find and analyze detections to understand malicious activity |
 | **Discover** | `Assets:read` | Search and analyze application inventory across your environment |
 | **Hosts** | `Hosts:read` | Manage and query host/device information |
@@ -133,6 +135,31 @@ The server provides core tools for interacting with the Falcon API:
 - `falcon_list_enabled_modules`: Lists enabled modules in the falcon-mcp server
     > These modules are determined by the `--modules` [flag](#module-configuration) when starting the server. If no modules are specified, all available modules are enabled.
 - `falcon_list_modules`: Lists all available modules in the falcon-mcp server
+
+### Custom IOA Module
+
+**API Scopes Required**:
+
+- `Custom IOA Rules:read`
+- `Custom IOA Rules:write`
+
+Provides tools for managing Custom IOA (Indicators of Attack) behavioral detection rules and rule groups:
+
+- `search_ioa_rule_groups`: Search Custom IOA rule groups and return full details including their rules
+- `get_ioa_platforms`: Get all available platforms for Custom IOA rule groups
+- `get_ioa_rule_types`: Get all available Custom IOA rule types with fields and disposition IDs
+- `create_ioa_rule_group`: Create a new Custom IOA rule group for a specific platform
+- `update_ioa_rule_group`: Update an existing Custom IOA rule group (name, description, enabled state)
+- `delete_ioa_rule_groups`: Delete Custom IOA rule groups by ID
+- `create_ioa_rule`: Create a new behavioral detection rule within a rule group
+- `update_ioa_rule`: Update an existing behavioral detection rule
+- `delete_ioa_rules`: Delete behavioral detection rules from a rule group
+
+**Resources**:
+
+- `falcon://custom-ioa/rule-groups/fql-guide`: FQL documentation and examples for IOA rule group searches
+
+**Use Cases**: Custom behavioral detection management, IOA rule lifecycle, platform-specific detection rules, security policy enforcement
 
 ### Detections Module
 

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -66,6 +66,18 @@ API_SCOPE_REQUIREMENTS = {
     "StartSearchV1": ["NGSIEM:write"],
     "GetSearchStatusV1": ["NGSIEM:read"],
     "StopSearchV1": ["NGSIEM:write"],
+    # Custom IOA operations
+    "query_rule_groups_full": ["Custom IOA Rules:read"],
+    "query_platformsMixin0": ["Custom IOA Rules:read"],
+    "get_platformsMixin0": ["Custom IOA Rules:read"],
+    "query_rule_types": ["Custom IOA Rules:read"],
+    "get_rule_types": ["Custom IOA Rules:read"],
+    "create_rule_groupMixin0": ["Custom IOA Rules:write"],
+    "update_rule_groupMixin0": ["Custom IOA Rules:write"],
+    "delete_rule_groupsMixin0": ["Custom IOA Rules:write"],
+    "create_rule": ["Custom IOA Rules:write"],
+    "update_rules_v2": ["Custom IOA Rules:write"],
+    "delete_rules": ["Custom IOA Rules:write"],
     # Add more mappings as needed
 }
 

--- a/falcon_mcp/modules/custom_ioa.py
+++ b/falcon_mcp/modules/custom_ioa.py
@@ -1,0 +1,618 @@
+"""
+Custom IOA module for Falcon MCP Server.
+
+This module provides tools for searching, creating, updating, and deleting
+Custom IOA (Indicators of Attack) behavioral rules and rule groups using
+Falcon Custom IOA Service Collection endpoints.
+"""
+
+from typing import Any
+
+from mcp.server import FastMCP
+from mcp.server.fastmcp.resources import TextResource
+from mcp.types import ToolAnnotations
+from pydantic import AnyUrl, Field
+
+from falcon_mcp.common.errors import _format_error_response
+from falcon_mcp.common.logging import get_logger
+from falcon_mcp.modules.base import BaseModule
+from falcon_mcp.resources.custom_ioa import SEARCH_IOA_RULE_GROUPS_FQL_DOCUMENTATION
+
+logger = get_logger(__name__)
+
+
+class CustomIOAModule(BaseModule):
+    """Module for managing Custom IOA behavioral rules and rule groups."""
+
+    def register_tools(self, server: FastMCP) -> None:
+        """Register tools with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        self._add_tool(
+            server=server,
+            method=self.search_ioa_rule_groups,
+            name="search_ioa_rule_groups",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.get_ioa_platforms,
+            name="get_ioa_platforms",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.get_ioa_rule_types,
+            name="get_ioa_rule_types",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.create_ioa_rule_group,
+            name="create_ioa_rule_group",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.update_ioa_rule_group,
+            name="update_ioa_rule_group",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.delete_ioa_rule_groups,
+            name="delete_ioa_rule_groups",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.create_ioa_rule,
+            name="create_ioa_rule",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.update_ioa_rule,
+            name="update_ioa_rule",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.delete_ioa_rules,
+            name="delete_ioa_rules",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+    def register_resources(self, server: FastMCP) -> None:
+        """Register resources with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        search_rule_groups_fql_resource = TextResource(
+            uri=AnyUrl("falcon://custom-ioa/rule-groups/fql-guide"),
+            name="falcon_search_ioa_rule_groups_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_ioa_rule_groups` tool.",
+            text=SEARCH_IOA_RULE_GROUPS_FQL_DOCUMENTATION,
+        )
+
+        self._add_resource(
+            server,
+            search_rule_groups_fql_resource,
+        )
+
+    def search_ioa_rule_groups(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter to limit rule group search results. IMPORTANT: use the `falcon://custom-ioa/rule-groups/fql-guide` resource when building this filter parameter.",
+            examples={"platform:'windows'+enabled:true", "rules.pattern_severity:'high'"},
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            le=500,
+            description="Maximum number of rule groups to return. (Max: 500)",
+        ),
+        offset: str | None = Field(
+            default=None,
+            description="Starting offset for pagination. Use the offset value from a previous response.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Sort rule groups using FQL sort syntax. Fields: created_by, created_on, enabled, modified_by, modified_on, name, description. Example: 'modified_on.desc'",
+            examples={"modified_on.desc", "name.asc"},
+        ),
+        q: str | None = Field(
+            default=None,
+            description="Free-text match query that searches across all filter string fields.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search Custom IOA rule groups and return full rule group details including their rules.
+
+        IMPORTANT: You must use the `falcon://custom-ioa/rule-groups/fql-guide` resource
+        when you need to use the `filter` parameter.
+
+        Rule groups are containers that hold behavioral detection rules. Each group is
+        associated with a specific platform (windows, mac, or linux).
+        """
+        result = self._base_search_api_call(
+            operation="query_rule_groups_full",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+                "q": q,
+            },
+            error_message="Failed to search IOA rule groups",
+        )
+
+        if self._is_error(result):
+            return self._format_fql_error_response(
+                [result], filter, SEARCH_IOA_RULE_GROUPS_FQL_DOCUMENTATION
+            )
+
+        if not result:
+            return self._format_fql_error_response(
+                [], filter, SEARCH_IOA_RULE_GROUPS_FQL_DOCUMENTATION
+            )
+
+        return result
+
+    def get_ioa_platforms(self) -> list[dict[str, Any]] | dict[str, Any]:
+        """Get all available platforms for Custom IOA rule groups.
+
+        Returns details about each available platform (e.g., windows, mac, linux).
+        Use this to discover valid platform values before creating a rule group.
+        """
+        platform_ids = self._base_search_api_call(
+            operation="query_platformsMixin0",
+            search_params={},
+            error_message="Failed to query IOA platforms",
+        )
+
+        if self._is_error(platform_ids):
+            return [platform_ids]
+
+        if not platform_ids:
+            return []
+
+        details = self._base_get_by_ids(
+            operation="get_platformsMixin0",
+            ids=platform_ids,
+            use_params=True,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        return details
+
+    def get_ioa_rule_types(
+        self,
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=500,
+            description="Maximum number of rule types to return. (Max: 500)",
+        ),
+        offset: str | None = Field(
+            default=None,
+            description="Starting offset for pagination.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Get all available Custom IOA rule types.
+
+        Returns details about each rule type including its name, platform, fields,
+        and supported disposition IDs. Use this to discover valid rule type IDs and
+        required field values before creating a behavioral rule.
+
+        Rule types define the category of behavioral detection (e.g., Process Creation,
+        Network Connection, File Creation).
+        """
+        rule_type_ids = self._base_search_api_call(
+            operation="query_rule_types",
+            search_params={
+                "limit": limit,
+                "offset": offset,
+            },
+            error_message="Failed to query IOA rule types",
+        )
+
+        if self._is_error(rule_type_ids):
+            return [rule_type_ids]
+
+        if not rule_type_ids:
+            return []
+
+        details = self._base_get_by_ids(
+            operation="get_rule_types",
+            ids=rule_type_ids,
+            use_params=True,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        return details
+
+    def create_ioa_rule_group(
+        self,
+        name: str = Field(
+            description="Name for the new rule group.",
+            examples={"Suspicious PowerShell Activity", "Lateral Movement Detection"},
+        ),
+        platform: str = Field(
+            description="Platform this rule group applies to. Allowed values: windows, mac, linux.",
+            examples={"windows", "mac", "linux"},
+        ),
+        description: str | None = Field(
+            default=None,
+            description="Optional description for the rule group.",
+        ),
+        comment: str | None = Field(
+            default=None,
+            description="Audit comment explaining why the rule group is being created.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Create a new Custom IOA rule group.
+
+        Rule groups are containers that hold behavioral detection rules for a specific
+        platform. After creating a group, use `falcon_create_ioa_rule` to add detection
+        rules to it.
+
+        Use `falcon_get_ioa_platforms` to see available platform values.
+        """
+        body: dict[str, Any] = {
+            "name": name,
+            "platform": platform,
+        }
+        if description is not None:
+            body["description"] = description
+        if comment is not None:
+            body["comment"] = comment
+
+        result = self._base_query_api_call(
+            operation="create_rule_groupMixin0",
+            body_params=body,
+            error_message="Failed to create IOA rule group",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def update_ioa_rule_group(
+        self,
+        id: str = Field(
+            description="ID of the rule group to update.",
+        ),
+        rulegroup_version: int = Field(
+            description="Current version of the rule group. Required for optimistic locking. Retrieve this from `falcon_search_ioa_rule_groups`.",
+        ),
+        name: str | None = Field(
+            default=None,
+            description="New name for the rule group.",
+        ),
+        description: str | None = Field(
+            default=None,
+            description="New description for the rule group.",
+        ),
+        enabled: bool | None = Field(
+            default=None,
+            description="Whether the rule group should be enabled or disabled.",
+        ),
+        comment: str | None = Field(
+            default=None,
+            description="Audit comment explaining why the rule group is being updated.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Update an existing Custom IOA rule group.
+
+        You can modify the name, description, and enabled state of a rule group.
+        The `rulegroup_version` is required for optimistic locking to prevent
+        concurrent modification conflicts.
+
+        Use `falcon_search_ioa_rule_groups` to retrieve the current version number.
+        """
+        body: dict[str, Any] = {
+            "id": id,
+            "rulegroup_version": rulegroup_version,
+        }
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if enabled is not None:
+            body["enabled"] = enabled
+        if comment is not None:
+            body["comment"] = comment
+
+        result = self._base_query_api_call(
+            operation="update_rule_groupMixin0",
+            body_params=body,
+            error_message="Failed to update IOA rule group",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def delete_ioa_rule_groups(
+        self,
+        ids: list[str] = Field(
+            description="IDs of the rule groups to delete.",
+        ),
+        comment: str | None = Field(
+            default=None,
+            description="Audit comment explaining why the rule groups are being deleted.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Delete Custom IOA rule groups by ID.
+
+        This permanently removes the rule groups and all rules within them.
+        Use `falcon_search_ioa_rule_groups` to find rule group IDs.
+        """
+        if not ids:
+            return [
+                _format_error_response(
+                    "`ids` must be provided to delete IOA rule groups.",
+                    operation="delete_rule_groupsMixin0",
+                )
+            ]
+
+        result = self._base_query_api_call(
+            operation="delete_rule_groupsMixin0",
+            query_params={
+                "ids": ids,
+                "comment": comment,
+            },
+            error_message="Failed to delete IOA rule groups",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def create_ioa_rule(
+        self,
+        rulegroup_id: str = Field(
+            description="ID of the rule group to add the rule to.",
+        ),
+        name: str = Field(
+            description="Name for the new rule.",
+            examples={"Block cmd.exe spawned from Office", "Detect encoded PowerShell"},
+        ),
+        ruletype_id: str = Field(
+            description="Rule type ID that defines the detection category. Use `falcon_get_ioa_rule_types` to find valid IDs.",
+        ),
+        disposition_id: int = Field(
+            description="Disposition ID that determines the action taken when the rule fires. Use `falcon_get_ioa_rule_types` to find valid disposition IDs for the rule type.",
+        ),
+        pattern_severity: str = Field(
+            description="Severity level for this rule. Allowed values: critical, high, medium, low, informational.",
+            examples={"critical", "high", "medium", "low", "informational"},
+        ),
+        field_values: list[dict[str, Any]] = Field(
+            description=(
+                "List of field value objects that define the rule's matching criteria. "
+                "Each field value object should include: 'name' (field name), 'value' (match value), "
+                "and optionally 'label', 'type', 'final_value', 'values' (list of label/value pairs). "
+                "Use `falcon_get_ioa_rule_types` to discover required fields for the chosen rule type."
+            ),
+            examples={
+                '[{"name": "GrandparentImageFilename", "value": ".*\\\\\\\\winword\\\\.exe", "label": "Grand Parent Image Filename"}]'
+            },
+        ),
+        description: str | None = Field(
+            default=None,
+            description="Optional description for the rule.",
+        ),
+        comment: str | None = Field(
+            default=None,
+            description="Audit comment explaining why this rule is being created.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Create a new Custom IOA behavioral detection rule within a rule group.
+
+        Before creating a rule:
+        1. Use `falcon_get_ioa_rule_types` to discover available rule types, their IDs,
+           required fields, and valid disposition IDs.
+        2. Use `falcon_search_ioa_rule_groups` to find the target rule group ID.
+
+        The `field_values` parameter defines the behavioral criteria the rule will match
+        against (e.g., process names, file paths, command line patterns using regex).
+        """
+        body: dict[str, Any] = {
+            "rulegroup_id": rulegroup_id,
+            "name": name,
+            "ruletype_id": ruletype_id,
+            "disposition_id": disposition_id,
+            "pattern_severity": pattern_severity,
+            "field_values": field_values,
+        }
+        if description is not None:
+            body["description"] = description
+        if comment is not None:
+            body["comment"] = comment
+
+        result = self._base_query_api_call(
+            operation="create_rule",
+            body_params=body,
+            error_message="Failed to create IOA rule",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def update_ioa_rule(
+        self,
+        rulegroup_id: str = Field(
+            description="ID of the rule group containing the rule.",
+        ),
+        rulegroup_version: int = Field(
+            description="Current version of the rule group. Required for optimistic locking. Retrieve from `falcon_search_ioa_rule_groups`.",
+        ),
+        instance_id: str = Field(
+            description="Instance ID of the rule to update. Retrieve from `falcon_search_ioa_rule_groups`.",
+        ),
+        name: str | None = Field(
+            default=None,
+            description="New name for the rule.",
+        ),
+        description: str | None = Field(
+            default=None,
+            description="New description for the rule.",
+        ),
+        enabled: bool | None = Field(
+            default=None,
+            description="Whether the rule should be enabled or disabled.",
+        ),
+        pattern_severity: str | None = Field(
+            default=None,
+            description="New severity level. Allowed values: critical, high, medium, low, informational.",
+        ),
+        disposition_id: int | None = Field(
+            default=None,
+            description="New disposition ID for the action taken when the rule fires.",
+        ),
+        field_values: list[dict[str, Any]] | None = Field(
+            default=None,
+            description="Updated field value objects that define the rule's matching criteria.",
+        ),
+        comment: str | None = Field(
+            default=None,
+            description="Audit comment explaining why the rule is being updated.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Update an existing Custom IOA behavioral detection rule.
+
+        The `rulegroup_version` is required for optimistic locking to prevent
+        concurrent modification conflicts. Use `falcon_search_ioa_rule_groups` to
+        retrieve the current version and instance ID.
+        """
+        rule_update: dict[str, Any] = {
+            "instance_id": instance_id,
+            "rulegroup_version": rulegroup_version,
+        }
+        if name is not None:
+            rule_update["name"] = name
+        if description is not None:
+            rule_update["description"] = description
+        if enabled is not None:
+            rule_update["enabled"] = enabled
+        if pattern_severity is not None:
+            rule_update["pattern_severity"] = pattern_severity
+        if disposition_id is not None:
+            rule_update["disposition_id"] = disposition_id
+        if field_values is not None:
+            rule_update["field_values"] = field_values
+
+        body: dict[str, Any] = {
+            "rulegroup_id": rulegroup_id,
+            "rulegroup_version": rulegroup_version,
+            "rule_updates": [rule_update],
+        }
+        if comment is not None:
+            body["comment"] = comment
+
+        result = self._base_query_api_call(
+            operation="update_rules_v2",
+            body_params=body,
+            error_message="Failed to update IOA rule",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def delete_ioa_rules(
+        self,
+        rule_group_id: str = Field(
+            description="ID of the rule group containing the rules to delete.",
+        ),
+        ids: list[str] = Field(
+            description="IDs of the rules to delete. Retrieve from `falcon_search_ioa_rule_groups`.",
+        ),
+        comment: str | None = Field(
+            default=None,
+            description="Audit comment explaining why the rules are being deleted.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Delete Custom IOA behavioral detection rules from a rule group.
+
+        Use `falcon_search_ioa_rule_groups` to find the rule group ID and
+        the individual rule IDs (instance IDs) to delete.
+        """
+        if not ids:
+            return [
+                _format_error_response(
+                    "`ids` must be provided to delete IOA rules.",
+                    operation="delete_rules",
+                )
+            ]
+
+        result = self._base_query_api_call(
+            operation="delete_rules",
+            query_params={
+                "rule_group_id": rule_group_id,
+                "ids": ids,
+                "comment": comment,
+            },
+            error_message="Failed to delete IOA rules",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result

--- a/falcon_mcp/resources/custom_ioa.py
+++ b/falcon_mcp/resources/custom_ioa.py
@@ -1,0 +1,129 @@
+"""
+Contains Custom IOA resources.
+"""
+
+from falcon_mcp.common.utils import generate_md_table
+
+SEARCH_IOA_RULE_GROUPS_FQL_FILTERS = [
+    (
+        "Field",
+        "Type",
+        "Description",
+    ),
+    (
+        "enabled",
+        "Boolean",
+        "Whether the rule group is enabled. Example: enabled:true",
+    ),
+    (
+        "platform",
+        "String",
+        "Platform for the rule group. Allowed values: windows, mac, linux. Example: platform:'windows'",
+    ),
+    (
+        "name",
+        "String",
+        "Name of the rule group. Example: name:'Suspicious Process Creation'",
+    ),
+    (
+        "description",
+        "String",
+        "Description of the rule group. Example: description:'*lateral movement*'",
+    ),
+    (
+        "rules.action_label",
+        "String",
+        "Action label for rules within the group. Example: rules.action_label:'Detect'",
+    ),
+    (
+        "rules.name",
+        "String",
+        "Name of rules within the group. Example: rules.name:'Block cmd.exe'",
+    ),
+    (
+        "rules.description",
+        "String",
+        "Description of rules within the group.",
+    ),
+    (
+        "rules.pattern_severity",
+        "String",
+        "Severity of rules. Allowed values: critical, high, medium, low, informational. Example: rules.pattern_severity:'high'",
+    ),
+    (
+        "rules.ruletype_name",
+        "String",
+        "Rule type name for rules. Example: rules.ruletype_name:'Process Creation'",
+    ),
+    (
+        "rules.enabled",
+        "Boolean",
+        "Whether rules in the group are enabled. Example: rules.enabled:true",
+    ),
+    (
+        "created_on",
+        "Timestamp",
+        "Creation timestamp. Example: created_on:>'2024-01-01T00:00:00Z'",
+    ),
+    (
+        "modified_on",
+        "Timestamp",
+        "Last modification timestamp. Example: modified_on:>'2024-06-01T00:00:00Z'",
+    ),
+]
+
+_SORT_FIELDS = """
+**Sort fields:** created_by, created_on, enabled, modified_by, modified_on, name, description
+
+**Sort formats:** `field.asc`, `field.desc`, `field|asc`, `field|desc`
+
+**Example:** `modified_on.desc`
+"""
+
+_FQL_OPERATORS = """
+**FQL Operators:**
+- Equality: `field:'value'`
+- Wildcard: `field:*'partial*'`
+- Range: `field:>'value'`, `field:<'value'`
+- Boolean: `field:true` or `field:false`
+- AND: `+` (e.g., `platform:'windows'+enabled:true`)
+- OR: `,` (e.g., `platform:'windows',platform:'mac'`)
+"""
+
+SEARCH_IOA_RULE_GROUPS_FQL_DOCUMENTATION = f"""
+# Custom IOA Rule Groups FQL Filter Guide
+
+Use FQL (Falcon Query Language) to filter rule groups returned by `falcon_search_ioa_rule_groups`.
+
+## Filter Fields
+
+{generate_md_table(SEARCH_IOA_RULE_GROUPS_FQL_FILTERS)}
+
+## Operators & Syntax
+{_FQL_OPERATORS}
+
+## Sort Options
+{_SORT_FIELDS}
+
+## Examples
+
+Search for enabled Windows rule groups:
+```
+platform:'windows'+enabled:true
+```
+
+Search for rule groups with high-severity rules:
+```
+rules.pattern_severity:'high'
+```
+
+Search for rule groups modified recently:
+```
+modified_on:>'2024-01-01T00:00:00Z'
+```
+
+Search for rule groups by name pattern:
+```
+name:*'Suspicious*'
+```
+"""

--- a/tests/integration/test_custom_ioa.py
+++ b/tests/integration/test_custom_ioa.py
@@ -1,0 +1,220 @@
+"""Integration tests for the Custom IOA module."""
+
+import warnings
+
+import pytest
+
+from falcon_mcp.modules.custom_ioa import CustomIOAModule
+from tests.integration.utils.base_integration_test import (
+    BaseIntegrationTest,
+    resolve_field_defaults,
+)
+
+
+@pytest.mark.integration
+class TestCustomIOAIntegration(BaseIntegrationTest):
+    """Integration tests for Custom IOA module with real API calls.
+
+    Validates:
+    - Correct FalconPy operation names (query_rule_groups_full, query_platformsMixin0,
+      get_platformsMixin0, query_rule_types, get_rule_types, create_rule_groupMixin0,
+      delete_rule_groupsMixin0)
+    - Two-step search pattern returns full details, not just IDs
+    - Full CRUD lifecycle for rule groups
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_module(self, falcon_client):
+        """Set up the Custom IOA module with a real client."""
+        self.module = CustomIOAModule(falcon_client)
+
+    @pytest.fixture(autouse=True, scope="class")
+    def create_test_rule_group(self, falcon_client):
+        """Create a test rule group for the class and clean up after all tests.
+
+        Creates a linux rule group with a clearly identifiable name for
+        easy identification and filter-based searching.
+        """
+        module = CustomIOAModule(falcon_client)
+
+        # Create test rule group
+        create_kwargs = resolve_field_defaults(module.create_ioa_rule_group, {
+            "name": "falcon-mcp-integration-test",
+            "platform": "linux",
+            "description": "Integration test rule group - safe to delete",
+            "comment": "Created by falcon-mcp integration tests",
+        })
+        result = module.create_ioa_rule_group(**create_kwargs)
+
+        # Validate creation succeeded
+        if isinstance(result, list) and len(result) > 0:
+            first = result[0]
+            if isinstance(first, dict) and "error" in first:
+                pytest.skip(
+                    f"Cannot create test rule group (check Custom IOA Rules:write scope): {first}"
+                )
+            if isinstance(first, dict) and "id" in first:
+                self.__class__._test_rule_group = first
+                self.__class__._test_rule_group_id = first["id"]
+            else:
+                pytest.skip(f"Unexpected create response shape: {result}")
+        else:
+            pytest.skip(f"Unexpected create response: {result}")
+
+        yield
+
+        # Teardown: delete the test rule group
+        try:
+            delete_kwargs = resolve_field_defaults(module.delete_ioa_rule_groups, {
+                "ids": [self.__class__._test_rule_group_id],
+                "comment": "Integration test cleanup",
+            })
+            module.delete_ioa_rule_groups(**delete_kwargs)
+        except Exception as e:
+            warnings.warn(
+                f"Failed to clean up test rule group {self.__class__._test_rule_group_id}: {e}",
+                stacklevel=2,
+            )
+
+    # ── Read-only tests ──────────────────────────────────────────────
+
+    def test_search_ioa_rule_groups(self):
+        """Test basic search returns results without errors."""
+        result = self.call_method(self.module.search_ioa_rule_groups, limit=5)
+        self.assert_no_error(result, context="search_ioa_rule_groups")
+        self.assert_valid_list_response(result, min_length=0, context="search_ioa_rule_groups")
+
+    def test_search_returns_full_details(self):
+        """Test that search returns full rule group details, not just IDs.
+
+        Validates the two-step search pattern returns objects with
+        expected fields including nested rules.
+        """
+        result = self.call_method(self.module.search_ioa_rule_groups, limit=5)
+
+        self.assert_no_error(result, context="search_returns_full_details")
+        self.assert_valid_list_response(result, min_length=0, context="search_returns_full_details")
+
+        if len(result) > 0:
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["id", "name", "platform", "enabled", "rules"],
+                context="search_returns_full_details",
+            )
+
+    def test_search_with_filter(self):
+        """Test search with FQL filter targeting the test rule group."""
+        result = self.call_method(
+            self.module.search_ioa_rule_groups,
+            filter="name:'falcon-mcp-integration-test'",
+            limit=5,
+        )
+
+        self.assert_no_error(result, context="search with filter")
+        self.assert_valid_list_response(result, min_length=0, context="search with filter")
+
+    def test_get_ioa_platforms(self):
+        """Test that get_ioa_platforms returns results with expected structure."""
+        result = self.call_method(self.module.get_ioa_platforms)
+
+        self.assert_no_error(result, context="get_ioa_platforms")
+        self.assert_valid_list_response(result, min_length=1, context="get_ioa_platforms")
+
+        if len(result) > 0:
+            first = result[0]
+            assert isinstance(first, dict), (
+                f"Expected dict for platform, got {type(first)}"
+            )
+
+    def test_get_ioa_rule_types(self):
+        """Test that get_ioa_rule_types returns results with expected structure."""
+        result = self.call_method(self.module.get_ioa_rule_types, limit=5)
+
+        self.assert_no_error(result, context="get_ioa_rule_types")
+        self.assert_valid_list_response(result, min_length=1, context="get_ioa_rule_types")
+
+        if len(result) > 0:
+            first = result[0]
+            assert isinstance(first, dict), (
+                f"Expected dict for rule type, got {type(first)}"
+            )
+
+    # ── Write tests (using shared fixture) ───────────────────────────
+
+    def test_create_rule_group_response_shape(self):
+        """Test that the create response from the fixture has expected fields."""
+        test_group = self.__class__._test_rule_group
+
+        assert isinstance(test_group, dict), (
+            f"Expected dict for created rule group, got {type(test_group)}"
+        )
+
+        for field in ["id", "name", "platform", "enabled", "rules"]:
+            assert field in test_group, (
+                f"Expected '{field}' in created rule group. "
+                f"Available fields: {list(test_group.keys())}"
+            )
+
+        assert test_group["name"] == "falcon-mcp-integration-test", (
+            f"Expected name 'falcon-mcp-integration-test', got '{test_group['name']}'"
+        )
+        assert test_group["platform"] == "linux", (
+            f"Expected platform 'linux', got '{test_group['platform']}'"
+        )
+
+    def test_search_finds_created_group(self):
+        """Round-trip: verify the created rule group is findable via search."""
+        result = self.call_method(
+            self.module.search_ioa_rule_groups,
+            filter="name:'falcon-mcp-integration-test'",
+            limit=10,
+        )
+
+        self.assert_no_error(result, context="round-trip search")
+        self.assert_valid_list_response(result, min_length=1, context="round-trip search")
+
+        found_ids = [
+            item.get("id") for item in result if isinstance(item, dict)
+        ]
+        assert self.__class__._test_rule_group_id in found_ids, (
+            f"Created rule group {self.__class__._test_rule_group_id} not found in search results. "
+            f"Found IDs: {found_ids}"
+        )
+
+    # ── Delete test (disposable object) ──────────────────────────────
+
+    def test_delete_rule_group(self):
+        """Test delete by creating a separate disposable rule group.
+
+        Creates a separate rule group (not the shared fixture), deletes it,
+        and verifies the delete response has no errors.
+        """
+        # Create a disposable rule group
+        create_result = self.call_method(
+            self.module.create_ioa_rule_group,
+            name="falcon-mcp-delete-test",
+            platform="linux",
+            description="Disposable rule group for delete test",
+            comment="Integration test delete verification",
+        )
+
+        self.assert_no_error(create_result, context="create disposable rule group")
+        self.assert_valid_list_response(
+            create_result, min_length=1, context="create disposable rule group"
+        )
+
+        disposable_id = self.get_first_id(create_result, id_field="id")
+        if not disposable_id:
+            self.skip_with_warning(
+                "Could not extract ID from created rule group",
+                context="test_delete_rule_group",
+            )
+
+        # Delete it
+        delete_result = self.call_method(
+            self.module.delete_ioa_rule_groups,
+            ids=[disposable_id],
+            comment="Integration test delete verification",
+        )
+
+        self.assert_no_error(delete_result, context="delete_ioa_rule_groups")

--- a/tests/modules/test_custom_ioa.py
+++ b/tests/modules/test_custom_ioa.py
@@ -1,0 +1,768 @@
+"""
+Tests for the Custom IOA module.
+"""
+
+import unittest
+
+from mcp.types import ToolAnnotations
+
+from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
+from falcon_mcp.modules.custom_ioa import CustomIOAModule
+from tests.modules.utils.test_modules import TestModules
+
+
+class TestCustomIOAModule(TestModules):
+    """Test cases for the Custom IOA module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(CustomIOAModule)
+
+    def test_register_tools(self):
+        """Test registering tools with the server."""
+        expected_tools = [
+            "falcon_search_ioa_rule_groups",
+            "falcon_get_ioa_platforms",
+            "falcon_get_ioa_rule_types",
+            "falcon_create_ioa_rule_group",
+            "falcon_update_ioa_rule_group",
+            "falcon_delete_ioa_rule_groups",
+            "falcon_create_ioa_rule",
+            "falcon_update_ioa_rule",
+            "falcon_delete_ioa_rules",
+        ]
+        self.assert_tools_registered(expected_tools)
+
+    def test_register_resources(self):
+        """Test registering resources with the server."""
+        expected_resources = [
+            "falcon_search_ioa_rule_groups_fql_guide",
+        ]
+        self.assert_resources_registered(expected_resources)
+
+    # --- search_ioa_rule_groups ---
+
+    def test_search_ioa_rule_groups_success(self):
+        """Test searching rule groups returns full group data."""
+        rule_groups = [
+            {
+                "id": "rg-001",
+                "name": "Windows Rules",
+                "platform": "windows",
+                "enabled": True,
+                "version": 1,
+                "rules": [],
+            },
+            {
+                "id": "rg-002",
+                "name": "Mac Rules",
+                "platform": "mac",
+                "enabled": True,
+                "version": 2,
+                "rules": [],
+            },
+        ]
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": rule_groups},
+        }
+
+        result = self.module.search_ioa_rule_groups(
+            filter="platform:'windows'",
+            limit=25,
+            offset=None,
+            sort=None,
+            q=None,
+        )
+
+        self.mock_client.command.assert_called_once()
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "query_rule_groups_full")
+        self.assertEqual(call_args[1]["parameters"]["filter"], "platform:'windows'")
+        self.assertEqual(call_args[1]["parameters"]["limit"], 25)
+        self.assertNotIn("offset", call_args[1]["parameters"])
+        self.assertNotIn("sort", call_args[1]["parameters"])
+        self.assertNotIn("q", call_args[1]["parameters"])
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "rg-001")
+
+    def test_search_ioa_rule_groups_empty_returns_fql_guide(self):
+        """Test that empty results return FQL guide context."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.search_ioa_rule_groups(filter="name:'nonexistent'")
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+        self.assertIn("fql_guide", result)
+        self.assertIn("No results matched", result["hint"])
+
+    def test_search_ioa_rule_groups_error_returns_fql_guide(self):
+        """Test that errors return FQL guide context."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid filter syntax"}]},
+        }
+
+        result = self.module.search_ioa_rule_groups(filter="bad filter syntax")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("error", result["results"][0])
+        self.assertIn("fql_guide", result)
+        self.assertIn("Filter error", result["hint"])
+
+    def test_search_ioa_rule_groups_no_filter(self):
+        """Test searching without filter omits filter param."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "rg-001"}]},
+        }
+
+        self.module.search_ioa_rule_groups(
+            filter=None,
+            offset=None,
+            sort=None,
+            q=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertNotIn("filter", call_args[1]["parameters"])
+
+    # --- get_ioa_platforms ---
+
+    def test_get_ioa_platforms_success(self):
+        """Test getting available platforms returns platform details."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["windows", "mac", "linux"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "windows", "name": "Windows"},
+                    {"id": "mac", "name": "Mac"},
+                    {"id": "linux", "name": "Linux"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.get_ioa_platforms()
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+        first_call = self.mock_client.command.call_args_list[0]
+        second_call = self.mock_client.command.call_args_list[1]
+        self.assertEqual(first_call[0][0], "query_platformsMixin0")
+        self.assertEqual(second_call[0][0], "get_platformsMixin0")
+        self.assertEqual(len(result), 3)
+
+    def test_get_ioa_platforms_empty(self):
+        """Test getting platforms when none available returns empty list."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.get_ioa_platforms()
+
+        self.mock_client.command.assert_called_once()
+        self.assertEqual(result, [])
+
+    def test_get_ioa_platforms_query_error(self):
+        """Test that query errors are surfaced correctly."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied"}]},
+        }
+
+        result = self.module.get_ioa_platforms()
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    # --- get_ioa_rule_types ---
+
+    def test_get_ioa_rule_types_success(self):
+        """Test getting rule types returns type details."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["rt-001", "rt-002"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "rt-001", "name": "Process Creation", "platform": "windows"},
+                    {"id": "rt-002", "name": "Network Connection", "platform": "windows"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.get_ioa_rule_types(limit=50)
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+        first_call = self.mock_client.command.call_args_list[0]
+        second_call = self.mock_client.command.call_args_list[1]
+        self.assertEqual(first_call[0][0], "query_rule_types")
+        self.assertEqual(first_call[1]["parameters"]["limit"], 50)
+        self.assertEqual(second_call[0][0], "get_rule_types")
+        self.assertEqual(len(result), 2)
+
+    def test_get_ioa_rule_types_empty(self):
+        """Test getting rule types when none exist returns empty list."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.get_ioa_rule_types()
+
+        self.mock_client.command.assert_called_once()
+        self.assertEqual(result, [])
+
+    # --- create_ioa_rule_group ---
+
+    def test_create_ioa_rule_group_success(self):
+        """Test creating a rule group with all fields."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{"id": "rg-001", "name": "Windows IOA Rules", "platform": "windows"}]
+            },
+        }
+
+        result = self.module.create_ioa_rule_group(
+            name="Windows IOA Rules",
+            platform="windows",
+            description="Rules for detecting suspicious Windows activity",
+            comment="Created for testing",
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "create_rule_groupMixin0",
+            body={
+                "name": "Windows IOA Rules",
+                "platform": "windows",
+                "description": "Rules for detecting suspicious Windows activity",
+                "comment": "Created for testing",
+            },
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "rg-001")
+
+    def test_create_ioa_rule_group_minimal(self):
+        """Test creating a rule group with only required fields."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "rg-002", "name": "Mac Rules", "platform": "mac"}]},
+        }
+
+        result = self.module.create_ioa_rule_group(
+            name="Mac Rules",
+            platform="mac",
+            description=None,
+            comment=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["body"]["name"], "Mac Rules")
+        self.assertEqual(call_args[1]["body"]["platform"], "mac")
+        self.assertNotIn("description", call_args[1]["body"])
+        self.assertNotIn("comment", call_args[1]["body"])
+        self.assertEqual(len(result), 1)
+
+    def test_create_ioa_rule_group_error(self):
+        """Test create rule group error is returned correctly."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid platform"}]},
+        }
+
+        result = self.module.create_ioa_rule_group(
+            name="Test Group",
+            platform="invalid_platform",
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    # --- update_ioa_rule_group ---
+
+    def test_update_ioa_rule_group_enable(self):
+        """Test enabling a rule group."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "rg-001", "enabled": True}]},
+        }
+
+        result = self.module.update_ioa_rule_group(
+            id="rg-001",
+            rulegroup_version=3,
+            name=None,
+            description=None,
+            enabled=True,
+            comment="Enabling for production",
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "update_rule_groupMixin0")
+        self.assertEqual(call_args[1]["body"]["id"], "rg-001")
+        self.assertEqual(call_args[1]["body"]["rulegroup_version"], 3)
+        self.assertEqual(call_args[1]["body"]["enabled"], True)
+        self.assertEqual(call_args[1]["body"]["comment"], "Enabling for production")
+        self.assertNotIn("name", call_args[1]["body"])
+        self.assertEqual(len(result), 1)
+
+    def test_update_ioa_rule_group_rename(self):
+        """Test renaming a rule group."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "rg-001", "name": "New Name"}]},
+        }
+
+        result = self.module.update_ioa_rule_group(
+            id="rg-001",
+            rulegroup_version=2,
+            name="New Name",
+            description=None,
+            enabled=None,
+            comment=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["body"]["name"], "New Name")
+        self.assertNotIn("enabled", call_args[1]["body"])
+        self.assertEqual(len(result), 1)
+
+    # --- delete_ioa_rule_groups ---
+
+    def test_delete_ioa_rule_groups_success(self):
+        """Test deleting rule groups by IDs."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "rg-001"}]},
+        }
+
+        result = self.module.delete_ioa_rule_groups(
+            ids=["rg-001"],
+            comment="Cleanup",
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "delete_rule_groupsMixin0",
+            parameters={"ids": ["rg-001"], "comment": "Cleanup"},
+        )
+        self.assertEqual(len(result), 1)
+
+    def test_delete_ioa_rule_groups_multiple(self):
+        """Test deleting multiple rule groups."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "rg-001"}, {"id": "rg-002"}]},
+        }
+
+        result = self.module.delete_ioa_rule_groups(
+            ids=["rg-001", "rg-002"],
+            comment=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["parameters"]["ids"], ["rg-001", "rg-002"])
+        self.assertNotIn("comment", call_args[1]["parameters"])
+        self.assertEqual(len(result), 2)
+
+    def test_delete_ioa_rule_groups_validation_error(self):
+        """Test delete requires at least one ID."""
+        result = self.module.delete_ioa_rule_groups(ids=[])
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+        self.mock_client.command.assert_not_called()
+
+    # --- create_ioa_rule ---
+
+    def test_create_ioa_rule_success(self):
+        """Test creating a behavioral rule within a rule group."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "instance_id": "rule-001",
+                        "name": "Block cmd.exe from Office",
+                        "rulegroup_id": "rg-001",
+                    }
+                ]
+            },
+        }
+
+        field_values = [
+            {
+                "name": "GrandparentImageFilename",
+                "value": ".*\\\\winword\\.exe",
+                "label": "Grand Parent Image Filename",
+            }
+        ]
+
+        result = self.module.create_ioa_rule(
+            rulegroup_id="rg-001",
+            name="Block cmd.exe from Office",
+            ruletype_id="rt-001",
+            disposition_id=10,
+            pattern_severity="high",
+            field_values=field_values,
+            description="Detects cmd.exe spawned from Office applications",
+            comment="New rule for lateral movement detection",
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "create_rule",
+            body={
+                "rulegroup_id": "rg-001",
+                "name": "Block cmd.exe from Office",
+                "ruletype_id": "rt-001",
+                "disposition_id": 10,
+                "pattern_severity": "high",
+                "field_values": field_values,
+                "description": "Detects cmd.exe spawned from Office applications",
+                "comment": "New rule for lateral movement detection",
+            },
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["instance_id"], "rule-001")
+
+    def test_create_ioa_rule_minimal(self):
+        """Test creating a rule with only required fields."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"instance_id": "rule-002"}]},
+        }
+
+        result = self.module.create_ioa_rule(
+            rulegroup_id="rg-001",
+            name="Test Rule",
+            ruletype_id="rt-001",
+            disposition_id=20,
+            pattern_severity="medium",
+            field_values=[],
+            description=None,
+            comment=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertNotIn("description", call_args[1]["body"])
+        self.assertNotIn("comment", call_args[1]["body"])
+        self.assertEqual(len(result), 1)
+
+    def test_create_ioa_rule_error(self):
+        """Test create rule error is returned."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid ruletype_id"}]},
+        }
+
+        result = self.module.create_ioa_rule(
+            rulegroup_id="rg-001",
+            name="Bad Rule",
+            ruletype_id="invalid-id",
+            disposition_id=10,
+            pattern_severity="high",
+            field_values=[],
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    # --- update_ioa_rule ---
+
+    def test_update_ioa_rule_enable(self):
+        """Test enabling a rule."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"instance_id": "rule-001", "enabled": True}]},
+        }
+
+        result = self.module.update_ioa_rule(
+            rulegroup_id="rg-001",
+            rulegroup_version=5,
+            instance_id="rule-001",
+            enabled=True,
+            comment="Enabling rule",
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "update_rules_v2")
+        body = call_args[1]["body"]
+        self.assertEqual(body["rulegroup_id"], "rg-001")
+        self.assertEqual(body["rulegroup_version"], 5)
+        self.assertEqual(body["comment"], "Enabling rule")
+        self.assertEqual(len(body["rule_updates"]), 1)
+        self.assertEqual(body["rule_updates"][0]["instance_id"], "rule-001")
+        self.assertEqual(body["rule_updates"][0]["enabled"], True)
+        self.assertEqual(len(result), 1)
+
+    def test_update_ioa_rule_change_severity(self):
+        """Test changing a rule's severity."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"instance_id": "rule-001", "pattern_severity": "critical"}]},
+        }
+
+        result = self.module.update_ioa_rule(
+            rulegroup_id="rg-001",
+            rulegroup_version=3,
+            instance_id="rule-001",
+            name=None,
+            description=None,
+            enabled=None,
+            pattern_severity="critical",
+            disposition_id=None,
+            field_values=None,
+            comment=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        rule_update = call_args[1]["body"]["rule_updates"][0]
+        self.assertEqual(rule_update["pattern_severity"], "critical")
+        self.assertNotIn("enabled", rule_update)
+        self.assertNotIn("name", rule_update)
+        self.assertEqual(len(result), 1)
+
+    def test_update_ioa_rule_with_field_values(self):
+        """Test updating a rule's field values."""
+        new_field_values = [{"name": "ImageFilename", "value": ".*\\\\malware\\.exe"}]
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"instance_id": "rule-001"}]},
+        }
+
+        self.module.update_ioa_rule(
+            rulegroup_id="rg-001",
+            rulegroup_version=2,
+            instance_id="rule-001",
+            field_values=new_field_values,
+        )
+
+        call_args = self.mock_client.command.call_args
+        rule_update = call_args[1]["body"]["rule_updates"][0]
+        self.assertEqual(rule_update["field_values"], new_field_values)
+
+    # --- delete_ioa_rules ---
+
+    def test_delete_ioa_rules_success(self):
+        """Test deleting rules from a rule group."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "rule-001"}]},
+        }
+
+        result = self.module.delete_ioa_rules(
+            rule_group_id="rg-001",
+            ids=["rule-001"],
+            comment="Cleanup old rule",
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "delete_rules",
+            parameters={
+                "rule_group_id": "rg-001",
+                "ids": ["rule-001"],
+                "comment": "Cleanup old rule",
+            },
+        )
+        self.assertEqual(len(result), 1)
+
+    def test_delete_ioa_rules_multiple(self):
+        """Test deleting multiple rules."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "rule-001"}, {"id": "rule-002"}]},
+        }
+
+        result = self.module.delete_ioa_rules(
+            rule_group_id="rg-001",
+            ids=["rule-001", "rule-002"],
+            comment=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["parameters"]["ids"], ["rule-001", "rule-002"])
+        self.assertNotIn("comment", call_args[1]["parameters"])
+        self.assertEqual(len(result), 2)
+
+    def test_delete_ioa_rules_validation_error(self):
+        """Test delete rules requires at least one ID."""
+        result = self.module.delete_ioa_rules(
+            rule_group_id="rg-001",
+            ids=[],
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+        self.mock_client.command.assert_not_called()
+
+    # --- Tool annotation tests ---
+
+    def test_search_ioa_rule_groups_has_read_only_annotations(self):
+        """Test that search_ioa_rule_groups is registered with read-only annotations."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_search_ioa_rule_groups", READ_ONLY_ANNOTATIONS)
+
+    def test_get_ioa_platforms_has_read_only_annotations(self):
+        """Test that get_ioa_platforms is registered with read-only annotations."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_get_ioa_platforms", READ_ONLY_ANNOTATIONS)
+
+    def test_get_ioa_rule_types_has_read_only_annotations(self):
+        """Test that get_ioa_rule_types is registered with read-only annotations."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_get_ioa_rule_types", READ_ONLY_ANNOTATIONS)
+
+    def test_create_ioa_rule_group_has_mutating_annotations(self):
+        """Test that create_ioa_rule_group is registered with non-destructive write annotations."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations(
+            "falcon_create_ioa_rule_group",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+    def test_update_ioa_rule_group_has_mutating_annotations(self):
+        """Test that update_ioa_rule_group is registered with non-destructive idempotent annotations."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations(
+            "falcon_update_ioa_rule_group",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+    def test_delete_ioa_rule_groups_has_destructive_annotations(self):
+        """Test that delete_ioa_rule_groups is registered with destructive annotations."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations(
+            "falcon_delete_ioa_rule_groups",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+    def test_create_ioa_rule_has_mutating_annotations(self):
+        """Test that create_ioa_rule is registered with non-destructive write annotations."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations(
+            "falcon_create_ioa_rule",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+    def test_update_ioa_rule_has_mutating_annotations(self):
+        """Test that update_ioa_rule is registered with idempotent write annotations."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations(
+            "falcon_update_ioa_rule",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+    def test_delete_ioa_rules_has_destructive_annotations(self):
+        """Test that delete_ioa_rules is registered with destructive annotations."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations(
+            "falcon_delete_ioa_rules",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+    # --- Permission / error handling tests ---
+
+    def test_search_rule_groups_permission_error(self):
+        """Test that permission errors are surfaced correctly."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied"}]},
+        }
+
+        result = self.module.search_ioa_rule_groups()
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("error", result["results"][0])
+
+    def test_create_rule_group_permission_error(self):
+        """Test create rule group 403 error is surfaced."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied"}]},
+        }
+
+        result = self.module.create_ioa_rule_group(
+            name="Test",
+            platform="windows",
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    def test_create_rule_permission_error(self):
+        """Test create rule 403 error is surfaced."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied"}]},
+        }
+
+        result = self.module.create_ioa_rule(
+            rulegroup_id="rg-001",
+            name="Test Rule",
+            ruletype_id="rt-001",
+            disposition_id=10,
+            pattern_severity="high",
+            field_values=[],
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    def test_delete_rule_groups_permission_error(self):
+        """Test delete rule groups 403 error is surfaced."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied"}]},
+        }
+
+        result = self.module.delete_ioa_rule_groups(ids=["rg-001"])
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a new `CustomIOAModule` with **9 MCP tools** for managing CrowdStrike Custom Indicators of Attack (IOA) behavioral detection rules
- Adds an FQL documentation resource for the `falcon_search_ioa_rule_groups` filter parameter
- Adds 11 Custom IOA Rules API scope mappings in `api_scopes.py`
- Adds 41 unit tests covering all tools, annotations, error paths, and edge cases

## Tools added

**Read-only:**
- `falcon_search_ioa_rule_groups` — FQL-filtered search returning full rule group + embedded rules in a single call (uses `query_rule_groups_full`)
- `falcon_get_ioa_platforms` — Discover available platforms (windows/mac/linux)
- `falcon_get_ioa_rule_types` — Discover rule types with their fields and valid disposition IDs

**Write:**
- `falcon_create_ioa_rule_group` — Create a new rule group for a given platform
- `falcon_update_ioa_rule_group` — Enable/disable/rename a rule group (requires `rulegroup_version` for optimistic locking)
- `falcon_delete_ioa_rule_groups` — Delete rule groups by ID
- `falcon_create_ioa_rule` — Create a behavioral detection rule within a group
- `falcon_update_ioa_rule` — Update rule severity, enabled state, or field values
- `falcon_delete_ioa_rules` — Delete specific rules from a rule group

## Required API scopes

- `Custom IOA Rules:read`
- `Custom IOA Rules:write`

## Testing

**Tested against a real CrowdStrike environment** — all read and write operations were verified end-to-end:

- `falcon_get_ioa_platforms` and `falcon_get_ioa_rule_types` confirmed returning correct platform and rule type data
- `falcon_search_ioa_rule_groups` confirmed returning existing rule groups with embedded rules in a single API call
- `falcon_create_ioa_rule_group` used to create a new `Credential Access Detection` group (mac, platform)
- `falcon_create_ioa_rule` used to create a Process Creation rule detecting execution from `~/.config/gcloud/*` and `~/.tsh/*` credential directories, with exclusions for known-legitimate tools — the excludable `ImageFilename` field with both include and exclude patterns compiled correctly to Falcon's internal `(*AND*)(*!...)` PCRE2 syntax

All 41 unit tests pass alongside the existing 317 tests (358 total).