### PR TITLE
docs(ci): replace upload-pages-artifact with upload-artifact in docs deploy

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -69,10 +69,23 @@ jobs:
       - name: Build docs site
         run: cd docs-site && pnpm run build
 
+      - name: Archive pages artifact
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory docs-site/dist/ \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          path: docs-site/dist/
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
   deploy:
     needs: build


### PR DESCRIPTION
The docs deploy workflow was failing because `upload-pages-artifact` isn't on the enterprise GitHub Actions allowlist. This swaps it out for `upload-artifact@v4` with a manual tar step — same artifact name (`github-pages`) that `deploy-pages` expects, just built by hand instead of relying on the blocked action.