### PR TITLE
feat(modules/rtr): add real time response support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   - [Hosts Module](#hosts-module)
   - [Identity Protection Module](#identity-protection-module)
   - [Incidents Module](#incidents-module)
+  - [Real Time Response Module](#real-time-response-module)
   - [NGSIEM Module](#ngsiem-module)
   - [Intel Module](#intel-module)
   - [IOC Module](#ioc-module)
@@ -92,6 +93,7 @@ The Falcon MCP Server supports different modules, each requiring specific API sc
 | **Hosts** | `Hosts:read` | Manage and query host/device information |
 | **Identity Protection** | `Identity Protection Entities:read`<br>`Identity Protection Timeline:read`<br>`Identity Protection Detections:read`<br>`Identity Protection Assessment:read`<br>`Identity Protection GraphQL:write` | Comprehensive entity investigation and identity protection analysis |
 | **Incidents** | `Incidents:read` | Analyze security incidents and coordinated activities |
+| **Real Time Response** | `Real time response:read`<br>`Real time response:write` | Initialize RTR sessions, execute read-only triage commands, inspect command output, and review RTR session artifacts |
 | **NGSIEM** | `NGSIEM:read`<br>`NGSIEM:write` | Execute CQL queries against Next-Gen SIEM |
 | **Intel** | `Actors (Falcon Intelligence):read`<br>`Indicators (Falcon Intelligence):read`<br>`Reports (Falcon Intelligence):read` | Research threat actors, IOCs, and intelligence reports |
 | **IOC** | `IOC Management:read`<br>`IOC Management:write` | Search, create, and remove custom IOCs using IOC Service Collection endpoints |
@@ -241,6 +243,26 @@ Provides tools for accessing and analyzing CrowdStrike Falcon incidents:
 - `falcon://incidents/behaviors/fql-guide`: Comprehensive FQL documentation and examples for behavior searches
 
 **Use Cases**: Incident management, threat assessment, attack pattern analysis, security posture monitoring
+
+### Real Time Response Module
+
+**API Scopes Required**:
+
+- `Real time response:read`
+- `Real time response:write`
+
+Provides tools for host-level hunt and triage workflows through CrowdStrike Real Time Response:
+
+- `falcon_search_rtr_sessions`: Search RTR sessions and return full session details
+- `falcon_get_rtr_session_details`: Retrieve detailed metadata for specific RTR session IDs
+- `falcon_init_rtr_session`: Initialize or reuse an RTR session for a host
+- `falcon_pulse_rtr_session`: Refresh an RTR session timeout for a host
+- `falcon_execute_rtr_read_only_command`: Execute a read-only RTR command such as `ls`, `ps`, `cat`, or `filehash`
+- `falcon_check_rtr_command_status`: Retrieve command execution status and output chunks
+- `falcon_list_rtr_session_files`: List files associated with an RTR session
+- `falcon_delete_rtr_session`: Close an RTR session
+
+**Use Cases**: Live host triage, evidence collection, execution verification, session-aware investigative workflows
 
 ### NGSIEM Module
 

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -77,6 +77,15 @@ API_SCOPE_REQUIREMENTS = {
     "StartSearchV1": ["NGSIEM:write"],
     "GetSearchStatusV1": ["NGSIEM:read"],
     "StopSearchV1": ["NGSIEM:write"],
+    # Real Time Response operations
+    "RTR_ListAllSessions": ["Real time response:read"],
+    "RTR_ListSessions": ["Real time response:read"],
+    "RTR_InitSession": ["Real time response:read"],
+    "RTR_DeleteSession": ["Real time response:read"],
+    "RTR_PulseSession": ["Real time response:read"],
+    "RTR_CheckCommandStatus": ["Real time response:read"],
+    "RTR_ExecuteCommand": ["Real time response:read"],
+    "RTR_ListFilesV2": ["Real time response:write"],
     # Custom IOA operations
     "query_rule_groups_full": ["Custom IOA Rules:read"],
     "query_platformsMixin0": ["Custom IOA Rules:read"],

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -9,20 +9,18 @@ from textwrap import dedent
 from typing import Any
 
 from mcp.server import FastMCP
+from mcp.server.fastmcp.resources import TextResource
 from mcp.types import ToolAnnotations
-from pydantic import Field
+from pydantic import AnyUrl, Field
 
 from falcon_mcp.common.logging import get_logger
 from falcon_mcp.modules.base import BaseModule
+from falcon_mcp.resources.rtr import (
+    EMBEDDED_FQL_SYNTAX,
+    SEARCH_RTR_SESSIONS_FQL_DOCUMENTATION,
+)
 
 logger = get_logger(__name__)
-
-SAFE_STATEFUL_ANNOTATIONS = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=False,
-    openWorldHint=True,
-)
 
 
 class RTRModule(BaseModule):
@@ -50,21 +48,36 @@ class RTRModule(BaseModule):
             server=server,
             method=self.init_session,
             name="init_rtr_session",
-            annotations=SAFE_STATEFUL_ANNOTATIONS,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
         )
 
         self._add_tool(
             server=server,
             method=self.pulse_session,
             name="pulse_rtr_session",
-            annotations=SAFE_STATEFUL_ANNOTATIONS,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
         )
 
         self._add_tool(
             server=server,
             method=self.execute_read_only_command,
             name="execute_rtr_read_only_command",
-            annotations=SAFE_STATEFUL_ANNOTATIONS,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
         )
 
         self._add_tool(
@@ -83,37 +96,38 @@ class RTRModule(BaseModule):
             server=server,
             method=self.delete_session,
             name="delete_rtr_session",
-            annotations=SAFE_STATEFUL_ANNOTATIONS,
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+    def register_resources(self, server: FastMCP) -> None:
+        """Register resources with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        search_rtr_sessions_fql_resource = TextResource(
+            uri=AnyUrl("falcon://rtr/sessions/search/fql-guide"),
+            name="falcon_search_rtr_sessions_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_rtr_sessions` tool.",
+            text=SEARCH_RTR_SESSIONS_FQL_DOCUMENTATION,
+        )
+
+        self._add_resource(
+            server,
+            search_rtr_sessions_fql_resource,
         )
 
     def search_sessions(
         self,
         filter: str | None = Field(
             default=None,
-            description=dedent("""
-                FQL expression used to limit RTR sessions.
-
-                Common fields include:
-                - `id`
-                - `created_at`
-                - `updated_at`
-                - `deleted_at`
-                - `aid`
-                - `hostname`
-                - `user_id`
-                - `origin`
-                - `cloud_request_id`
-                - `command_string`
-                - `base_command`
-                - `offline_queued`
-                - `commands_queued`
-
-                `user_id:'@me'` restricts results to the current API user.
-            """).strip(),
-            examples={
-                "hostname:'BRR-WB-LIB-22'",
-                "aid:'2c5c4e7738004deaa9dfcdb86f633f3e'",
-            },
+            description=EMBEDDED_FQL_SYNTAX,
+            examples=["hostname:'BRR-WB-LIB-22'", "aid:'2c5c4e7738...'"],
         ),
         limit: int = Field(
             default=10,
@@ -131,14 +145,15 @@ class RTRModule(BaseModule):
                 Sort RTR sessions by a supported session property such as:
                 `created_at.asc`, `updated_at.desc`, or `hostname.asc`.
             """).strip(),
-            examples={"created_at.desc", "hostname.asc"},
+            examples=["created_at.desc", "hostname.asc"],
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search RTR sessions and return full session details.
 
-        Use this tool to discover RTR sessions by hostname, aid, command metadata,
-        or origin. If matching session IDs are found, the tool fetches their full
-        details before returning.
+        IMPORTANT: You must use the `falcon://rtr/sessions/search/fql-guide` resource when you need to use the `filter` parameter.
+        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_rtr_sessions` tool.
+
+        Returns FQL syntax guide on error or empty results to help refine queries.
         """
         session_ids = self._base_search_api_call(
             operation="RTR_ListAllSessions",
@@ -152,10 +167,14 @@ class RTRModule(BaseModule):
         )
 
         if self._is_error(session_ids):
-            return [session_ids]
+            return self._format_fql_error_response(
+                [session_ids], filter, SEARCH_RTR_SESSIONS_FQL_DOCUMENTATION
+            )
 
         if not session_ids:
-            return []
+            return self._format_fql_error_response(
+                [], filter, SEARCH_RTR_SESSIONS_FQL_DOCUMENTATION
+            )
 
         details = self._base_get_by_ids(
             operation="RTR_ListSessions",
@@ -215,12 +234,14 @@ class RTRModule(BaseModule):
         """Initialize or reuse an RTR session for a single host."""
         return self._base_query_api_call(
             operation="RTR_InitSession",
+            query_params={
+                "timeout": timeout,
+                "timeout_duration": timeout_duration,
+            },
             body_params={
                 "device_id": device_id,
                 "origin": origin,
                 "queue_offline": queue_offline,
-                "timeout": timeout,
-                "timeout_duration": timeout_duration,
             },
             error_message="Failed to initialize RTR session",
         )
@@ -253,11 +274,11 @@ class RTRModule(BaseModule):
     def execute_read_only_command(
         self,
         session_id: str = Field(
-            description="RTR session ID returned from init_rtr_session or search_rtr_sessions.",
+            description="RTR session ID returned from falcon_init_rtr_session or falcon_search_rtr_sessions.",
         ),
         base_command: str = Field(
             description="Read-only RTR base command to execute, such as `ls`, `ps`, `cat`, `filehash`, or `reg`.",
-            examples={"ls", "ps", "filehash"},
+            examples=["ls", "ps", "filehash"],
         ),
         command_string: str | None = Field(
             default=None,
@@ -288,7 +309,7 @@ class RTRModule(BaseModule):
     def check_command_status(
         self,
         cloud_request_id: str = Field(
-            description="Cloud request ID returned from execute_rtr_read_only_command.",
+            description="Cloud request ID returned from falcon_execute_rtr_read_only_command.",
         ),
         sequence_id: int = Field(
             default=0,

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -1,0 +1,333 @@
+"""
+Real Time Response module for Falcon MCP Server.
+
+This module provides tools for initiating and inspecting RTR sessions and for
+executing read-only RTR commands during host investigations.
+"""
+
+from textwrap import dedent
+from typing import Any
+
+from mcp.server import FastMCP
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from falcon_mcp.common.logging import get_logger
+from falcon_mcp.modules.base import BaseModule
+
+logger = get_logger(__name__)
+
+SAFE_STATEFUL_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=True,
+)
+
+
+class RTRModule(BaseModule):
+    """Module for Real Time Response hunt and triage workflows."""
+
+    def register_tools(self, server: FastMCP) -> None:
+        """Register tools with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        self._add_tool(
+            server=server,
+            method=self.search_sessions,
+            name="search_rtr_sessions",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.get_session_details,
+            name="get_rtr_session_details",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.init_session,
+            name="init_rtr_session",
+            annotations=SAFE_STATEFUL_ANNOTATIONS,
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.pulse_session,
+            name="pulse_rtr_session",
+            annotations=SAFE_STATEFUL_ANNOTATIONS,
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.execute_read_only_command,
+            name="execute_rtr_read_only_command",
+            annotations=SAFE_STATEFUL_ANNOTATIONS,
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.check_command_status,
+            name="check_rtr_command_status",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.list_session_files,
+            name="list_rtr_session_files",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.delete_session,
+            name="delete_rtr_session",
+            annotations=SAFE_STATEFUL_ANNOTATIONS,
+        )
+
+    def search_sessions(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description=dedent("""
+                FQL expression used to limit RTR sessions.
+
+                Common fields include:
+                - `id`
+                - `created_at`
+                - `updated_at`
+                - `deleted_at`
+                - `aid`
+                - `hostname`
+                - `user_id`
+                - `origin`
+                - `cloud_request_id`
+                - `command_string`
+                - `base_command`
+                - `offline_queued`
+                - `commands_queued`
+
+                `user_id:'@me'` restricts results to the current API user.
+            """).strip(),
+            examples={
+                "hostname:'BRR-WB-LIB-22'",
+                "aid:'2c5c4e7738004deaa9dfcdb86f633f3e'",
+            },
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            le=5000,
+            description="Maximum number of RTR session IDs to return. Max: 5000.",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index of overall result set from which to return IDs.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description=dedent("""
+                Sort RTR sessions by a supported session property such as:
+                `created_at.asc`, `updated_at.desc`, or `hostname.asc`.
+            """).strip(),
+            examples={"created_at.desc", "hostname.asc"},
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search RTR sessions and return full session details.
+
+        Use this tool to discover RTR sessions by hostname, aid, command metadata,
+        or origin. If matching session IDs are found, the tool fetches their full
+        details before returning.
+        """
+        session_ids = self._base_search_api_call(
+            operation="RTR_ListAllSessions",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+            },
+            error_message="Failed to search RTR sessions",
+        )
+
+        if self._is_error(session_ids):
+            return [session_ids]
+
+        if not session_ids:
+            return []
+
+        details = self._base_get_by_ids(
+            operation="RTR_ListSessions",
+            ids=session_ids,
+            id_key="ids",
+            use_params=False,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        return details
+
+    def get_session_details(
+        self,
+        ids: list[str] = Field(
+            description="RTR session IDs to retrieve details for.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve detailed metadata for one or more RTR sessions."""
+        logger.debug("Getting RTR session details for IDs: %s", ids)
+
+        if not ids:
+            return []
+
+        return self._base_get_by_ids(
+            operation="RTR_ListSessions",
+            ids=ids,
+            id_key="ids",
+            use_params=False,
+        )
+
+    def init_session(
+        self,
+        device_id: str = Field(
+            description="The host agent ID (AID) to open or reuse an RTR session for.",
+        ),
+        origin: str = Field(
+            default="falcon-mcp",
+            description="Origin label for the RTR request.",
+        ),
+        queue_offline: bool = Field(
+            default=False,
+            description="Queue the request if the host is currently offline.",
+        ),
+        timeout: int | None = Field(
+            default=None,
+            ge=1,
+            le=600,
+            description="How long to wait for the request in seconds. Max: 600.",
+        ),
+        timeout_duration: str | None = Field(
+            default=None,
+            description="Alternate duration syntax such as `30s`, `2m`, or `1h`.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Initialize or reuse an RTR session for a single host."""
+        return self._base_query_api_call(
+            operation="RTR_InitSession",
+            body_params={
+                "device_id": device_id,
+                "origin": origin,
+                "queue_offline": queue_offline,
+                "timeout": timeout,
+                "timeout_duration": timeout_duration,
+            },
+            error_message="Failed to initialize RTR session",
+        )
+
+    def pulse_session(
+        self,
+        device_id: str = Field(
+            description="The host agent ID (AID) whose RTR session timeout should be refreshed.",
+        ),
+        origin: str = Field(
+            default="falcon-mcp",
+            description="Origin label for the RTR request.",
+        ),
+        queue_offline: bool = Field(
+            default=False,
+            description="Queue the pulse if the host is currently offline.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Refresh an RTR session timeout for a single host."""
+        return self._base_query_api_call(
+            operation="RTR_PulseSession",
+            body_params={
+                "device_id": device_id,
+                "origin": origin,
+                "queue_offline": queue_offline,
+            },
+            error_message="Failed to pulse RTR session",
+        )
+
+    def execute_read_only_command(
+        self,
+        session_id: str = Field(
+            description="RTR session ID returned from init_rtr_session or search_rtr_sessions.",
+        ),
+        base_command: str = Field(
+            description="Read-only RTR base command to execute, such as `ls`, `ps`, `cat`, `filehash`, or `reg`.",
+            examples={"ls", "ps", "filehash"},
+        ),
+        command_string: str | None = Field(
+            default=None,
+            description="Optional full command line to execute. Example: `cat C:\\Windows\\win.ini`.",
+        ),
+        persist: bool = Field(
+            default=False,
+            description="Persist the read-only command in the RTR session history.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Execute a read-only RTR command on a single host.
+
+        This tool is intentionally limited to the read-only RTR endpoint for
+        hunt and triage workflows. It does not expose admin or remediation
+        command APIs.
+        """
+        return self._base_query_api_call(
+            operation="RTR_ExecuteCommand",
+            body_params={
+                "session_id": session_id,
+                "base_command": base_command,
+                "command_string": command_string,
+                "persist": persist,
+            },
+            error_message="Failed to execute RTR read-only command",
+        )
+
+    def check_command_status(
+        self,
+        cloud_request_id: str = Field(
+            description="Cloud request ID returned from execute_rtr_read_only_command.",
+        ),
+        sequence_id: int = Field(
+            default=0,
+            ge=0,
+            description="Sequence chunk to retrieve for command output. Starts at 0.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Get the status and output chunk for an RTR command."""
+        return self._base_query_api_call(
+            operation="RTR_CheckCommandStatus",
+            query_params={
+                "cloud_request_id": cloud_request_id,
+                "sequence_id": sequence_id,
+            },
+            error_message="Failed to check RTR command status",
+        )
+
+    def list_session_files(
+        self,
+        session_id: str = Field(
+            description="RTR session ID to retrieve extracted session files for.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """List files currently associated with an RTR session."""
+        return self._base_query_api_call(
+            operation="RTR_ListFilesV2",
+            query_params={"session_id": session_id},
+            error_message="Failed to list RTR session files",
+        )
+
+    def delete_session(
+        self,
+        session_id: str = Field(
+            description="RTR session ID to close.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Delete an RTR session."""
+        return self._base_query_api_call(
+            operation="RTR_DeleteSession",
+            query_params={"session_id": session_id},
+            error_message="Failed to delete RTR session",
+        )

--- a/falcon_mcp/resources/rtr.py
+++ b/falcon_mcp/resources/rtr.py
@@ -1,0 +1,226 @@
+"""
+Contains RTR (Real Time Response) resources.
+"""
+
+from falcon_mcp.common.utils import generate_md_table
+
+# Concise FQL syntax for embedding in tool parameter descriptions
+EMBEDDED_FQL_SYNTAX = """FQL filter string for querying RTR sessions.
+
+SYNTAX:
+- Equals: field:'value'
+- Not equals: field:!'value'
+- Comparison: field:>50, field:>=50, field:<50, field:<=50
+- Contains (case-insensitive): field:~'partial'
+- Wildcard: field:'prefix*', field:'*suffix'
+
+COMBINING:
+- AND (all must match): field1:'value1'+field2:'value2'
+- OR (any can match): field:'value1',field:'value2'
+- Grouping: (field1:'v1',field1:'v2')+field2:'v3'
+
+COMMON FIELDS:
+- aid: Host agent ID
+- hostname: Host name
+- user_id: API user who created the session ('@me' for current user)
+- origin: Session origin label (e.g., 'falcon-mcp')
+- created_at: Session creation timestamp (ISO 8601)
+- updated_at: Last update timestamp (ISO 8601)
+- base_command: RTR command name (e.g., 'ls', 'ps', 'cat')
+- command_string: Full command line executed
+- offline_queued: Whether session was queued offline (true/false)
+
+EXAMPLES:
+- Sessions for a host: hostname:'BRR-WB-LIB-22'
+- Sessions by agent ID: aid:'2c5c4e7738004deaa9dfcdb86f633f3e'
+- Current user sessions: user_id:'@me'
+- Offline-queued sessions: offline_queued:true+hostname:'DC*'
+"""
+
+# List of tuples containing filter options data: (name, type, description)
+SEARCH_RTR_SESSIONS_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Description",
+    ),
+    (
+        "id",
+        "String",
+        """
+        RTR session ID.
+        Ex: 9f3c5e7a-1234-5678-abcd-ef0123456789
+        """,
+    ),
+    (
+        "created_at",
+        "Timestamp",
+        """
+        When the RTR session was created (ISO 8601).
+        Ex: 2025-03-15T10:30:00Z
+        """,
+    ),
+    (
+        "updated_at",
+        "Timestamp",
+        """
+        When the RTR session was last updated (ISO 8601).
+        Ex: 2025-03-15T11:00:00Z
+        """,
+    ),
+    (
+        "deleted_at",
+        "Timestamp",
+        """
+        When the RTR session was deleted (ISO 8601).
+        Ex: 2025-03-15T12:00:00Z
+        """,
+    ),
+    (
+        "aid",
+        "String",
+        """
+        Host agent ID the session is connected to.
+        Ex: 2c5c4e7738004deaa9dfcdb86f633f3e
+        """,
+    ),
+    (
+        "hostname",
+        "String",
+        """
+        Hostname of the connected host.
+        Ex: BRR-WB-LIB-22
+        """,
+    ),
+    (
+        "user_id",
+        "String",
+        """
+        API user who created the session. Use '@me' to
+        restrict results to the current API user.
+        Ex: user@example.com
+        """,
+    ),
+    (
+        "origin",
+        "String",
+        """
+        Origin label for the RTR session.
+        Ex: falcon-mcp
+        """,
+    ),
+    (
+        "cloud_request_id",
+        "String",
+        """
+        Cloud request ID associated with a command execution.
+        Ex: a1b2c3d4-5678-90ab-cdef-1234567890ab
+        """,
+    ),
+    (
+        "command_string",
+        "String",
+        """
+        Full command line string that was executed.
+        Ex: cat C:\\Windows\\win.ini
+        """,
+    ),
+    (
+        "base_command",
+        "String",
+        """
+        RTR base command name. Common values: ls, ps, cat,
+        filehash, reg, netstat, ifconfig, mount, users.
+        Ex: ps
+        """,
+    ),
+    (
+        "offline_queued",
+        "Boolean",
+        """
+        Whether the session was queued for offline execution.
+        Ex: true
+        """,
+    ),
+    (
+        "commands_queued",
+        "Boolean",
+        """
+        Whether commands are queued in the session.
+        Ex: true
+        """,
+    ),
+]
+
+SEARCH_RTR_SESSIONS_FQL_DOCUMENTATION = r"""Falcon Query Language (FQL) - Search RTR Sessions Guide
+
+=== BASIC SYNTAX ===
+field_name:[operator]'value'
+
+=== OPERATORS ===
+• = (default): field_name:'value'
+• !: field_name:!'value' (not equal)
+• >, >=, <, <=: field_name:>'2025-01-01T00:00:00Z' (comparison)
+• ~: field_name:~'partial' (text match, case insensitive)
+• !~: field_name:!~'exclude' (not text match)
+• *: field_name:'prefix*' or field_name:'*suffix*' (wildcards)
+
+=== DATA TYPES ===
+• String: 'value'
+• Number: 123 (no quotes)
+• Boolean: true/false (no quotes)
+• Timestamp: 'YYYY-MM-DDTHH:MM:SSZ'
+
+=== WILDCARDS ===
+✅ **String fields**: field_name:'pattern*' (prefix), field_name:'*pattern' (suffix), field_name:'*pattern*' (contains)
+❌ **Timestamp fields**: Not supported (causes errors)
+
+=== COMBINING ===
+• + = AND: hostname:'DC*'+user_id:'@me'
+• , = OR: base_command:'ls',base_command:'ps'
+• () = GROUPING: (base_command:'ls',base_command:'ps')+hostname:'DC*'
+
+=== SORT OPTIONS ===
+• created_at: When the session was created
+• updated_at: When the session was last updated
+• hostname: Hostname of the connected host
+
+Sort either asc (ascending) or desc (descending).
+Examples: 'created_at.desc', 'hostname.asc'
+
+=== falcon_search_rtr_sessions FQL filter available fields ===
+
+""" + generate_md_table(SEARCH_RTR_SESSIONS_FQL_FILTERS) + """
+
+=== COMPLEX FILTER EXAMPLES ===
+
+# Sessions for a specific host
+hostname:'BRR-WB-LIB-22'
+
+# Sessions by agent ID
+aid:'2c5c4e7738004deaa9dfcdb86f633f3e'
+
+# Current user's sessions only
+user_id:'@me'
+
+# Sessions created after a specific date
+created_at:>'2025-03-01T00:00:00Z'
+
+# Offline-queued sessions for a hostname pattern
+offline_queued:true+hostname:'DC*'
+
+# Sessions that ran specific commands
+base_command:'ps'+hostname:'PROD*'
+
+# Sessions with a specific origin label
+origin:'falcon-mcp'+user_id:'@me'
+
+# Sessions matching multiple commands
+(base_command:'ls',base_command:'cat',base_command:'filehash')+hostname:'WEB*'
+
+# Recent sessions for a host with queued commands
+commands_queued:true+created_at:>'2025-03-10T00:00:00Z'
+
+# Exclude deleted sessions for an agent
+deleted_at:!'*'+aid:'2c5c4e7738004deaa9dfcdb86f633f3e'
+"""

--- a/tests/integration/test_rtr.py
+++ b/tests/integration/test_rtr.py
@@ -1,9 +1,15 @@
 """Integration tests for the RTR module."""
 
+import warnings
+
 import pytest
 
+from falcon_mcp.modules.hosts import HostsModule
 from falcon_mcp.modules.rtr import RTRModule
-from tests.integration.utils.base_integration_test import BaseIntegrationTest
+from tests.integration.utils.base_integration_test import (
+    BaseIntegrationTest,
+    resolve_field_defaults,
+)
 
 
 @pytest.mark.integration
@@ -14,6 +20,9 @@ class TestRTRIntegration(BaseIntegrationTest):
     - Correct FalconPy operation names for RTR session search and details
     - Two-step search pattern returns full session details, not just IDs
     - POST body usage for session detail lookups
+    - FQL filter field names are accepted by the API
+    - FQL examples from documentation are syntactically valid
+    - Sort expressions work correctly
     """
 
     @pytest.fixture(autouse=True)
@@ -21,19 +30,44 @@ class TestRTRIntegration(BaseIntegrationTest):
         """Set up the RTR module with a real client."""
         self.module = RTRModule(falcon_client)
 
+    def _assert_fql_field_accepted(self, field_filter: str, context: str) -> None:
+        """Assert that an FQL filter expression is accepted by the API.
+
+        Calls search_sessions with the filter and checks that the API did not
+        reject the field name with a 400 error.  The method returns either a
+        list (results found) or a dict (FQL guide response on empty/error).
+
+        For dict responses we inspect the ``hint`` value:
+        - "No results matched" → field was accepted, just no data
+        - "Filter error occurred" → field was rejected (HTTP 400)
+        """
+        result = self.call_method(self.module.search_sessions, filter=field_filter, limit=1)
+        self.assert_no_error(result, context=context)
+
+        if isinstance(result, dict):
+            hint = result.get("hint", "")
+            assert "Filter error occurred" not in hint, (
+                f"FQL field rejected by API ({context}): filter={field_filter!r}, hint={hint}"
+            )
+
+    # ------------------------------------------------------------------
+    # Existing tests
+    # ------------------------------------------------------------------
+
     def test_search_rtr_sessions_returns_details(self):
         """Test that RTR session search returns full session details."""
         result = self.call_method(self.module.search_sessions, limit=5)
 
         self.assert_no_error(result, context="search_rtr_sessions")
-        self.assert_valid_list_response(result, min_length=0, context="search_rtr_sessions")
 
-        if len(result) > 0:
-            self.assert_search_returns_details(
-                result,
-                expected_fields=["id", "device_id", "hostname"],
-                context="search_rtr_sessions",
-            )
+        if isinstance(result, list):
+            self.assert_valid_list_response(result, min_length=0, context="search_rtr_sessions")
+            if len(result) > 0:
+                self.assert_search_returns_details(
+                    result,
+                    expected_fields=["id", "device_id", "hostname"],
+                    context="search_rtr_sessions",
+                )
 
     def test_search_rtr_sessions_with_sort(self):
         """Test RTR session search with a supported sort expression."""
@@ -44,17 +78,18 @@ class TestRTRIntegration(BaseIntegrationTest):
         )
 
         self.assert_no_error(result, context="search_rtr_sessions with sort")
-        self.assert_valid_list_response(
-            result,
-            min_length=0,
-            context="search_rtr_sessions with sort",
-        )
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result,
+                min_length=0,
+                context="search_rtr_sessions with sort",
+            )
 
     def test_get_rtr_session_details_with_valid_id(self):
         """Test session detail lookup using a valid session ID."""
         search_result = self.call_method(self.module.search_sessions, limit=1)
 
-        if not search_result or len(search_result) == 0:
+        if not isinstance(search_result, list) or len(search_result) == 0:
             self.skip_with_warning(
                 "No RTR sessions available to test get_rtr_session_details",
                 context="test_get_rtr_session_details_with_valid_id",
@@ -81,3 +116,412 @@ class TestRTRIntegration(BaseIntegrationTest):
         """Validate that the RTR FalconPy operation names are correct."""
         result = self.call_method(self.module.search_sessions, limit=1)
         self.assert_no_error(result, context="RTR operation name validation")
+
+    # ------------------------------------------------------------------
+    # FQL filter tests
+    # ------------------------------------------------------------------
+
+    def test_search_rtr_sessions_with_filter(self):
+        """Test search_sessions with a basic FQL filter."""
+        result = self.call_method(
+            self.module.search_sessions,
+            filter="hostname:'NONEXISTENT_HOST_XYZZY12345'",
+            limit=1,
+        )
+
+        self.assert_no_error(result, context="search_rtr_sessions with filter")
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result, min_length=0, context="search_rtr_sessions with filter"
+            )
+
+    def test_fql_string_fields_are_accepted(self):
+        """Validate that all documented string FQL fields are accepted."""
+        string_fields = [
+            "id",
+            "aid",
+            "hostname",
+            "user_id",
+            "origin",
+            "cloud_request_id",
+            "command_string",
+            "base_command",
+        ]
+        for field in string_fields:
+            self._assert_fql_field_accepted(
+                f"{field}:'NONEXISTENT_VALUE_XYZZY12345'",
+                context=f"string field {field}",
+            )
+
+    def test_fql_boolean_fields_are_accepted(self):
+        """Validate that all documented boolean FQL fields are accepted."""
+        boolean_fields = ["offline_queued", "commands_queued"]
+        for field in boolean_fields:
+            self._assert_fql_field_accepted(
+                f"{field}:true",
+                context=f"boolean field {field}",
+            )
+
+    def test_fql_timestamp_fields_are_accepted(self):
+        """Validate that all documented timestamp FQL fields are accepted."""
+        timestamp_fields = ["created_at", "updated_at", "deleted_at"]
+        for field in timestamp_fields:
+            self._assert_fql_field_accepted(
+                f"{field}:>'2099-01-01T00:00:00Z'",
+                context=f"timestamp field {field}",
+            )
+
+    # ------------------------------------------------------------------
+    # FQL example validation
+    # ------------------------------------------------------------------
+
+    def test_fql_example_user_id_at_me(self):
+        """Validate the @me special token is accepted."""
+        self._assert_fql_field_accepted(
+            "user_id:'@me'",
+            context="user_id @me special token",
+        )
+
+    def test_fql_example_deleted_at_not_wildcard(self):
+        """Validate deleted_at:!'*' wildcard exclusion syntax."""
+        self._assert_fql_field_accepted(
+            "deleted_at:!'*'",
+            context="deleted_at not-wildcard",
+        )
+
+    def test_fql_example_compound_filter(self):
+        """Validate compound AND filter with wildcard."""
+        self._assert_fql_field_accepted(
+            "offline_queued:true+hostname:'NONEXISTENT_XYZZY12345*'",
+            context="compound AND filter with wildcard",
+        )
+
+    # ------------------------------------------------------------------
+    # Sort expression tests
+    # ------------------------------------------------------------------
+
+    def test_sort_additional_fields(self):
+        """Validate additional sort expressions beyond created_at.desc."""
+        sort_expressions = ["updated_at.asc", "hostname.asc"]
+        for sort_expr in sort_expressions:
+            result = self.call_method(
+                self.module.search_sessions,
+                sort=sort_expr,
+                limit=1,
+            )
+            self.assert_no_error(result, context=f"sort {sort_expr}")
+
+
+@pytest.mark.integration
+class TestRTRLifecycleIntegration(BaseIntegrationTest):
+    """Integration tests for RTR session lifecycle (mutating operations).
+
+    Validates:
+    - Correct FalconPy operation names for RTR_InitSession, RTR_PulseSession,
+      RTR_ExecuteCommand, RTR_CheckCommandStatus, RTR_ListFilesV2, RTR_DeleteSession
+    - Parameter shapes accepted by the real API
+    - Response schemas match expectations
+
+    Requires:
+    - At least one host in the Falcon environment
+    - API key with Real time response:read scope
+    - Real time response:write scope for list_session_files (skipped if missing)
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_module(self, falcon_client):
+        """Set up the RTR module with a real client."""
+        self.module = RTRModule(falcon_client)
+
+    @pytest.fixture(autouse=True, scope="class")
+    def init_rtr_session(self, falcon_client):
+        """Initialize an RTR session for the class and clean up after all tests.
+
+        Looks up a real host AID via HostsModule, then opens an RTR session
+        with queue_offline=True so the API accepts immediately even if the
+        host is offline.
+        """
+        hosts_module = HostsModule(falcon_client)
+        rtr_module = RTRModule(falcon_client)
+
+        # Find a real host (last seen within the past hour)
+        host_kwargs = resolve_field_defaults(
+            hosts_module.search_hosts,
+            {
+                "filter": "last_seen:>='now-1h'",
+                "limit": 1,
+            },
+        )
+        hosts_result = hosts_module.search_hosts(**host_kwargs)
+
+        if not isinstance(hosts_result, list) or len(hosts_result) == 0:
+            pytest.skip("No hosts found in environment")
+
+        first_host = hosts_result[0]
+        if isinstance(first_host, dict) and "error" in first_host:
+            pytest.skip(f"Host search failed (check Hosts:read scope): {first_host}")
+
+        device_id = first_host.get("device_id") if isinstance(first_host, dict) else None
+        if not device_id:
+            pytest.skip("Could not extract device_id from host search results")
+
+        # Init RTR session with queue_offline=True for safety
+        init_kwargs = resolve_field_defaults(
+            rtr_module.init_session,
+            {
+                "device_id": device_id,
+                "queue_offline": True,
+                "origin": "falcon-mcp-integration-test",
+            },
+        )
+        result = rtr_module.init_session(**init_kwargs)
+
+        # Check for error (e.g. missing RTR read scope)
+        if isinstance(result, dict) and "error" in result:
+            pytest.skip(f"Cannot init RTR session (check Real time response:read scope): {result}")
+        if isinstance(result, list) and len(result) > 0:
+            first = result[0]
+            if isinstance(first, dict) and "error" in first:
+                pytest.skip(
+                    f"Cannot init RTR session (check Real time response:read scope): {first}"
+                )
+
+        # Extract session_id from response
+        session_id = None
+        if isinstance(result, list) and len(result) > 0:
+            first = result[0]
+            if isinstance(first, dict):
+                session_id = first.get("session_id")
+        elif isinstance(result, dict):
+            session_id = result.get("session_id")
+
+        if not session_id:
+            pytest.skip(f"Could not extract session_id from init response: {result}")
+
+        self.__class__._session_id = session_id
+        self.__class__._device_id = device_id
+        self.__class__._init_result = result
+        self.__class__._cloud_request_id = None  # sentinel for cascade-skip
+
+        yield
+
+        # Teardown: delete the session (idempotent)
+        try:
+            delete_kwargs = resolve_field_defaults(
+                rtr_module.delete_session,
+                {
+                    "session_id": session_id,
+                },
+            )
+            rtr_module.delete_session(**delete_kwargs)
+        except Exception as e:
+            warnings.warn(
+                f"Failed to clean up RTR session {session_id}: {e}",
+                stacklevel=2,
+            )
+
+    # ------------------------------------------------------------------
+    # Test methods
+    # ------------------------------------------------------------------
+
+    def test_init_session_response_shape(self):
+        """Validate that RTR_InitSession returned a dict with a session_id.
+
+        Uses the stored fixture result — no extra API call needed.
+        """
+        result = self.__class__._init_result
+
+        # Result is either a single dict or a list wrapping one
+        if isinstance(result, list):
+            assert len(result) > 0, "init_session returned empty list"
+            session = result[0]
+        else:
+            session = result
+
+        assert isinstance(session, dict), (
+            f"Expected dict for init_session response, got {type(session)}"
+        )
+        assert "session_id" in session, (
+            f"Expected 'session_id' in init response. Available fields: {list(session.keys())}"
+        )
+        assert isinstance(session["session_id"], str) and len(session["session_id"]) > 0, (
+            f"Expected non-empty session_id string, got {session['session_id']!r}"
+        )
+
+    def test_pulse_session(self):
+        """Validate RTR_PulseSession accepts the correct parameter shape."""
+        result = self.call_method(
+            self.module.pulse_session,
+            device_id=self.__class__._device_id,
+            queue_offline=True,
+        )
+
+        self.assert_no_error(result, context="pulse_session")
+
+        if isinstance(result, list):
+            self.assert_valid_list_response(result, min_length=0, context="pulse_session")
+
+    def test_execute_read_only_command(self):
+        """Validate RTR_ExecuteCommand with a simple `ls` command.
+
+        If the host is offline the API returns an error — store None for
+        cloud_request_id and downstream tests will cascade-skip.
+
+        Note: the RTR API requires `command_string` to contain the full
+        command line; `base_command` alone is not sufficient.
+        """
+        result = self.call_method(
+            self.module.execute_read_only_command,
+            session_id=self.__class__._session_id,
+            base_command="ls",
+            command_string="ls C:\\",
+        )
+
+        # Host may be offline — treat error as a graceful skip
+        if isinstance(result, dict) and "error" in result:
+            self.__class__._cloud_request_id = None
+            self.skip_with_warning(
+                "execute_read_only_command returned error (host likely offline)",
+                context="test_execute_read_only_command",
+            )
+
+        if isinstance(result, list) and len(result) > 0:
+            first = result[0]
+            if isinstance(first, dict) and "error" in first:
+                self.__class__._cloud_request_id = None
+                self.skip_with_warning(
+                    "execute_read_only_command returned error (host likely offline)",
+                    context="test_execute_read_only_command",
+                )
+
+        self.assert_no_error(result, context="execute_read_only_command")
+
+        # Extract cloud_request_id
+        cloud_request_id = None
+        if isinstance(result, list) and len(result) > 0:
+            first = result[0]
+            if isinstance(first, dict):
+                cloud_request_id = first.get("cloud_request_id")
+        elif isinstance(result, dict):
+            cloud_request_id = result.get("cloud_request_id")
+
+        assert cloud_request_id, f"Expected cloud_request_id in execute response. Got: {result}"
+        self.__class__._cloud_request_id = cloud_request_id
+
+    def test_check_command_status(self):
+        """Validate RTR_CheckCommandStatus returns output for a known request."""
+        if self.__class__._cloud_request_id is None:
+            self.skip_with_warning(
+                "No cloud_request_id available (execute command was skipped or failed)",
+                context="test_check_command_status",
+            )
+
+        result = self.call_method(
+            self.module.check_command_status,
+            cloud_request_id=self.__class__._cloud_request_id,
+            sequence_id=0,
+        )
+
+        self.assert_no_error(result, context="check_command_status")
+
+        if isinstance(result, list):
+            self.assert_valid_list_response(result, min_length=0, context="check_command_status")
+            if len(result) > 0:
+                first = result[0]
+                if isinstance(first, dict):
+                    assert "complete" in first, (
+                        f"Expected 'complete' field in command status. "
+                        f"Available fields: {list(first.keys())}"
+                    )
+                    assert "stdout" in first, (
+                        f"Expected 'stdout' field in command status. "
+                        f"Available fields: {list(first.keys())}"
+                    )
+
+    def test_list_session_files(self):
+        """Validate RTR_ListFilesV2 against a real session.
+
+        This operation requires Real time response:write scope. If the API
+        returns a 403 error, skip gracefully with a scope hint.
+        """
+        if self.__class__._cloud_request_id is None:
+            self.skip_with_warning(
+                "No cloud_request_id available (execute command was skipped or failed)",
+                context="test_list_session_files",
+            )
+
+        result = self.call_method(
+            self.module.list_session_files,
+            session_id=self.__class__._session_id,
+        )
+
+        # Handle 403 from missing :write scope
+        if isinstance(result, dict) and "error" in result:
+            error_str = str(result.get("error", ""))
+            if "403" in error_str or "Forbidden" in error_str:
+                self.skip_with_warning(
+                    "list_session_files returned 403 (check Real time response:write scope)",
+                    context="test_list_session_files",
+                )
+        if isinstance(result, list) and len(result) > 0:
+            first = result[0]
+            if isinstance(first, dict) and "error" in first:
+                error_str = str(first.get("error", ""))
+                if "403" in error_str or "Forbidden" in error_str:
+                    self.skip_with_warning(
+                        "list_session_files returned 403 (check Real time response:write scope)",
+                        context="test_list_session_files",
+                    )
+
+        self.assert_no_error(result, context="list_session_files")
+
+        if isinstance(result, list):
+            # Empty is valid — ls doesn't extract files
+            self.assert_valid_list_response(result, min_length=0, context="list_session_files")
+
+    def test_delete_session(self):
+        """Validate RTR_DeleteSession by creating and deleting a disposable session.
+
+        Does NOT delete the shared fixture's session — creates a fresh
+        disposable session with queue_offline=True and immediately deletes it.
+        """
+        # Create a disposable session
+        init_result = self.call_method(
+            self.module.init_session,
+            device_id=self.__class__._device_id,
+            queue_offline=True,
+            origin="falcon-mcp-integration-test-delete",
+        )
+
+        # Extract session_id from disposable session
+        disposable_session_id = None
+        if isinstance(init_result, list) and len(init_result) > 0:
+            first = init_result[0]
+            if isinstance(first, dict):
+                if "error" in first:
+                    self.skip_with_warning(
+                        f"Could not create disposable session: {first}",
+                        context="test_delete_session",
+                    )
+                disposable_session_id = first.get("session_id")
+        elif isinstance(init_result, dict):
+            if "error" in init_result:
+                self.skip_with_warning(
+                    f"Could not create disposable session: {init_result}",
+                    context="test_delete_session",
+                )
+            disposable_session_id = init_result.get("session_id")
+
+        if not disposable_session_id:
+            self.skip_with_warning(
+                f"Could not extract session_id from disposable init response: {init_result}",
+                context="test_delete_session",
+            )
+
+        # Delete it
+        delete_result = self.call_method(
+            self.module.delete_session,
+            session_id=disposable_session_id,
+        )
+
+        self.assert_no_error(delete_result, context="delete_session")

--- a/tests/integration/test_rtr.py
+++ b/tests/integration/test_rtr.py
@@ -1,0 +1,83 @@
+"""Integration tests for the RTR module."""
+
+import pytest
+
+from falcon_mcp.modules.rtr import RTRModule
+from tests.integration.utils.base_integration_test import BaseIntegrationTest
+
+
+@pytest.mark.integration
+class TestRTRIntegration(BaseIntegrationTest):
+    """Integration tests for the RTR module with real API calls.
+
+    Validates:
+    - Correct FalconPy operation names for RTR session search and details
+    - Two-step search pattern returns full session details, not just IDs
+    - POST body usage for session detail lookups
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_module(self, falcon_client):
+        """Set up the RTR module with a real client."""
+        self.module = RTRModule(falcon_client)
+
+    def test_search_rtr_sessions_returns_details(self):
+        """Test that RTR session search returns full session details."""
+        result = self.call_method(self.module.search_sessions, limit=5)
+
+        self.assert_no_error(result, context="search_rtr_sessions")
+        self.assert_valid_list_response(result, min_length=0, context="search_rtr_sessions")
+
+        if len(result) > 0:
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["id", "device_id", "hostname"],
+                context="search_rtr_sessions",
+            )
+
+    def test_search_rtr_sessions_with_sort(self):
+        """Test RTR session search with a supported sort expression."""
+        result = self.call_method(
+            self.module.search_sessions,
+            sort="created_at.desc",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="search_rtr_sessions with sort")
+        self.assert_valid_list_response(
+            result,
+            min_length=0,
+            context="search_rtr_sessions with sort",
+        )
+
+    def test_get_rtr_session_details_with_valid_id(self):
+        """Test session detail lookup using a valid session ID."""
+        search_result = self.call_method(self.module.search_sessions, limit=1)
+
+        if not search_result or len(search_result) == 0:
+            self.skip_with_warning(
+                "No RTR sessions available to test get_rtr_session_details",
+                context="test_get_rtr_session_details_with_valid_id",
+            )
+
+        session_id = self.get_first_id(search_result)
+        if not session_id:
+            self.skip_with_warning(
+                "Could not extract session ID from RTR search results",
+                context="test_get_rtr_session_details_with_valid_id",
+            )
+
+        result = self.call_method(self.module.get_session_details, ids=[session_id])
+
+        self.assert_no_error(result, context="get_rtr_session_details")
+        self.assert_valid_list_response(result, min_length=1, context="get_rtr_session_details")
+        self.assert_search_returns_details(
+            result,
+            expected_fields=["id", "device_id", "hostname"],
+            context="get_rtr_session_details",
+        )
+
+    def test_operation_names_are_correct(self):
+        """Validate that the RTR FalconPy operation names are correct."""
+        result = self.call_method(self.module.search_sessions, limit=1)
+        self.assert_no_error(result, context="RTR operation name validation")

--- a/tests/modules/test_rtr.py
+++ b/tests/modules/test_rtr.py
@@ -46,6 +46,15 @@ class TestRTRModule(TestModules):
             ),
         )
         self.assert_tool_annotations(
+            "falcon_pulse_rtr_session",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        self.assert_tool_annotations(
             "falcon_execute_rtr_read_only_command",
             ToolAnnotations(
                 readOnlyHint=False,
@@ -56,6 +65,22 @@ class TestRTRModule(TestModules):
         )
         self.assert_tool_annotations("falcon_check_rtr_command_status", READ_ONLY_ANNOTATIONS)
         self.assert_tool_annotations("falcon_list_rtr_session_files", READ_ONLY_ANNOTATIONS)
+        self.assert_tool_annotations(
+            "falcon_delete_rtr_session",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+    def test_register_resources(self):
+        """Test registering resources with the server."""
+        expected_resources = [
+            "falcon_search_rtr_sessions_fql_guide",
+        ]
+        self.assert_resources_registered(expected_resources)
 
     def test_search_sessions_returns_full_details(self):
         """Test searching RTR sessions fetches details after IDs are returned."""
@@ -121,12 +146,14 @@ class TestRTRModule(TestModules):
 
         self.mock_client.command.assert_called_once_with(
             "RTR_InitSession",
+            parameters={
+                "timeout": 30,
+                "timeout_duration": "30s",
+            },
             body={
                 "device_id": "aid-123",
                 "origin": "falcon-mcp",
                 "queue_offline": True,
-                "timeout": 30,
-                "timeout_duration": "30s",
             },
         )
         self.assertEqual(result[0]["session_id"], "session-1")
@@ -203,3 +230,142 @@ class TestRTRModule(TestModules):
             parameters={"session_id": "session-1"},
         )
         self.assertTrue(result[0]["deleted"])
+
+    def test_search_sessions_error_returns_fql_guide(self):
+        """Test searching RTR sessions with API error returns FQL guide."""
+        mock_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid filter"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        result = self.module.search_sessions(
+            filter="invalid:::filter",
+            limit=10,
+            offset=None,
+            sort=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("fql_guide", result)
+        self.assertIn("hint", result)
+        self.assertIn("Filter error occurred", result["hint"])
+
+    def test_search_sessions_empty_returns_fql_guide(self):
+        """Test searching RTR sessions with no results returns FQL guide."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.search_sessions(
+            filter="hostname:'nonexistent'",
+            limit=10,
+            offset=None,
+            sort=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("fql_guide", result)
+        self.assertIn("hint", result)
+        self.assertIn("No results matched", result["hint"])
+
+    def test_search_sessions_with_special_characters_in_filter(self):
+        """Test that special characters in filter are passed through safely."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        filter_with_special = "hostname:'test';DROP TABLE--"
+        self.module.search_sessions(
+            filter=filter_with_special,
+            limit=10,
+            offset=None,
+            sort=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["parameters"]["filter"], filter_with_special)
+
+    def test_search_sessions_with_long_filter_value(self):
+        """Test that extremely long filter values are passed through to the API."""
+        long_value = "a" * 10000
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        self.module.search_sessions(
+            filter=f"hostname:'{long_value}'",
+            limit=10,
+            offset=None,
+            sort=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertIn(long_value, call_args[1]["parameters"]["filter"])
+
+    def test_execute_command_with_malformed_session_id(self):
+        """Test execute_read_only_command with malformed session ID returns API error."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Session ID is invalid"}]},
+        }
+
+        result = self.module.execute_read_only_command(
+            session_id="not-a-real-session-!!!",
+            base_command="ps",
+            command_string=None,
+            persist=False,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    def test_check_command_status_with_malformed_request_id(self):
+        """Test check_command_status with malformed cloud_request_id returns API error."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "cloud_request_id must be a uuid string"}]},
+        }
+
+        result = self.module.check_command_status(
+            cloud_request_id="not-a-uuid-!!!",
+            sequence_id=0,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    def test_delete_session_with_malformed_session_id(self):
+        """Test delete_session with malformed session ID returns API error."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Session ID is invalid"}]},
+        }
+
+        result = self.module.delete_session(session_id="not-a-real-session-!!!")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    def test_init_session_permission_error(self):
+        """Test init_session with 403 permission error returns error response."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied, authorization failed"}]},
+        }
+
+        result = self.module.init_session(
+            device_id="aid-123",
+            origin="falcon-mcp",
+            queue_offline=False,
+            timeout=None,
+            timeout_duration=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)

--- a/tests/modules/test_rtr.py
+++ b/tests/modules/test_rtr.py
@@ -1,0 +1,205 @@
+"""
+Tests for the RTR module.
+"""
+
+from mcp.types import ToolAnnotations
+
+from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
+from falcon_mcp.modules.rtr import RTRModule
+from tests.modules.utils.test_modules import TestModules
+
+
+class TestRTRModule(TestModules):
+    """Test cases for the RTR module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(RTRModule)
+
+    def test_register_tools(self):
+        """Test registering tools with the server."""
+        expected_tools = [
+            "falcon_search_rtr_sessions",
+            "falcon_get_rtr_session_details",
+            "falcon_init_rtr_session",
+            "falcon_pulse_rtr_session",
+            "falcon_execute_rtr_read_only_command",
+            "falcon_check_rtr_command_status",
+            "falcon_list_rtr_session_files",
+            "falcon_delete_rtr_session",
+        ]
+        self.assert_tools_registered(expected_tools)
+
+    def test_tool_annotations(self):
+        """Test tool annotations are correctly set."""
+        self.module.register_tools(self.mock_server)
+
+        self.assert_tool_annotations("falcon_search_rtr_sessions", READ_ONLY_ANNOTATIONS)
+        self.assert_tool_annotations("falcon_get_rtr_session_details", READ_ONLY_ANNOTATIONS)
+        self.assert_tool_annotations(
+            "falcon_init_rtr_session",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        self.assert_tool_annotations(
+            "falcon_execute_rtr_read_only_command",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        self.assert_tool_annotations("falcon_check_rtr_command_status", READ_ONLY_ANNOTATIONS)
+        self.assert_tool_annotations("falcon_list_rtr_session_files", READ_ONLY_ANNOTATIONS)
+
+    def test_search_sessions_returns_full_details(self):
+        """Test searching RTR sessions fetches details after IDs are returned."""
+        search_response = {
+            "status_code": 200,
+            "body": {"resources": ["session-1", "session-2"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "session-1", "aid": "aid-1"},
+                    {"id": "session-2", "aid": "aid-2"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [search_response, details_response]
+
+        result = self.module.search_sessions(
+            filter="hostname:'BRR-WB-LIB-22'",
+            limit=25,
+            offset=0,
+            sort="created_at.desc",
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+        first_call = self.mock_client.command.call_args_list[0]
+        second_call = self.mock_client.command.call_args_list[1]
+
+        self.assertEqual(first_call[0][0], "RTR_ListAllSessions")
+        self.assertEqual(first_call[1]["parameters"]["filter"], "hostname:'BRR-WB-LIB-22'")
+        self.assertEqual(first_call[1]["parameters"]["limit"], 25)
+        self.assertEqual(first_call[1]["parameters"]["offset"], 0)
+        self.assertEqual(first_call[1]["parameters"]["sort"], "created_at.desc")
+
+        self.assertEqual(second_call[0][0], "RTR_ListSessions")
+        self.assertEqual(second_call[1]["body"]["ids"], ["session-1", "session-2"])
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "session-1")
+
+    def test_get_session_details_empty_ids(self):
+        """Test get_session_details returns early for empty input."""
+        result = self.module.get_session_details(ids=[])
+
+        self.assertEqual(result, [])
+        self.mock_client.command.assert_not_called()
+
+    def test_init_session(self):
+        """Test RTR session initialization."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"session_id": "session-1"}]},
+        }
+
+        result = self.module.init_session(
+            device_id="aid-123",
+            origin="falcon-mcp",
+            queue_offline=True,
+            timeout=30,
+            timeout_duration="30s",
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_InitSession",
+            body={
+                "device_id": "aid-123",
+                "origin": "falcon-mcp",
+                "queue_offline": True,
+                "timeout": 30,
+                "timeout_duration": "30s",
+            },
+        )
+        self.assertEqual(result[0]["session_id"], "session-1")
+
+    def test_execute_read_only_command(self):
+        """Test RTR read-only command execution."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-123"}]},
+        }
+
+        result = self.module.execute_read_only_command(
+            session_id="session-1",
+            base_command="cat",
+            command_string=r"cat C:\Windows\win.ini",
+            persist=False,
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_ExecuteCommand",
+            body={
+                "session_id": "session-1",
+                "base_command": "cat",
+                "command_string": r"cat C:\Windows\win.ini",
+                "persist": False,
+            },
+        )
+        self.assertEqual(result[0]["cloud_request_id"], "req-123")
+
+    def test_check_command_status(self):
+        """Test retrieving RTR command status."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"complete": True, "stdout": "ok"}]},
+        }
+
+        result = self.module.check_command_status(
+            cloud_request_id="req-123",
+            sequence_id=1,
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_CheckCommandStatus",
+            parameters={"cloud_request_id": "req-123", "sequence_id": 1},
+        )
+        self.assertTrue(result[0]["complete"])
+
+    def test_list_session_files(self):
+        """Test listing RTR session files."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"sha256": "abc"}]},
+        }
+
+        result = self.module.list_session_files(session_id="session-1")
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_ListFilesV2",
+            parameters={"session_id": "session-1"},
+        )
+        self.assertEqual(result[0]["sha256"], "abc")
+
+    def test_delete_session(self):
+        """Test deleting an RTR session."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"session_id": "session-1", "deleted": True}]},
+        }
+
+        result = self.module.delete_session(session_id="session-1")
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_DeleteSession",
+            parameters={"session_id": "session-1"},
+        )
+        self.assertTrue(result[0]["deleted"])


### PR DESCRIPTION
## Summary

This draft PR adds a Real Time Response (RTR) module to `falcon-mcp` so agents can perform session-aware host triage through Falcon while staying within the project's existing module and testing patterns.

The user-facing gap this addresses is that the server currently exposes investigation workflows for detections, incidents, hosts, and related data sources, but it does not yet provide a native MCP path into RTR session discovery and read-oriented host response operations. That makes host-level triage harder to keep inside the same MCP-driven workflow.

## What changed

This PR adds a new `rtr` module with tools for searching RTR sessions, retrieving session details, initializing and pulsing sessions, executing read-only RTR commands, checking command status, listing session files, and deleting sessions. It also adds the required RTR scope mappings in `falcon_mcp/common/api_scopes.py` and documents the new module and scopes in `README.md`.

To keep the change easy to review, this PR is intentionally limited to the RTR slice only. Other local module work was left out of this branch.

## Root cause and effect

The underlying issue was not a bug in an existing module, but a missing capability area in the server surface. Without an RTR module, agent workflows that need host-level live response either stop at endpoint metadata or require custom code outside the upstream MCP project. Adding the module closes that gap and makes it easier to keep investigative flows inside the official server architecture.

## Validation

I validated the change with the RTR-specific test set:

- `python -m pytest tests/modules/test_rtr.py tests/integration/test_rtr.py`
- `C:\Security\falcon-mcp\.venv\Scripts\python.exe -m ruff check README.md falcon_mcp/common/api_scopes.py falcon_mcp/modules/rtr.py tests/modules/test_rtr.py tests/integration/test_rtr.py`

The module tests passed, and the integration tests skipped cleanly when live integration prerequisites were not present.

## Notes

This PR is opened as a draft to make it easier to get feedback on scope, naming, and whether the RTR tool set should stay bundled as-is or be split further.
