### PR TITLE
feat(modules/cloud): add CSPM asset inventory search

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The Falcon MCP Server supports different modules, each requiring specific API sc
 
 | Module | Required API Scopes | Purpose |
 | - | - | - |
-| **Cloud Security** | `Falcon Container Image:read` | Find and analyze kubernetes containers inventory and container imges vulnerabilities |
+| **Cloud Security** | `Falcon Container Image:read`<br>`Cloud Security API Assets:Read` | Find and analyze kubernetes containers inventory, container images vulnerabilities, and CSPM cloud asset inventory |
 | **Core** | _No additional scopes_ | Basic connectivity and system information |
 | **Custom IOA** | `Custom IOA Rules:read`<br>`Custom IOA Rules:write` | Create and manage Custom IOA behavioral detection rules and rule groups |
 | **Detections** | `Alerts:read` | Find and analyze detections to understand malicious activity |
@@ -112,20 +112,23 @@ The Falcon MCP Server supports different modules, each requiring specific API sc
 
 **API Scopes Required**:
 
-- `Falcon Container Image:read`
+- `Falcon Container Image:read` (for Kubernetes containers and image vulnerabilities)
+- `Cloud Security API Assets:Read` (for CSPM asset inventory)
 
 Provides tools for accessing and analyzing CrowdStrike Cloud Security resources:
 
 - `falcon_search_kubernetes_containers`: Search for containers from CrowdStrike Kubernetes & Containers inventory
 - `falcon_count_kubernetes_containers`: Count for containers by filter criteria from CrowdStrike Kubernetes & Containers inventory
 - `falcon_search_images_vulnerabilities`: Search for images vulnerabilities from CrowdStrike Image Assessments
+- `falcon_search_cspm_assets`: Search cloud assets in CSPM inventory with comprehensive FQL filtering (resource types, tags, compliance, security posture)
 
 **Resources**:
 
 - `falcon://cloud/kubernetes-containers/fql-guide`: Comprehensive FQL documentation and examples for kubernetes containers searches
 - `falcon://cloud/images-vulnerabilities/fql-guide`: Comprehensive FQL documentation and examples for images vulnerabilities searches
+- `falcon://cloud/cspm-assets/fql-guide`: Comprehensive FQL documentation and examples for CSPM asset searches with filtering by resource type, tags, compliance, and security posture
 
-**Use Cases**: Manage kubernetes containers inventory, container images vulnerabilities analysis
+**Use Cases**: Manage kubernetes containers inventory, container images vulnerabilities analysis, cloud asset inventory with tag-based filtering for compliance and cost management
 
 ### Core Functionality (Built into Server)
 

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -50,6 +50,9 @@ API_SCOPE_REQUIREMENTS = {
     "ReadContainerCombined": ["Falcon Container Image:read"],
     "ReadContainerCount": ["Falcon Container Image:read"],
     "ReadCombinedVulnerabilities": ["Falcon Container Image:read"],
+    # CSPM Assets operations
+    "cloud_security_assets_queries": ["Cloud Security API Assets:Read"],
+    "cloud_security_assets_entities_get": ["Cloud Security API Assets:Read"],
     # Identity Protection operations
     "api_preempt_proxy_post_graphql": [
         "Identity Protection Entities:read",

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -19,6 +19,7 @@ from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.resources.cloud import (
     IMAGES_VULNERABILITIES_FQL_DOCUMENTATION,
     KUBERNETES_CONTAINERS_FQL_DOCUMENTATION,
+    SEARCH_CSPM_ASSETS_FQL_DOCUMENTATION,
 )
 
 logger = get_logger(__name__)
@@ -53,6 +54,12 @@ class CloudModule(BaseModule):
             name="search_images_vulnerabilities",
         )
 
+        self._add_tool(
+            server=server,
+            method=self.search_cspm_assets,
+            name="search_cspm_assets",
+        )
+
     def register_resources(self, server: FastMCP) -> None:
         """Register resources with the MCP server.
         Args:
@@ -79,6 +86,18 @@ class CloudModule(BaseModule):
         self._add_resource(
             server,
             images_vulnerabilities_fql_resource,
+        )
+
+        cspm_assets_fql_resource = TextResource(
+            uri=AnyUrl("falcon://cloud/cspm-assets/fql-guide"),
+            name="falcon_search_cspm_assets_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_cspm_assets` tool.",
+            text=SEARCH_CSPM_ASSETS_FQL_DOCUMENTATION,
+        )
+
+        self._add_resource(
+            server,
+            cspm_assets_fql_resource,
         )
 
     def search_kubernetes_containers(
@@ -242,3 +261,134 @@ class CloudModule(BaseModule):
             error_message="Failed to perform operation",
             default_result=[],
         )
+
+    def search_cspm_assets(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://cloud/cspm-assets/fql-guide` resource when building this filter parameter.",
+            examples=["cloud_provider:'AWS'", "tags.'Environment':'Production'"],
+        ),
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=1000,
+            description="The maximum number of assets to return in this response (default: 100; max: 1000). Use with the offset or after parameter to manage pagination of results.",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index of overall result set from which to return assets.",
+        ),
+        after: str | None = Field(
+            default=None,
+            description="A pagination token used with the limit parameter to manage pagination of results. On your first request, don't provide an after token. On subsequent requests, provide the after token from the previous response to continue from that result set.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description=dedent(
+                """
+                Sort cloud assets using these options:
+
+                cloud_provider: Cloud provider name (AWS, Azure, GCP)
+                account_id: Cloud account ID
+                account_name: Cloud account name
+                resource_type: Resource type (e.g., AWS::EC2::Instance)
+                region: Cloud region
+                creation_time: When the asset was created
+                updated_at: When the asset was last updated
+
+                Sort either asc (ascending) or desc (descending).
+                Both formats are supported: 'updated_at.desc' or 'updated_at|desc'
+
+                Examples: 'updated_at.desc', 'resource_type.asc'
+            """
+            ).strip(),
+            examples=["updated_at.desc", "resource_type.asc"],
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search for cloud assets in your CrowdStrike CSPM Asset Inventory.
+
+        This tool queries cloud resources (EC2 instances, VPCs, subnets, load balancers, etc.)
+        managed by CrowdStrike CSPM. Supports comprehensive FQL filtering including:
+        - Cloud provider and resource type filtering
+        - Tag-based filtering (AWS/Azure/GCP tags)
+        - Security posture (publicly exposed, severity, IOM/IOA counts)
+        - Compliance status and benchmarks
+        - Temporal filtering (creation time, last updated)
+
+        IMPORTANT: You must use the `falcon://cloud/cspm-assets/fql-guide` resource when you need to use the `filter` parameter.
+        This resource contains the guide on how to build the FQL `filter` parameter for `falcon_search_cspm_assets` tool.
+
+        Returns FQL syntax guide on error or empty results to help refine queries.
+        """
+        # Step 1: Query for asset IDs
+        asset_ids = self._base_search_api_call(
+            operation="cloud_security_assets_queries",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "after": after,
+                "sort": sort,
+            },
+            error_message="Failed to query CSPM assets",
+        )
+
+        # Handle search error - return with FQL guide
+        if self._is_error(asset_ids):
+            return self._format_fql_error_response(
+                [asset_ids],
+                filter,
+                SEARCH_CSPM_ASSETS_FQL_DOCUMENTATION,
+            )
+
+        # Handle empty results - return with FQL guide
+        if not asset_ids:
+            return self._format_fql_error_response(
+                [],
+                filter,
+                SEARCH_CSPM_ASSETS_FQL_DOCUMENTATION,
+            )
+
+        # Step 2: Batch fetch full details (API limit: 100 IDs per request)
+        details = self._batch_get_cspm_assets(asset_ids)
+
+        if self._is_error(details):
+            return [details]
+
+        return details
+
+    def _batch_get_cspm_assets(self, asset_ids: list[str]) -> list[dict[str, Any]] | dict[str, Any]:
+        """Fetch CSPM asset details in batches of 100 (API limit).
+
+        The cloud_security_assets_entities_get API endpoint has a strict limit of 100 IDs
+        per request (as confirmed by API validation). This helper method splits large ID
+        lists into chunks and aggregates the results.
+
+        Args:
+            asset_ids: List of asset IDs to fetch
+
+        Returns:
+            List of asset details or error dict
+        """
+        BATCH_SIZE = 100
+        all_assets: list[dict[str, Any]] = []
+
+        for i in range(0, len(asset_ids), BATCH_SIZE):
+            batch = asset_ids[i : i + BATCH_SIZE]
+            result = self._base_get_by_ids(
+                operation="cloud_security_assets_entities_get",
+                ids=batch,
+                id_key="ids",
+                use_params=True,  # CRITICAL: GET method requires use_params
+            )
+
+            # Fail fast on error
+            if self._is_error(result):
+                return result
+
+            # Aggregate results
+            if isinstance(result, list):
+                all_assets.extend(result)
+
+        return all_assets

--- a/falcon_mcp/resources/cloud.py
+++ b/falcon_mcp/resources/cloud.py
@@ -579,3 +579,218 @@ cvss_score:>5+container_running_status:true
 registry:*'*docker*'
 """
 )
+
+# List of tuples containing filter options data: (name, type, description)
+SEARCH_CSPM_ASSETS_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Description"
+    ),
+    (
+        "account_id",
+        "String",
+        """
+        The cloud provider account ID.
+
+        Ex: account_id:'123456789012'
+        """
+    ),
+    (
+        "account_name",
+        "String",
+        """
+        The cloud provider account name.
+
+        Ex: account_name:'production-account'
+        """
+    ),
+    (
+        "cloud_provider",
+        "String",
+        """
+        The cloud provider hosting the resource.
+        Values: AWS, Azure, GCP (case-sensitive).
+
+        Ex: cloud_provider:'AWS'
+        Ex: cloud_provider:['AWS', 'Azure']
+        """
+    ),
+    (
+        "resource_type",
+        "String",
+        """
+        The cloud resource type in ARN format or short format.
+        Examples: AWS::EC2::Instance, ec2-instance, AWS::S3::Bucket.
+
+        Ex: resource_type:'AWS::EC2::Instance'
+        Ex: resource_type:'ec2-instance'
+        Ex: resource_type:*'*S3*'
+        """
+    ),
+    (
+        "resource_id",
+        "String",
+        """
+        The unique identifier of the cloud resource.
+
+        Ex: resource_id:'//ec2.amazonaws.com/i-1234567890abcdef0'
+        """
+    ),
+    (
+        "region",
+        "String",
+        """
+        The cloud region where the resource is deployed.
+
+        Ex: region:'us-east-1'
+        Ex: region:['us-east-1', 'us-west-2']
+        """
+    ),
+    (
+        "tags",
+        "String",
+        """
+        AWS/Azure/GCP tags in key-value format.
+        IMPORTANT: Use tags.'key':'value' syntax with single quotes.
+
+        Ex: tags.'Environment':'Production'
+        Ex: tags.'Application':'*web*'
+        Ex: tags.'Owner':'CloudOps'+tags.'CostCenter':'12345'
+        Ex: tags.'Team':*  (tag key exists, any value)
+        """
+    ),
+    (
+        "creation_time",
+        "Timestamp",
+        """
+        Timestamp when the cloud resource was created in UTC format.
+
+        Ex: creation_time:>'2025-01-01T00:00:00Z'
+        Ex: creation_time:<='2024-12-31T23:59:59Z'
+        """
+    ),
+    (
+        "updated_at",
+        "Timestamp",
+        """
+        Timestamp when the asset was last updated in CrowdStrike in UTC format.
+
+        Ex: updated_at:>'2025-03-01T00:00:00Z'
+        """
+    ),
+    (
+        "active",
+        "Boolean",
+        """
+        Indicates if the asset is currently active.
+
+        Ex: active:true
+        """
+    ),
+    (
+        "service",
+        "String",
+        """
+        The cloud service category.
+        Examples: EC2, S3, API Gateway, Lambda, VPC.
+
+        Ex: service:'EC2'
+        Ex: service:*'*Gateway*'
+        """
+    ),
+    (
+        "service_category",
+        "String",
+        """
+        The broader service category.
+        Examples: Compute, Storage, Networking, Database.
+
+        Ex: service_category:'Compute'
+        """
+    ),
+    (
+        "location",
+        "String",
+        """
+        The geographic location of the resource (may differ from region).
+
+        Ex: location:'us-central1'
+        Ex: location:'global'
+        """
+    ),
+]
+
+SEARCH_CSPM_ASSETS_FQL_DOCUMENTATION = (
+    FQL_DOCUMENTATION
+    + """
+=== falcon_search_cspm_assets FQL filter available fields ===
+
+""" + generate_md_table(SEARCH_CSPM_ASSETS_FQL_FILTERS) + """
+
+=== falcon_search_cspm_assets FQL filter examples ===
+
+# Find AWS production assets by tag
+tags.'Environment':'Production'+cloud_provider:'AWS'
+
+# Find EC2 instances
+resource_type:'AWS::EC2::Instance'
+
+# Find assets by multiple tags (AND condition)
+tags.'Owner':'CloudOps'+tags.'CostCenter':'12345'
+
+# Find assets with any value for a specific tag key
+tags.'Team':*
+
+# Find assets by cloud provider and region
+cloud_provider:'AWS'+region:['us-east-1', 'us-west-2']
+
+# Find assets created in the last 30 days
+creation_time:>'2025-02-16T00:00:00Z'
+
+# Find assets by service category and active status
+service_category:'Compute'+active:true
+
+# Find assets with wildcard on resource type
+resource_type:*'*S3*'
+
+# Find assets by account and service
+account_name:'production-account'+service:'Lambda'
+
+=== Cloud Resource Tag Filtering Syntax ===
+
+Cloud resource tags (AWS/Azure/GCP) use a special nested syntax: tags.'key':'value'
+
+IMPORTANT RULES:
+• Always use single quotes: tags.'Environment':'Production'
+• Tag keys and values are case-sensitive: 'Production' ≠ 'production'
+• Wildcards supported: tags.'Application':'*web*'
+• Multiple tags with AND: tags.'Env':'Prod'+tags.'Owner':'Ops'
+• Check if tag exists: tags.'CostCenter':*
+• Combine with other filters: tags.'Env':'Prod'+cloud_provider:'AWS'
+
+EXAMPLES:
+tags.'Environment':'Production'              # Exact match
+tags.'Application':'*web*'                   # Contains 'web'
+tags.'Owner':'CloudOps'+tags.'Env':'Prod'    # Multiple tags
+tags.'CostCenter':*                          # Tag key exists
+cloud_provider:'AWS'+tags.'Team':'Security'  # Tags + provider
+
+=== Common Use Cases ===
+
+# Compliance: Find production assets for audit
+tags.'Environment':'Production'+tags.'Compliance':'PCI'
+
+# Cost Management: Find resources by cost center
+tags.'CostCenter':'12345'+active:true
+
+# Security: Find exposed compute resources
+service_category:'Compute'+cloud_provider:'AWS'
+
+# Multi-region inventory
+cloud_provider:'AWS'+region:['us-east-1', 'eu-west-1']
+
+# Recent changes: Assets updated in last 7 days
+updated_at:>'2025-03-11T00:00:00Z'
+"""
+)

--- a/tests/integration/test_cloud.py
+++ b/tests/integration/test_cloud.py
@@ -122,3 +122,92 @@ class TestCloudIntegration(BaseIntegrationTest):
         # Test ReadCombinedVulnerabilities
         result = self.call_method(self.module.search_images_vulnerabilities, limit=1)
         self.assert_no_error(result, context="ReadCombinedVulnerabilities operation name")
+
+        # Test cloud_security_assets_queries and cloud_security_assets_entities_get
+        result = self.call_method(self.module.search_cspm_assets, limit=1)
+        self.assert_no_error(result, context="CSPM operation names")
+
+    def test_search_cspm_assets_returns_details(self):
+        """Test that search_cspm_assets returns full asset details using two-step pattern.
+
+        Validates:
+        - cloud_security_assets_queries operation name is correct
+        - cloud_security_assets_entities_get operation name is correct
+        - Two-step pattern (query IDs -> get details) works correctly
+        - Returns full asset records, not just IDs
+        """
+        result = self.call_method(self.module.search_cspm_assets, limit=5)
+
+        self.assert_no_error(result, context="search_cspm_assets")
+        self.assert_valid_list_response(result, min_length=0, context="search_cspm_assets")
+
+        if len(result) > 0:
+            # Verify we get full details, not just IDs
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["id", "cloud_provider", "resource_type"],
+                context="search_cspm_assets",
+            )
+
+    def test_search_cspm_assets_with_cloud_provider_filter(self):
+        """Test search_cspm_assets with cloud provider FQL filter."""
+        result = self.call_method(
+            self.module.search_cspm_assets,
+            filter="cloud_provider:'AWS'",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="search_cspm_assets with cloud_provider filter")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_cspm_assets with cloud_provider filter"
+        )
+
+        # If results exist, verify they match the filter
+        if len(result) > 0:
+            for asset in result:
+                assert "cloud_provider" in asset, "Asset should have cloud_provider field"
+                # Note: Filter may return AWS and aws, be flexible
+                assert asset["cloud_provider"].upper() == "AWS", (
+                    f"Expected cloud_provider AWS, got {asset['cloud_provider']}"
+                )
+
+    def test_search_cspm_assets_with_tag_filter(self):
+        """Test search_cspm_assets with tag FQL filter syntax.
+
+        Validates the tags.'key':'value' FQL syntax is accepted by the API.
+        May return empty results if no assets have this tag.
+        """
+        result = self.call_method(
+            self.module.search_cspm_assets,
+            filter="tags.'Environment':*",
+            limit=10,
+        )
+
+        self.assert_no_error(result, context="search_cspm_assets with tag filter")
+        self.assert_valid_list_response(result, min_length=0, context="search_cspm_assets with tag filter")
+
+    def test_search_cspm_assets_with_sort(self):
+        """Test search_cspm_assets with sort parameter."""
+        result = self.call_method(
+            self.module.search_cspm_assets,
+            sort="updated_at.desc",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="search_cspm_assets with sort")
+        self.assert_valid_list_response(result, min_length=0, context="search_cspm_assets with sort")
+
+    def test_search_cspm_assets_batching_large_result(self):
+        """Test search_cspm_assets with large limit to verify batching works.
+
+        If the environment has >100 assets, this tests the batching logic.
+        """
+        result = self.call_method(self.module.search_cspm_assets, limit=500)
+
+        self.assert_no_error(result, context="search_cspm_assets with large limit")
+        self.assert_valid_list_response(result, min_length=0, context="search_cspm_assets large result")
+
+        # If we got >100 results, batching was tested successfully
+        if len(result) > 100:
+            print(f"✅ Batching tested successfully with {len(result)} assets")
+

--- a/tests/modules/test_cloud.py
+++ b/tests/modules/test_cloud.py
@@ -21,6 +21,7 @@ class TestCloudModule(TestModules):
             "falcon_search_kubernetes_containers",
             "falcon_count_kubernetes_containers",
             "falcon_search_images_vulnerabilities",
+            "falcon_search_cspm_assets",
         ]
         self.assert_tools_registered(expected_tools)
 
@@ -29,6 +30,7 @@ class TestCloudModule(TestModules):
         expected_resources = [
             "falcon_kubernetes_containers_fql_filter_guide",
             "falcon_images_vulnerabilities_fql_filter_guide",
+            "falcon_search_cspm_assets_fql_guide",
         ]
         self.assert_resources_registered(expected_resources)
 
@@ -125,6 +127,199 @@ class TestCloudModule(TestModules):
         self.assertIn("error", result)
         self.assertIn("details", result)
 
+    def test_search_cspm_assets_success(self):
+        """Test searching for CSPM assets with two-step pattern."""
+        # Mock query response (returns IDs)
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["asset_1", "asset_2", "asset_3"]},
+        }
+        # Mock get response (returns full details)
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "asset_1", "cloud_provider": "AWS", "resource_type": "ec2-instance"},
+                    {"id": "asset_2", "cloud_provider": "AWS", "resource_type": "s3-bucket"},
+                    {"id": "asset_3", "cloud_provider": "Azure", "resource_type": "vm"},
+                ]
+            },
+        }
+
+        # Configure side_effect to return query then get
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_cspm_assets(
+            filter="cloud_provider:'AWS'", limit=10
+        )
+
+        # Verify 2 API calls made
+        self.assertEqual(self.mock_client.command.call_count, 2)
+
+        # Verify first call (query)
+        first_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(first_call[0][0], "cloud_security_assets_queries")
+        self.assertEqual(first_call[1]["parameters"]["filter"], "cloud_provider:'AWS'")
+        self.assertEqual(first_call[1]["parameters"]["limit"], 10)
+
+        # Verify second call (get details)
+        second_call = self.mock_client.command.call_args_list[1]
+        self.assertEqual(second_call[0][0], "cloud_security_assets_entities_get")
+        self.assertEqual(
+            second_call[1]["parameters"]["ids"], ["asset_1", "asset_2", "asset_3"]
+        )
+
+        # Verify result is full details, not just IDs
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 3)
+        self.assertIn("cloud_provider", result[0])
+        self.assertIn("resource_type", result[0])
+
+    def test_search_cspm_assets_batching(self):
+        """Test CSPM assets search handles >100 IDs with batching."""
+        # Mock 250 IDs
+        asset_ids = [f"asset_{i}" for i in range(250)]
+        query_response = {"status_code": 200, "body": {"resources": asset_ids}}
+
+        # Mock 3 batches (100 + 100 + 50)
+        batch1_assets = [
+            {"id": f"asset_{i}", "cloud_provider": "AWS"}
+            for i in range(100)
+        ]
+        batch2_assets = [
+            {"id": f"asset_{i}", "cloud_provider": "AWS"}
+            for i in range(100, 200)
+        ]
+        batch3_assets = [
+            {"id": f"asset_{i}", "cloud_provider": "AWS"}
+            for i in range(200, 250)
+        ]
+
+        batch1 = {"status_code": 200, "body": {"resources": batch1_assets}}
+        batch2 = {"status_code": 200, "body": {"resources": batch2_assets}}
+        batch3 = {"status_code": 200, "body": {"resources": batch3_assets}}
+
+        self.mock_client.command.side_effect = [
+            query_response,
+            batch1,
+            batch2,
+            batch3,
+        ]
+
+        result = self.module.search_cspm_assets(limit=1000)
+
+        # Verify 4 calls: 1 query + 3 get batches
+        self.assertEqual(self.mock_client.command.call_count, 4)
+
+        # Verify batching calls - validate both length and content
+        # Second call should contain IDs 0-99
+        second_call = self.mock_client.command.call_args_list[1]
+        self.assertEqual(second_call[0][0], "cloud_security_assets_entities_get")
+        self.assertEqual(
+            second_call[1]["parameters"]["ids"], [f"asset_{i}" for i in range(100)]
+        )
+
+        # Third call should contain IDs 100-199
+        third_call = self.mock_client.command.call_args_list[2]
+        self.assertEqual(third_call[0][0], "cloud_security_assets_entities_get")
+        self.assertEqual(
+            third_call[1]["parameters"]["ids"], [f"asset_{i}" for i in range(100, 200)]
+        )
+
+        # Fourth call should contain IDs 200-249
+        fourth_call = self.mock_client.command.call_args_list[3]
+        self.assertEqual(fourth_call[0][0], "cloud_security_assets_entities_get")
+        self.assertEqual(
+            fourth_call[1]["parameters"]["ids"], [f"asset_{i}" for i in range(200, 250)]
+        )
+
+        # Verify all 250 assets returned
+        self.assertEqual(len(result), 250)
+
+    def test_search_cspm_assets_error_returns_fql_guide(self):
+        """Test CSPM assets search returns FQL guide on error."""
+        mock_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid FQL syntax"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        result = self.module.search_cspm_assets(filter="invalid::syntax")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("fql_guide", result)
+        self.assertIn("filter_used", result)
+        self.assertIn("hint", result)
+        self.assertIn("tags.'key':'value'", result["fql_guide"])
+
+    def test_search_cspm_assets_empty_returns_fql_guide(self):
+        """Test CSPM assets search returns FQL guide on empty results."""
+        query_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = query_response
+
+        result = self.module.search_cspm_assets(filter="cloud_provider:'NonExistent'")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("fql_guide", result)
+        self.assertIn("filter_used", result)
+        self.assertEqual(result["results"], [])
+        self.assertIn("Cloud Resource Tag Filtering", result["fql_guide"])
+
+    def test_search_cspm_assets_batch_error_fails_fast(self):
+        """Test CSPM assets batching fails fast on batch error."""
+        # Mock 250 IDs
+        asset_ids = [f"asset_{i}" for i in range(250)]
+        query_response = {"status_code": 200, "body": {"resources": asset_ids}}
+
+        # First batch succeeds, second batch fails
+        batch1 = {
+            "status_code": 200,
+            "body": {"resources": [{"id": f"asset_{i}"} for i in range(100)]},
+        }
+        batch2_error = {
+            "status_code": 500,
+            "body": {"errors": [{"message": "Internal server error"}]},
+        }
+
+        self.mock_client.command.side_effect = [
+            query_response,
+            batch1,
+            batch2_error,
+        ]
+
+        result = self.module.search_cspm_assets(limit=1000)
+
+        # Verify only 3 calls (query + batch1 + batch2 error)
+        self.assertEqual(self.mock_client.command.call_count, 3)
+
+        # Verify error returned (not partial results)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    def test_search_cspm_assets_uses_params_true(self):
+        """Test CSPM assets get request uses use_params=True for GET method."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["asset_1"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "asset_1"}]},
+        }
+
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        self.module.search_cspm_assets(limit=1)
+
+        # Verify second call uses parameters (not body)
+        second_call = self.mock_client.command.call_args_list[1]
+        self.assertIn("parameters", second_call[1])
+        self.assertNotIn("body", second_call[1])
+
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
Closes #278

Adds `falcon_search_cspm_assets` tool for querying CrowdStrike CSPM cloud asset inventory with full FQL support including tag filtering syntax (`tags.'key':'value'`). Implements the two-step search pattern (query IDs then get details) with batched entity retrieval for result sets exceeding the 100-ID API limit. Includes a comprehensive FQL documentation resource covering filter fields, tag syntax, and common use cases. Also adds the `Cloud Security API Assets:Read` scope and updates the README accordingly.