### PR TITLE
fix: handle trailing-slash redirects and json-rpc content-type in HTTP transports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,7 @@ CLAUDE.md
 .aider/
 .aider*
 .clinerules/
+.mcp.json
 memory-bank/
 
 # E2E artifacts

--- a/falcon_mcp/common/auth.py
+++ b/falcon_mcp/common/auth.py
@@ -1,9 +1,4 @@
-"""
-Authentication middleware for Falcon MCP Server HTTP transports.
-
-This module provides API key authentication middleware for HTTP-based
-transports (SSE, streamable-http).
-"""
+"""ASGI middleware for Falcon MCP Server HTTP transports."""
 
 import secrets
 from collections.abc import Awaitable, Callable, MutableMapping
@@ -12,11 +7,69 @@ from typing import Any
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from falcon_mcp.common.logging import get_logger
+
 # ASGI type aliases - using MutableMapping for Starlette compatibility
 Scope = MutableMapping[str, Any]
 ASGIReceive = Callable[[], Awaitable[MutableMapping[str, Any]]]
 ASGISend = Callable[[MutableMapping[str, Any]], Awaitable[None]]
 ASGIApp = Callable[[Scope, ASGIReceive, ASGISend], Awaitable[None]]
+
+
+def strip_trailing_slash_middleware(app: ASGIApp) -> ASGIApp:
+    """Strip trailing slashes from HTTP request paths.
+
+    Args:
+        app: The ASGI application to wrap
+
+    Returns:
+        ASGI app that normalizes paths by removing trailing slashes
+    """
+
+    async def middleware(scope: Scope, receive: ASGIReceive, send: ASGISend) -> None:
+        if scope["type"] == "http":
+            path: str = scope["path"]
+            if path != "/" and path.endswith("/"):
+                scope["path"] = path.rstrip("/")
+                if "raw_path" in scope and isinstance(scope["raw_path"], bytes):
+                    raw = scope["raw_path"]
+                    scope["raw_path"] = raw.rstrip(b"/") or b"/"
+        await app(scope, receive, send)
+
+    return middleware
+
+
+def normalize_content_type_middleware(app: ASGIApp) -> ASGIApp:
+    """Normalize ``application/json-rpc`` to ``application/json`` in HTTP request headers.
+
+    Args:
+        app: The ASGI application to wrap
+
+    Returns:
+        ASGI app that normalizes Content-Type headers
+    """
+    ct_logger = get_logger("falcon_mcp.content_type")
+
+    async def middleware(scope: Scope, receive: ASGIReceive, send: ASGISend) -> None:
+        if scope["type"] == "http":
+            headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+            new_headers: list[tuple[bytes, bytes]] = []
+            for name, value in headers:
+                if name == b"content-type":
+                    decoded = value.decode("utf-8")
+                    if decoded.lower().startswith("application/json-rpc"):
+                        # Replace only the media type, keep params (e.g. "; charset=utf-8")
+                        rest = decoded[len("application/json-rpc"):]
+                        new_value = f"application/json{rest}"
+                        ct_logger.debug(
+                            "Normalized Content-Type: %s -> %s", decoded, new_value
+                        )
+                        value = new_value.encode("utf-8")
+                new_headers.append((name, value))
+            scope["headers"] = new_headers
+        await app(scope, receive, send)
+
+    return middleware
 
 
 def auth_middleware(app: ASGIApp, api_key: str) -> ASGIApp:

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -16,7 +16,12 @@ from mcp.server.fastmcp import FastMCP
 
 from falcon_mcp import registry
 from falcon_mcp.client import FalconClient
-from falcon_mcp.common.auth import ASGIApp, auth_middleware
+from falcon_mcp.common.auth import (
+    ASGIApp,
+    auth_middleware,
+    normalize_content_type_middleware,
+    strip_trailing_slash_middleware,
+)
 from falcon_mcp.common.logging import configure_logging, get_logger
 from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
 
@@ -191,53 +196,39 @@ class FalconMCPServer:
         """Lists all available modules in the falcon-mcp server."""
         return {"modules": registry.get_module_names()}
 
+    def _run_http_transport(self, app: ASGIApp) -> None:
+        """Apply middleware and start uvicorn for an HTTP transport.
+
+        Args:
+            app: The ASGI application from FastMCP
+        """
+        app = strip_trailing_slash_middleware(app)
+        app = normalize_content_type_middleware(app)
+        if self.api_key:
+            app = auth_middleware(app, self.api_key)
+            logger.info("API key authentication enabled")
+        uvicorn.run(
+            app,
+            host=self.host,
+            port=self.port,
+            log_level="debug" if self.debug else "info",
+        )
+
     def run(self, transport: TransportType = "stdio") -> None:
         """Run the MCP server.
 
         Args:
             transport: Transport protocol to use ("stdio", "sse", or "streamable-http")
         """
-        app: ASGIApp
-        if transport == "streamable-http":
-            # For streamable-http, use uvicorn directly for custom host/port
-            logger.info("Starting streamable-http server on %s:%d", self.host, self.port)
-
-            # Get the ASGI app from FastMCP (handles /mcp path automatically)
-            app = self.server.streamable_http_app()
-
-            # Add API key authentication middleware if configured
-            if self.api_key:
-                app = auth_middleware(app, self.api_key)
-                logger.info("API key authentication enabled")
-
-            # Run with uvicorn for custom host/port configuration
-            uvicorn.run(
-                app,
-                host=self.host,
-                port=self.port,
-                log_level="info" if not self.debug else "debug",
+        if transport in ("streamable-http", "sse"):
+            logger.info("Starting %s server on %s:%d", transport, self.host, self.port)
+            app_method = (
+                self.server.streamable_http_app
+                if transport == "streamable-http"
+                else self.server.sse_app
             )
-        elif transport == "sse":
-            # For sse, use uvicorn directly for custom host/port (same pattern as streamable-http)
-            logger.info("Starting sse server on %s:%d", self.host, self.port)
-
-            # Get the ASGI app from FastMCP
-            app = self.server.sse_app()
-
-            # Add API key authentication middleware if configured
-            if self.api_key:
-                app = auth_middleware(app, self.api_key)
-                logger.info("API key authentication enabled")
-
-            # Run with uvicorn for custom host/port configuration
-            uvicorn.run(
-                app,
-                host=self.host,
-                port=self.port,
-                log_level="info" if not self.debug else "debug",
-            )
+            self._run_http_transport(app_method())
         else:
-            # For stdio, use the default FastMCP run method (no host/port needed)
             self.server.run(transport)
 
 

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -2,7 +2,7 @@
 Tests for server-level API key authentication integration.
 
 These tests verify that the FalconMCPServer correctly stores and applies
-API key authentication for HTTP transports.
+API key authentication and ASGI middleware for HTTP transports.
 """
 
 from unittest.mock import MagicMock, patch
@@ -225,3 +225,230 @@ class TestLogging:
             "API key authentication enabled" in str(call) for call in info_calls
         )
         assert not auth_log_found, f"Unexpected auth log found: {info_calls}"
+
+
+class TestTrailingSlashMiddlewareApplication:
+    """Test that trailing slash middleware is correctly applied to HTTP transports."""
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.strip_trailing_slash_middleware")
+    @patch("falcon_mcp.server.uvicorn")
+    def test_trailing_slash_middleware_applied_to_streamable_http(
+        self, _mock_uvicorn, mock_slash_middleware, mock_registry, mock_client_class
+    ):
+        """Trailing slash middleware is applied to streamable-http transport."""
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        mock_slash_middleware.return_value = MagicMock()
+
+        server = FalconMCPServer()
+        server.run(transport="streamable-http")
+
+        mock_slash_middleware.assert_called_once()
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.strip_trailing_slash_middleware")
+    @patch("falcon_mcp.server.uvicorn")
+    def test_trailing_slash_middleware_applied_to_sse(
+        self, _mock_uvicorn, mock_slash_middleware, mock_registry, mock_client_class
+    ):
+        """Trailing slash middleware is applied to SSE transport."""
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        mock_slash_middleware.return_value = MagicMock()
+
+        server = FalconMCPServer()
+        server.run(transport="sse")
+
+        mock_slash_middleware.assert_called_once()
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.strip_trailing_slash_middleware")
+    def test_trailing_slash_middleware_not_applied_to_stdio(
+        self, mock_slash_middleware, mock_registry, mock_client_class
+    ):
+        """Trailing slash middleware is NOT applied for stdio transport."""
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        server = FalconMCPServer()
+        server.server.run = MagicMock()
+        server.run(transport="stdio")
+
+        mock_slash_middleware.assert_not_called()
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.auth_middleware")
+    @patch("falcon_mcp.server.normalize_content_type_middleware")
+    @patch("falcon_mcp.server.strip_trailing_slash_middleware")
+    @patch("falcon_mcp.server.uvicorn")
+    def test_middleware_ordering_slash_before_auth(
+        self,
+        mock_uvicorn,
+        mock_slash_middleware,
+        mock_ct_middleware,
+        mock_auth_middleware,
+        mock_registry,
+        mock_client_class,
+    ):
+        """Trailing slash middleware wraps base app, then content-type, then auth.
+
+        The ordering ensures: request -> auth -> normalize_ct -> trailing_slash_strip -> app
+        """
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        # Track the call chain
+        slash_wrapped = MagicMock(name="slash_wrapped_app")
+        ct_wrapped = MagicMock(name="ct_wrapped_app")
+        auth_wrapped = MagicMock(name="auth_wrapped_app")
+        mock_slash_middleware.return_value = slash_wrapped
+        mock_ct_middleware.return_value = ct_wrapped
+        mock_auth_middleware.return_value = auth_wrapped
+
+        server = FalconMCPServer(api_key="test-key")
+        server.run(transport="streamable-http")
+
+        # strip_trailing_slash_middleware is called with the base app
+        mock_slash_middleware.assert_called_once()
+        base_app = mock_slash_middleware.call_args[0][0]
+        assert base_app is not None
+
+        # normalize_content_type_middleware wraps the slash-wrapped app
+        mock_ct_middleware.assert_called_once_with(slash_wrapped)
+
+        # auth_middleware is called with the ct-wrapped app
+        mock_auth_middleware.assert_called_once_with(ct_wrapped, "test-key")
+
+        # uvicorn gets the fully wrapped app (auth on top)
+        uvicorn_app = mock_uvicorn.run.call_args[0][0]
+        assert uvicorn_app == auth_wrapped
+
+
+class TestContentTypeMiddlewareApplication:
+    """Test that content-type normalization middleware is correctly applied."""
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.normalize_content_type_middleware")
+    @patch("falcon_mcp.server.uvicorn")
+    def test_ct_middleware_applied_to_streamable_http(
+        self, _mock_uvicorn, mock_ct_middleware, mock_registry, mock_client_class
+    ):
+        """Content-type normalization middleware is applied to streamable-http."""
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        mock_ct_middleware.return_value = MagicMock()
+
+        server = FalconMCPServer()
+        server.run(transport="streamable-http")
+
+        mock_ct_middleware.assert_called_once()
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.normalize_content_type_middleware")
+    @patch("falcon_mcp.server.uvicorn")
+    def test_ct_middleware_applied_to_sse(
+        self, _mock_uvicorn, mock_ct_middleware, mock_registry, mock_client_class
+    ):
+        """Content-type normalization middleware is applied to SSE transport."""
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        mock_ct_middleware.return_value = MagicMock()
+
+        server = FalconMCPServer()
+        server.run(transport="sse")
+
+        mock_ct_middleware.assert_called_once()
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.normalize_content_type_middleware")
+    def test_ct_middleware_not_applied_to_stdio(
+        self, mock_ct_middleware, mock_registry, mock_client_class
+    ):
+        """Content-type normalization middleware is NOT applied for stdio transport."""
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        server = FalconMCPServer()
+        server.server.run = MagicMock()
+        server.run(transport="stdio")
+
+        mock_ct_middleware.assert_not_called()
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.normalize_content_type_middleware")
+    @patch("falcon_mcp.server.strip_trailing_slash_middleware")
+    @patch("falcon_mcp.server.uvicorn")
+    def test_ct_middleware_wraps_slash_middleware_result(
+        self,
+        _mock_uvicorn,
+        mock_slash_middleware,
+        mock_ct_middleware,
+        mock_registry,
+        mock_client_class,
+    ):
+        """normalize_content_type wraps the strip_trailing_slash result."""
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        slash_wrapped = MagicMock(name="slash_wrapped_app")
+        mock_slash_middleware.return_value = slash_wrapped
+        mock_ct_middleware.return_value = MagicMock()
+
+        server = FalconMCPServer()
+        server.run(transport="streamable-http")
+
+        # normalize_content_type is called with the slash-wrapped app
+        mock_ct_middleware.assert_called_once_with(slash_wrapped)

--- a/tests/test_streamable_http_transport.py
+++ b/tests/test_streamable_http_transport.py
@@ -14,8 +14,12 @@ class TestStreamableHttpTransport(unittest.TestCase):
     @patch("falcon_mcp.server.FalconClient")
     @patch("falcon_mcp.server.FastMCP")
     @patch("falcon_mcp.server.uvicorn")
+    @patch("falcon_mcp.server.strip_trailing_slash_middleware", side_effect=lambda app: app)
+    @patch("falcon_mcp.server.normalize_content_type_middleware", side_effect=lambda app: app)
     def test_streamable_http_transport_initialization(
         self,
+        _mock_ct_mw,
+        _mock_slash_mw,
         mock_uvicorn,
         mock_fastmcp,
         mock_client,
@@ -180,8 +184,12 @@ class TestStreamableHttpTransport(unittest.TestCase):
     @patch("falcon_mcp.server.FalconClient")
     @patch("falcon_mcp.server.FastMCP")
     @patch("falcon_mcp.server.uvicorn")
+    @patch("falcon_mcp.server.strip_trailing_slash_middleware", side_effect=lambda app: app)
+    @patch("falcon_mcp.server.normalize_content_type_middleware", side_effect=lambda app: app)
     def test_streamable_http_default_parameters(
         self,
+        _mock_ct_mw,
+        _mock_slash_mw,
         mock_uvicorn,
         mock_fastmcp,
         mock_client,
@@ -242,8 +250,12 @@ class TestStreamableHttpTransport(unittest.TestCase):
     @patch("falcon_mcp.server.FalconClient")
     @patch("falcon_mcp.server.FastMCP")
     @patch("falcon_mcp.server.uvicorn")
+    @patch("falcon_mcp.server.strip_trailing_slash_middleware", side_effect=lambda app: app)
+    @patch("falcon_mcp.server.normalize_content_type_middleware", side_effect=lambda app: app)
     def test_streamable_http_custom_parameters(
         self,
+        _mock_ct_mw,
+        _mock_slash_mw,
         mock_uvicorn,
         mock_fastmcp,
         mock_client,
@@ -276,8 +288,12 @@ class TestStreamableHttpTransport(unittest.TestCase):
     @patch("falcon_mcp.server.FalconClient")
     @patch("falcon_mcp.server.FastMCP")
     @patch("falcon_mcp.server.uvicorn")
+    @patch("falcon_mcp.server.strip_trailing_slash_middleware", side_effect=lambda app: app)
+    @patch("falcon_mcp.server.normalize_content_type_middleware", side_effect=lambda app: app)
     def test_streamable_http_logging_levels(
         self,
+        _mock_ct_mw,
+        _mock_slash_mw,
         mock_uvicorn,
         mock_fastmcp,
         mock_client,

--- a/tests/test_trailing_slash_middleware.py
+++ b/tests/test_trailing_slash_middleware.py
@@ -1,0 +1,255 @@
+"""
+Tests for the trailing slash stripping ASGI middleware.
+
+These tests verify that strip_trailing_slash_middleware correctly normalizes
+request paths to prevent Starlette's Router from issuing 307 redirects when
+clients send requests with trailing slashes (e.g. /mcp/ instead of /mcp).
+"""
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from falcon_mcp.common.auth import (
+    ASGIApp,
+    normalize_content_type_middleware,
+    strip_trailing_slash_middleware,
+)
+
+
+def _echo_handler(request: Request) -> JSONResponse:
+    """Echo handler that returns request details for verification."""
+    return JSONResponse({
+        "path": request.url.path,
+        "method": request.method,
+        "query": str(request.query_params),
+    })
+
+
+async def _async_echo_handler(request: Request) -> JSONResponse:
+    """Async echo handler that reads and returns the POST body."""
+    body = await request.body()
+    return JSONResponse({
+        "path": request.url.path,
+        "body": body.decode("utf-8"),
+        "content_type": request.headers.get("content-type", ""),
+    })
+
+
+def _make_app(use_middleware: bool = True) -> Starlette | ASGIApp:
+    """Create a Starlette app with a /mcp route, optionally wrapped with middleware."""
+    app = Starlette(
+        routes=[
+            Route("/mcp", _echo_handler, methods=["GET", "POST"]),
+            Route("/mcp/post", _async_echo_handler, methods=["POST"]),
+            Route("/", _echo_handler, methods=["GET"]),
+        ],
+    )
+    if use_middleware:
+        return strip_trailing_slash_middleware(app)
+    return app
+
+
+class TestTrailingSlashRedirectProblem:
+    """Confirm the 307 redirect behavior without middleware."""
+
+    def test_trailing_slash_redirects_without_middleware(self):
+        """Without middleware, /mcp/ returns a 307 redirect to /mcp."""
+        app = _make_app(use_middleware=False)
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/mcp/")
+        assert response.status_code == 307
+
+    def test_no_trailing_slash_works_without_middleware(self):
+        """Without middleware, /mcp (no trailing slash) works normally."""
+        app = _make_app(use_middleware=False)
+        client = TestClient(app)
+        response = client.get("/mcp")
+        assert response.status_code == 200
+
+
+class TestMiddlewareFixesRedirect:
+    """Verify the middleware prevents 307 redirects."""
+
+    def test_trailing_slash_returns_200_with_middleware(self):
+        """/mcp/ returns 200 with middleware (no redirect)."""
+        app = _make_app(use_middleware=True)
+        client = TestClient(app)
+        response = client.get("/mcp/")
+        assert response.status_code == 200
+        assert response.json()["path"] == "/mcp"
+
+    def test_no_trailing_slash_still_works(self):
+        """/mcp (no trailing slash) continues to work."""
+        app = _make_app(use_middleware=True)
+        client = TestClient(app)
+        response = client.get("/mcp")
+        assert response.status_code == 200
+        assert response.json()["path"] == "/mcp"
+
+    def test_post_body_preserved(self):
+        """POST body is preserved through the middleware."""
+        app = _make_app(use_middleware=True)
+        client = TestClient(app)
+        response = client.post(
+            "/mcp/post/",
+            content='{"jsonrpc":"2.0","method":"initialize","id":1}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["body"] == '{"jsonrpc":"2.0","method":"initialize","id":1}'
+        assert data["content_type"] == "application/json"
+
+
+class TestEdgeCases:
+    """Test edge cases for the middleware."""
+
+    def test_root_path_not_modified(self):
+        """Root path / is not stripped."""
+        app = _make_app(use_middleware=True)
+        client = TestClient(app)
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.json()["path"] == "/"
+
+    def test_multiple_trailing_slashes(self):
+        """Multiple trailing slashes are all stripped."""
+        app = _make_app(use_middleware=True)
+        client = TestClient(app)
+        response = client.get("/mcp///")
+        assert response.status_code == 200
+        assert response.json()["path"] == "/mcp"
+
+    def test_query_params_preserved(self):
+        """Query parameters are preserved through the middleware."""
+        app = _make_app(use_middleware=True)
+        client = TestClient(app)
+        response = client.get("/mcp/?foo=bar&baz=1")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["path"] == "/mcp"
+        assert "foo=bar" in data["query"]
+
+    def test_non_http_scope_passthrough(self):
+        """Non-HTTP scopes (e.g. lifespan) are passed through unchanged."""
+
+        async def inner_app(scope, receive, send):
+            """Track that the inner app was called."""
+            inner_app.called = True
+            inner_app.scope_type = scope["type"]
+
+        inner_app.called = False
+        inner_app.scope_type = None
+
+        wrapped = strip_trailing_slash_middleware(inner_app)
+
+        import asyncio
+
+        scope = {"type": "lifespan", "path": "/should-not-be-touched/"}
+
+        asyncio.run(wrapped(scope, None, None))
+
+        assert inner_app.called is True
+        # Path should not be modified for non-http scopes
+        assert scope["path"] == "/should-not-be-touched/"
+
+    def test_post_to_trailing_slash_returns_200(self):
+        """POST to /mcp/ returns 200 (not 307 redirect losing the body)."""
+        app = _make_app(use_middleware=True)
+        client = TestClient(app, follow_redirects=False)
+        response = client.post(
+            "/mcp/",
+            content='{"test": true}',
+            headers={"Content-Type": "application/json"},
+        )
+        # Should be 200 (handled), not 307 (redirect)
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Content-Type normalization middleware tests
+# ---------------------------------------------------------------------------
+
+
+def _make_content_type_app() -> ASGIApp:
+    """Create a Starlette app wrapped with content-type normalization middleware."""
+    base_app = Starlette(
+        routes=[
+            Route("/mcp", _async_echo_handler, methods=["POST"]),
+        ],
+    )
+    return normalize_content_type_middleware(base_app)
+
+
+class TestContentTypeNormalization:
+    """Verify that application/json-rpc is rewritten to application/json."""
+
+    def test_json_rpc_rewritten_to_json(self):
+        """application/json-rpc is rewritten to application/json."""
+        app = _make_content_type_app()
+        client = TestClient(app)
+        response = client.post(
+            "/mcp",
+            content='{"method":"tools/call"}',
+            headers={"Content-Type": "application/json-rpc"},
+        )
+        assert response.status_code == 200
+        assert response.json()["content_type"] == "application/json"
+
+    def test_json_rpc_with_charset_preserves_params(self):
+        """application/json-rpc; charset=utf-8 becomes application/json; charset=utf-8."""
+        app = _make_content_type_app()
+        client = TestClient(app)
+        response = client.post(
+            "/mcp",
+            content='{"method":"tools/call"}',
+            headers={"Content-Type": "application/json-rpc; charset=utf-8"},
+        )
+        assert response.status_code == 200
+        assert response.json()["content_type"] == "application/json; charset=utf-8"
+
+    def test_plain_json_left_untouched(self):
+        """application/json is left unchanged."""
+        app = _make_content_type_app()
+        client = TestClient(app)
+        response = client.post(
+            "/mcp",
+            content='{"method":"initialize"}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 200
+        assert response.json()["content_type"] == "application/json"
+
+    def test_missing_content_type_left_alone(self):
+        """Requests without Content-Type header are passed through."""
+        app = _make_content_type_app()
+        client = TestClient(app)
+        # Send a POST without explicitly setting Content-Type
+        response = client.post("/mcp", content=b"raw-body")
+        # The app should still receive the request (may get a default content-type
+        # from the test client, but the middleware should not error)
+        assert response.status_code == 200
+
+    def test_non_http_scope_passthrough(self):
+        """Non-HTTP scopes (e.g. lifespan) are passed through unchanged."""
+
+        async def inner_app(scope, receive, send):
+            inner_app.called = True
+            inner_app.scope_type = scope["type"]
+
+        inner_app.called = False
+        inner_app.scope_type = None
+
+        wrapped = normalize_content_type_middleware(inner_app)
+
+        import asyncio
+
+        scope = {"type": "lifespan"}
+
+        asyncio.run(wrapped(scope, None, None))
+
+        assert inner_app.called is True
+        assert scope["type"] == "lifespan"


### PR DESCRIPTION
Adds two ASGI middleware functions to fix HTTP transport compatibility issues: `strip_trailing_slash_middleware` prevents Starlette's 307 redirects when clients hit `/mcp/` instead of `/mcp` (which strips POST bodies/headers), and `normalize_content_type_middleware` rewrites `application/json-rpc` to `application/json` so the MCP SDK doesn't reject requests with 415. Also extracted a `_run_http_transport()` helper to DRY up the duplicated streamable-http/sse transport setup.

> [!IMPORTANT]
> This impacts our AWS AgentCore deployment. I have tested this fix and validated it works in bedrock.