### PR TITLE
feat: add version reporting via startup log, CLI flag, and MCP metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,9 +620,11 @@ If no modules are specified via command line or environment variable, all availa
 
 ### Additional Command Line Options
 
-For all available options:
-
 ```bash
+# Print the server version and exit
+falcon-mcp --version
+
+# Show all available options
 falcon-mcp --help
 ```
 

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
 from falcon_mcp import registry
-from falcon_mcp.client import FalconClient
+from falcon_mcp.client import FalconClient, get_version
 from falcon_mcp.common.auth import (
     ASGIApp,
     auth_middleware,
@@ -104,6 +104,9 @@ class FalconMCPServer:
             port=self.port,
         )
 
+        # Set the server version in MCP protocol metadata (returned in initialize handshake)
+        self.server._mcp_server.version = get_version()
+
         # Initialize and register modules
         self.modules = {}
         available_modules = registry.get_available_modules()
@@ -125,7 +128,8 @@ class FalconMCPServer:
         module_word = "module" if module_count == 1 else "modules"
 
         logger.info(
-            "Initialized %d %s with %d %s and %d %s",
+            "Falcon MCP v%s — %d %s, %d %s, %d %s",
+            get_version(),
             module_count,
             module_word,
             tool_count,
@@ -271,6 +275,14 @@ def parse_modules_list(modules_string: str) -> list[str]:
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Falcon MCP Server")
+
+    # Version
+    parser.add_argument(
+        "--version",
+        "-V",
+        action="version",
+        version=f"%(prog)s {get_version()}",
+    )
 
     # Transport options
     parser.add_argument(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 Tests for the Falcon MCP server.
 """
 
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -469,6 +470,47 @@ class TestFalconMCPServer(unittest.TestCase):
         call_args = mock_client.call_args[1]
         # Should be None (the default)
         self.assertIsNone(call_args["member_cid"])
+
+
+    @patch("falcon_mcp.server.get_version", return_value="1.2.3")
+    def test_version_flag(self, _mock_version):
+        """Test --version flag prints version and exits."""
+        with patch.object(sys, "argv", ["falcon-mcp", "--version"]):
+            with self.assertRaises(SystemExit) as cm:
+                from falcon_mcp.server import parse_args
+
+                parse_args()
+            self.assertEqual(cm.exception.code, 0)
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.FastMCP")
+    def test_mcp_server_version_is_set(self, mock_fastmcp, mock_client):
+        """Test that MCP server metadata version is set to falcon-mcp version."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.authenticate.return_value = True
+        mock_client.return_value = mock_client_instance
+
+        mock_server_instance = MagicMock()
+        mock_fastmcp.return_value = mock_server_instance
+
+        FalconMCPServer(enabled_modules=set())
+
+        # Verify version was set on the underlying MCP server
+        self.assertIsNotNone(mock_server_instance._mcp_server.version)
+
+    @patch("falcon_mcp.server.get_version", return_value="0.9.0")
+    @patch("falcon_mcp.server.FalconClient")
+    def test_startup_log_includes_version(self, mock_client, _mock_version):
+        """Test that startup log message includes the server version."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.authenticate.return_value = True
+        mock_client.return_value = mock_client_instance
+
+        with self.assertLogs("falcon_mcp.server", level="INFO") as cm:
+            FalconMCPServer(enabled_modules=set())
+
+        version_logs = [msg for msg in cm.output if "Falcon MCP v0.9.0" in msg]
+        self.assertEqual(len(version_logs), 1, "Expected exactly one startup log with version")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `falcon-mcp --version` CLI flag for quick version checks without starting the server
- Sets the server version in MCP `initialize` handshake metadata for programmatic consumers
- Updates startup log to show `Falcon MCP v{version}` alongside module/tool/resource counts
