### PR TITLE
feat: add Flight Control (MSSP) support with member_cid parameter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,14 @@ FALCON_CLIENT_SECRET=your-client-secret
 FALCON_BASE_URL=https://api.us-2.crowdstrike.com
 
 # =============================================================================
+# Optional: Flight Control (MSSP) Support
+# =============================================================================
+# Child CID for Flight Control (MSSP multi-tenancy)
+# Use this to target a specific child CID when authenticating with parent credentials
+# Requires Flight Control enabled on the parent tenant
+#FALCON_MEMBER_CID=
+
+# =============================================================================
 # Optional: Server Configuration
 # =============================================================================
 # Modules to enable (comma-separated list)

--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ FALCON_CLIENT_SECRET=your-client-secret
 FALCON_BASE_URL=https://api.crowdstrike.com
 
 # Optional Configuration (uncomment and modify as needed)
+#FALCON_MEMBER_CID=your-child-cid                       # Flight Control child CID
 #FALCON_MCP_MODULES=detections,incidents,intel
 #FALCON_MCP_TRANSPORT=stdio
 #FALCON_MCP_DEBUG=false
@@ -434,6 +435,7 @@ export FALCON_CLIENT_SECRET="your-client-secret"
 export FALCON_BASE_URL="https://api.crowdstrike.com"
 
 # Optional Configuration
+export FALCON_MEMBER_CID="your-child-cid"               # Flight Control child CID
 export FALCON_MCP_MODULES="detections,incidents,intel"  # Comma-separated list (default: all modules)
 export FALCON_MCP_TRANSPORT="stdio"                     # Transport method: stdio, sse, streamable-http
 export FALCON_MCP_DEBUG="false"                         # Enable debug logging: true, false
@@ -442,6 +444,66 @@ export FALCON_MCP_PORT="8000"                           # Port for HTTP transpor
 export FALCON_MCP_STATELESS_HTTP="false"                # Stateless mode for scalable deployments
 export FALCON_MCP_API_KEY="your-api-key"                # API key for HTTP transport auth (x-api-key header)
 ```
+
+### Flight Control (MSSP) Support
+
+falcon-mcp supports CrowdStrike Flight Control for MSSP (Managed Security Service Provider) environments. Use parent CID API credentials with the `--member-cid` flag or `FALCON_MEMBER_CID` environment variable to target a specific child CID.
+
+#### Configuration
+
+**Environment Variable**:
+
+```bash
+export FALCON_MEMBER_CID="abc123-child-cid-xyz"
+falcon-mcp
+```
+
+**Command Line Flag**:
+
+```bash
+falcon-mcp --member-cid "abc123-child-cid-xyz"
+```
+
+**In `.env` file**:
+
+```bash
+# Parent CID credentials (required)
+FALCON_CLIENT_ID=parent-client-id
+FALCON_CLIENT_SECRET=parent-client-secret
+
+# Child CID to target (optional - for Flight Control)
+FALCON_MEMBER_CID=abc123-child-cid-xyz
+```
+
+#### Requirements
+
+- Parent CID API credentials (use parent's `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET`)
+- Flight Control enabled on the parent tenant
+- Valid child CID identifier
+- Parent API client must have appropriate scopes for operations on the child CID
+
+#### Behavior
+
+- **Session-level**: All tools in the server instance target the specified child CID
+- **Cannot switch mid-session**: The member_cid is set during authentication and persists for the server's lifetime
+- **Multiple child CIDs**: To query multiple child CIDs, run separate server instances on different ports
+
+#### Multi-Tenant Workflow Example
+
+To work with multiple child CIDs simultaneously, run separate server instances:
+
+```bash
+# Parent CID (default)
+falcon-mcp --transport streamable-http --port 8000
+
+# Child CID 1
+falcon-mcp --member-cid "child-cid-1" --transport streamable-http --port 8001
+
+# Child CID 2
+falcon-mcp --member-cid "child-cid-2" --transport streamable-http --port 8002
+```
+
+Each instance maintains its own authentication context and can be accessed independently by your MCP client.
 
 **CrowdStrike API Region URLs:**
 

--- a/falcon_mcp/client.py
+++ b/falcon_mcp/client.py
@@ -28,6 +28,7 @@ class FalconClient:
         user_agent_comment: str | None = None,
         client_id: str | None = None,
         client_secret: str | None = None,
+        member_cid: str | None = None,
     ):
         """Initialize the Falcon client.
 
@@ -37,6 +38,7 @@ class FalconClient:
             user_agent_comment: Additional information to include in the User-Agent comment section
             client_id: Falcon API Client ID (defaults to FALCON_CLIENT_ID env var)
             client_secret: Falcon API Client Secret (defaults to FALCON_CLIENT_SECRET env var)
+            member_cid: Child CID for Flight Control (MSSP) support (defaults to FALCON_MEMBER_CID env var)
         """
         # Get credentials from parameters or environment variables (parameters take precedence)
         self.client_id = client_id or os.environ.get("FALCON_CLIENT_ID")
@@ -48,6 +50,7 @@ class FalconClient:
         self.user_agent_comment = user_agent_comment or os.environ.get(
             "FALCON_MCP_USER_AGENT_COMMENT"
         )
+        self.member_cid = member_cid or os.environ.get("FALCON_MEMBER_CID")
 
         if not self.client_id or not self.client_secret:
             raise ValueError(
@@ -55,16 +58,25 @@ class FalconClient:
                 "parameters or set FALCON_CLIENT_ID and FALCON_CLIENT_SECRET environment variables."
             )
 
+        # Build APIHarnessV2 initialization parameters
+        api_params = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "base_url": self.base_url,
+            "debug": debug,
+            "user_agent": self.get_user_agent(),
+        }
+
+        # Only include member_cid if it's provided
+        if self.member_cid:
+            api_params["member_cid"] = self.member_cid
+
         # Initialize the Falcon API client using APIHarnessV2
-        self.client = APIHarnessV2(
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            base_url=self.base_url,
-            debug=debug,
-            user_agent=self.get_user_agent(),
-        )
+        self.client = APIHarnessV2(**api_params)
 
         logger.debug("Initialized Falcon client with base URL: %s", self.base_url)
+        if self.member_cid:
+            logger.debug("Flight Control member_cid: %s", self.member_cid)
 
     def authenticate(self) -> bool:
         """Authenticate with the Falcon API.

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -46,6 +46,7 @@ class FalconMCPServer:
         api_key: str | None = None,
         host: str = "127.0.0.1",
         port: int = 8000,
+        member_cid: str | None = None,
     ):
         """Initialize the Falcon MCP server.
 
@@ -60,6 +61,7 @@ class FalconMCPServer:
             api_key: API key for HTTP transport authentication (x-api-key header)
             host: Host to bind to for HTTP transports (default: 127.0.0.1)
             port: Port to listen on for HTTP transports (default: 8000)
+            member_cid: Child CID for Flight Control (MSSP) support (defaults to FALCON_MEMBER_CID env var)
         """
         # Store configuration
         self.base_url = base_url
@@ -83,6 +85,7 @@ class FalconMCPServer:
             user_agent_comment=self.user_agent_comment,
             client_id=client_id,
             client_secret=client_secret,
+            member_cid=member_cid,
         )
 
         # Authenticate with the Falcon API
@@ -343,6 +346,13 @@ def parse_args() -> argparse.Namespace:
         help="API key for HTTP transport authentication (x-api-key header, env: FALCON_MCP_API_KEY)",
     )
 
+    # Flight Control (MSSP) support
+    parser.add_argument(
+        "--member-cid",
+        default=os.environ.get("FALCON_MEMBER_CID"),
+        help="Child CID for Flight Control (MSSP) support (env: FALCON_MEMBER_CID)",
+    )
+
     return parser.parse_args()
 
 
@@ -365,6 +375,7 @@ def main() -> None:
             api_key=args.api_key,
             host=args.host,
             port=args.port,
+            member_cid=args.member_cid,
         )
         logger.info("Starting server with %s transport", args.transport)
         server.run(args.transport)

--- a/tests/integration/test_flight_control.py
+++ b/tests/integration/test_flight_control.py
@@ -1,0 +1,181 @@
+"""
+Integration tests for Flight Control (MSSP) support.
+
+These tests verify that the member_cid parameter works correctly with real API calls.
+
+Prerequisites:
+- FALCON_CLIENT_ID and FALCON_CLIENT_SECRET environment variables set with parent CID credentials
+- FALCON_MEMBER_CID environment variable set with a valid child CID
+- Flight Control enabled on the parent tenant
+- Parent API client must have appropriate scopes for the child CID
+
+Note: These tests require a real Flight Control enabled tenant and will be skipped if
+FALCON_MEMBER_CID is not set.
+"""
+
+import os
+
+import pytest
+
+from falcon_mcp.client import FalconClient
+
+
+@pytest.fixture(scope="module")
+def member_cid():
+    """
+    Get the member_cid from environment for testing.
+
+    Tests will be skipped if FALCON_MEMBER_CID is not set.
+    """
+    member_cid_value = os.environ.get("FALCON_MEMBER_CID")
+    if not member_cid_value:
+        pytest.skip(
+            "Flight Control integration tests require FALCON_MEMBER_CID environment variable. "
+            "Set this to a valid child CID in your .env file or environment."
+        )
+    return member_cid_value
+
+
+@pytest.fixture(scope="module")
+def parent_client():
+    """
+    Create a FalconClient for the parent CID (no member_cid).
+
+    This client will authenticate with the parent tenant.
+    """
+    client_id = os.environ.get("FALCON_CLIENT_ID")
+    client_secret = os.environ.get("FALCON_CLIENT_SECRET")
+
+    if not client_id or not client_secret:
+        pytest.skip(
+            "Integration tests require FALCON_CLIENT_ID and FALCON_CLIENT_SECRET "
+            "environment variables. Set these in your .env file or environment."
+        )
+
+    client = FalconClient()
+
+    if not client.authenticate():
+        pytest.skip(
+            "Failed to authenticate with Falcon API. Check your credentials "
+            "and ensure they have the required API scopes."
+        )
+
+    return client
+
+
+@pytest.fixture(scope="module")
+def child_client(member_cid):
+    """
+    Create a FalconClient for a child CID using member_cid parameter.
+
+    This client will authenticate with the specified child tenant.
+    """
+    client_id = os.environ.get("FALCON_CLIENT_ID")
+    client_secret = os.environ.get("FALCON_CLIENT_SECRET")
+
+    if not client_id or not client_secret:
+        pytest.skip(
+            "Integration tests require FALCON_CLIENT_ID and FALCON_CLIENT_SECRET "
+            "environment variables. Set these in your .env file or environment."
+        )
+
+    client = FalconClient(member_cid=member_cid)
+
+    if not client.authenticate():
+        pytest.skip(
+            "Failed to authenticate with Falcon API using member_cid. "
+            "Check that Flight Control is enabled and the member_cid is valid."
+        )
+
+    return client
+
+
+def test_client_initialization_with_member_cid(member_cid):
+    """Test that FalconClient can be initialized with member_cid."""
+    client = FalconClient(member_cid=member_cid)
+    assert client.member_cid == member_cid
+
+
+def test_client_initialization_with_env_var_member_cid(member_cid):
+    """Test that FalconClient loads member_cid from environment variable."""
+    # member_cid fixture already checks that FALCON_MEMBER_CID is set
+    client = FalconClient()
+
+    # If FALCON_MEMBER_CID is set, it should be loaded
+    # If not set, it should be None (which causes the skip in the fixture)
+    if os.environ.get("FALCON_MEMBER_CID"):
+        assert client.member_cid == member_cid
+
+
+def test_parent_client_connectivity(parent_client):
+    """Test connectivity with parent CID client."""
+    assert parent_client.is_authenticated()
+
+
+def test_child_client_connectivity(child_client):
+    """Test connectivity with child CID client."""
+    assert child_client.is_authenticated()
+
+
+def test_child_client_has_different_token_context(parent_client, child_client):
+    """
+    Test that parent and child clients have different authentication contexts.
+
+    This is a sanity check to ensure that member_cid actually affects the token.
+    Note: Both clients may have similar headers format but the token should be
+    scoped differently (we can't directly validate token claims without decoding).
+    """
+    parent_headers = parent_client.get_headers()
+    child_headers = child_client.get_headers()
+
+    # Both should have Authorization headers
+    assert "Authorization" in parent_headers
+    assert "Authorization" in child_headers
+
+    # The tokens should be different (different CID context)
+    # Note: In some cases they might be the same if member_cid doesn't affect the token,
+    # but typically they should differ
+    assert parent_headers["Authorization"] != child_headers["Authorization"], (
+        "Parent and child clients have identical tokens, which suggests member_cid "
+        "is not affecting authentication. Check Flight Control configuration."
+    )
+
+
+def test_child_client_command_execution(child_client):
+    """
+    Test that child client can execute commands successfully.
+
+    This uses a simple query operation that should work with minimal permissions.
+    """
+    # Use QueryDevicesByFilter as a lightweight test operation
+    # This should return data scoped to the child CID
+    result = child_client.command(
+        "QueryDevicesByFilter",
+        limit=1,  # Just need one result to verify it works
+    )
+
+    # Check basic response structure
+    assert isinstance(result, dict)
+    assert "status_code" in result
+
+    # Status code should be 200 (success) or 404 (no devices found, but API worked)
+    assert result["status_code"] in [200, 404], (
+        f"Unexpected status code: {result['status_code']}. "
+        f"Response: {result}"
+    )
+
+
+def test_member_cid_stored_correctly(member_cid):
+    """Test that member_cid is stored correctly in the client instance."""
+    client = FalconClient(member_cid=member_cid)
+    assert hasattr(client, "member_cid")
+    assert client.member_cid == member_cid
+
+
+def test_member_cid_parameter_precedence(member_cid):
+    """Test that member_cid parameter takes precedence over environment variable."""
+    # Even if FALCON_MEMBER_CID is set in environment, the parameter should override
+    param_cid = "param-override-cid"
+    client = FalconClient(member_cid=param_cid)
+    assert client.member_cid == param_cid
+    assert client.member_cid != member_cid  # Should not use env var

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -315,6 +315,88 @@ class TestFalconClient(unittest.TestCase):
         call_args = mock_apiharness.call_args[1]
         self.assertEqual(call_args["user_agent"], expected)
 
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_client_initialization_with_member_cid(
+        self, mock_apiharness, mock_environ_get
+    ):
+        """Test client initialization with member_cid parameter."""
+        # Setup mock environment variables
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+        }.get(key, default)
+
+        # Create client with member_cid parameter
+        _client = FalconClient(member_cid="abc123-child-cid-xyz")
+
+        # Verify APIHarnessV2 was initialized with member_cid
+        mock_apiharness.assert_called_once()
+        call_args = mock_apiharness.call_args[1]
+        self.assertEqual(call_args["member_cid"], "abc123-child-cid-xyz")
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_client_initialization_with_member_cid_env_var(
+        self, mock_apiharness, mock_environ_get
+    ):
+        """Test client initialization with FALCON_MEMBER_CID environment variable."""
+        # Setup mock environment variables including member_cid
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+            "FALCON_MEMBER_CID": "env-child-cid-456",
+        }.get(key, default)
+
+        # Create client without member_cid parameter (should use env var)
+        _client = FalconClient()
+
+        # Verify APIHarnessV2 was initialized with member_cid from env var
+        mock_apiharness.assert_called_once()
+        call_args = mock_apiharness.call_args[1]
+        self.assertEqual(call_args["member_cid"], "env-child-cid-456")
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_client_member_cid_parameter_overrides_env_var(
+        self, mock_apiharness, mock_environ_get
+    ):
+        """Test that member_cid parameter takes precedence over environment variable."""
+        # Setup mock environment variables with both member_cid
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+            "FALCON_MEMBER_CID": "env-child-cid",
+        }.get(key, default)
+
+        # Create client with member_cid parameter (should override env var)
+        _client = FalconClient(member_cid="param-child-cid")
+
+        # Verify APIHarnessV2 was initialized with member_cid from parameter, not env var
+        mock_apiharness.assert_called_once()
+        call_args = mock_apiharness.call_args[1]
+        self.assertEqual(call_args["member_cid"], "param-child-cid")
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_client_initialization_without_member_cid(
+        self, mock_apiharness, mock_environ_get
+    ):
+        """Test client initialization without member_cid (parent CID mode)."""
+        # Setup mock environment variables without member_cid
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+        }.get(key, default)
+
+        # Create client without member_cid
+        _client = FalconClient()
+
+        # Verify APIHarnessV2 was initialized without member_cid
+        mock_apiharness.assert_called_once()
+        call_args = mock_apiharness.call_args[1]
+        self.assertNotIn("member_cid", call_args)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -429,6 +429,47 @@ class TestFalconMCPServer(unittest.TestCase):
                 f"or pass explicit annotations for mutating tools.",
             )
 
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.FastMCP")
+    def test_server_initialization_with_member_cid(self, mock_fastmcp, mock_client):
+        """Test server initialization with member_cid parameter."""
+        # Setup mocks
+        mock_client_instance = MagicMock()
+        mock_client_instance.authenticate.return_value = True
+        mock_client.return_value = mock_client_instance
+
+        mock_server_instance = MagicMock()
+        mock_fastmcp.return_value = mock_server_instance
+
+        # Create server with member_cid
+        _server = FalconMCPServer(member_cid="abc123-child-cid-xyz")
+
+        # Verify FalconClient was initialized with member_cid
+        mock_client.assert_called_once()
+        call_args = mock_client.call_args[1]
+        self.assertEqual(call_args["member_cid"], "abc123-child-cid-xyz")
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.FastMCP")
+    def test_server_initialization_without_member_cid(self, mock_fastmcp, mock_client):
+        """Test server initialization without member_cid (parent CID mode)."""
+        # Setup mocks
+        mock_client_instance = MagicMock()
+        mock_client_instance.authenticate.return_value = True
+        mock_client.return_value = mock_client_instance
+
+        mock_server_instance = MagicMock()
+        mock_fastmcp.return_value = mock_server_instance
+
+        # Create server without member_cid
+        _server = FalconMCPServer()
+
+        # Verify FalconClient was initialized without member_cid
+        mock_client.assert_called_once()
+        call_args = mock_client.call_args[1]
+        # Should be None (the default)
+        self.assertIsNone(call_args["member_cid"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds Flight Control support for MSSPs to target child CIDs using parent tenant credentials. The member_cid parameter can be set via FALCON_MEMBER_CID environment variable or --member-cid CLI flag.

The implementation follows FalconPy's authentication model where member_cid is passed to the OAuth2 token endpoint during authentication. This scopes all subsequent API calls to the specified child CID. The scope is session-level - the entire server instance operates within a single CID context.

For MSSPs managing multiple child CIDs, separate server instances can be run on different ports, each targeting a different child CID.

All unit tests and integration tests pass, with comprehensive coverage of authentication flows and data scoping between parent and child CIDs.

Closes #283