### PR TITLE
feat(modules/shield): add Falcon Shield (SaaS Security) module

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Full docs are available at **[crowdstrike.github.io/falcon-mcp](https://crowdstr
 | [Scheduled Reports](https://crowdstrike.github.io/falcon-mcp/modules/scheduled-reports/) | Manage scheduled reports and download report files |
 | [Sensor Usage](https://crowdstrike.github.io/falcon-mcp/modules/sensor-usage/) | Access and analyze sensor usage data |
 | [Serverless](https://crowdstrike.github.io/falcon-mcp/modules/serverless/) | Search for vulnerabilities in serverless functions |
+| [Shield](https://crowdstrike.github.io/falcon-mcp/modules/shield/) | SaaS security posture, checks, alerts, and app inventory |
 | [Spotlight](https://crowdstrike.github.io/falcon-mcp/modules/spotlight/) | Manage and analyze vulnerability data and security assessments |
 
 See the [Module Overview](https://crowdstrike.github.io/falcon-mcp/modules/overview/) for required API scopes, available tools, and FQL resources.

--- a/docs-site/src/content/docs/modules/overview.md
+++ b/docs-site/src/content/docs/modules/overview.md
@@ -24,4 +24,5 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 | [Scheduled Reports](/falcon-mcp/modules/scheduled-reports/) | `Scheduled Reports:read` | Accessing and managing CrowdStrike Falcon scheduled reports and scheduled searches |
 | [Sensor Usage](/falcon-mcp/modules/sensor-usage/) | `Sensor Usage:read` | Accessing CrowdStrike Falcon sensor usage data |
 | [Serverless](/falcon-mcp/modules/serverless/) | `Falcon Container Image:read` | Accessing and managing CrowdStrike Falcon Serverless Vulnerabilities |
+| [Shield](/falcon-mcp/modules/shield/) | `SaaS Security:read`, `SaaS Security:write` | Shield module for CrowdStrike Falcon. |
 | [Spotlight](/falcon-mcp/modules/spotlight/) | `Vulnerabilities:read` | Accessing and managing CrowdStrike Falcon Spotlight vulnerabilities |

--- a/docs-site/src/content/docs/modules/shield.md
+++ b/docs-site/src/content/docs/modules/shield.md
@@ -1,0 +1,314 @@
+---
+title: Shield
+description: Shield module for CrowdStrike Falcon.
+sidebar:
+  order: 10
+---
+
+Shield module for CrowdStrike Falcon.
+
+## API Scopes
+
+- `SaaS Security:read`
+- `SaaS Security:write`
+
+## Tools
+
+### `falcon_dismiss_shield_check`
+
+:::caution
+This tool performs destructive operations.
+:::
+
+**Required scopes:** `SaaS Security:write`
+
+Dismiss a Falcon Shield (SaaS Security) posture check to suppress it from
+the failed checks list.
+
+WARNING: This action is permanent and cannot be undone from the API. The
+dismissal reason is recorded in audit logs.
+
+When entities is omitted, the entire check is dismissed for all entities.
+When entities is provided, only the specified entities are dismissed and the
+check remains active for others.
+
+**Example prompts:**
+
+- "Dismiss a low-impact Shield check entity with reason 'No longer applicable'"
+
+### `falcon_get_shield_activity_monitor`
+
+**Required scopes:** `SaaS Security:read`
+
+Get events from the Falcon Shield (SaaS Security) activity monitor.
+Data retained for 180 days.
+
+Note: When using integration_id, category, or actor filters, the date range
+(from_date to to_date) must be within 24 hours.
+
+Pagination: Use meta.pagination.next as to_date and meta.pagination.offset as
+skip for subsequent pages.
+
+IMPORTANT: Consult the falcon://shield/search/query-guide resource for valid
+category, actor, and projection values.
+
+Returns activity event objects including timestamp, event name, actor identity,
+integration, category, and location details.
+
+**Example prompts:**
+
+- "Show me Shield activity events from the last 24 hours"
+
+### `falcon_get_shield_app_users`
+
+**Required scopes:** `SaaS Security:read`
+
+Retrieve the users who have authorized or are associated with a specific
+third-party app in Falcon Shield (SaaS Security).
+
+Use this after `search_shield_apps` to drill into a specific app's user
+population.
+
+Returns user objects including email, display name, and granted permissions.
+
+**Example prompts:**
+
+- "Show me which users have authorized Shield app abc123"
+
+### `falcon_get_shield_check_affected_entities`
+
+**Required scopes:** `SaaS Security:read`
+
+Retrieve the specific entities (users, apps, or devices) that are violating
+a given Falcon Shield (SaaS Security) posture check.
+
+Use this after `search_shield_checks` to drill into which entities are failing
+a specific check.
+
+Returns entity objects with entity name, type, and relevant security details.
+
+**Example prompts:**
+
+- "Show me the entities affected by a failed Shield check"
+
+### `falcon_get_shield_check_compliance`
+
+**Required scopes:** `SaaS Security:read`
+
+Retrieve the compliance framework mappings for a specific Falcon Shield
+(SaaS Security) posture check.
+
+Use this to understand the regulatory impact of a failing check.
+
+Returns compliance objects identifying the framework (e.g., SOC 2, CIS, NIST,
+PCI DSS), control ID, and control description that the check satisfies.
+
+**Example prompts:**
+
+- "Find a Shield check with compliance framework mappings"
+
+### `falcon_get_shield_integrations`
+
+**Required scopes:** `SaaS Security:read`
+
+List all SaaS integrations connected to Falcon Shield (SaaS Security) and
+their current connection status.
+
+The integration_id values returned here are used as input to most other Shield
+tools. Call this tool first when starting a Shield investigation to discover
+available integrations.
+
+Returns integration objects containing integration_id, SaaS platform name,
+connection health, and last sync time.
+
+**Example prompts:**
+
+- "List all connected SaaS integrations in Falcon Shield"
+
+### `falcon_get_shield_posture_metrics`
+
+**Required scopes:** `SaaS Security:read`
+
+Get aggregated Falcon Shield (SaaS Security) posture metrics.
+
+Use this for a summary/dashboard view of your security posture. To retrieve
+individual check records with remediation details, use `search_shield_checks`
+instead.
+
+Returns total check counts, overall score percentage, and breakdown of checks
+by status (Passed, Failed, Dismissed, etc.) across connected SaaS applications.
+
+**Example prompts:**
+
+- "Show me my overall Falcon Shield posture metrics"
+
+### `falcon_get_shield_supported_saas`
+
+**Required scopes:** `SaaS Security:read`
+
+List SaaS platforms supported by Falcon Shield (SaaS Security) for integration.
+
+Use this to discover which SaaS applications can be connected to Shield
+before setting up new integrations.
+
+Returns supported SaaS platform objects including platform name and ID.
+
+**Example prompts:**
+
+- "List all SaaS platforms supported by Falcon Shield"
+
+### `falcon_get_shield_system_logs`
+
+**Required scopes:** `SaaS Security:read`
+
+Retrieve Falcon Shield (SaaS Security) system audit logs. Data retained
+for 90 days.
+
+Logs include integration creates/updates, check dismissals, and data syncs.
+
+Use date range filters to narrow results. Without filters, returns the most
+recent logs up to the limit.
+
+Returns log objects containing timestamp, event type, actor, and details.
+
+**Example prompts:**
+
+- "Show me the last 10 Falcon Shield system audit logs"
+
+### `falcon_get_shield_system_users`
+
+**Required scopes:** `SaaS Security:read`
+
+List Falcon Shield (SaaS Security) platform administrators.
+
+These are Shield console administrators, not end-users of connected SaaS
+applications. For SaaS app end-users, use `search_shield_users`.
+
+Returns system-level user objects including email, role, and MFA status.
+
+**Example prompts:**
+
+- "Show me the Falcon Shield platform administrators and their MFA status"
+
+### `falcon_search_shield_alerts`
+
+**Required scopes:** `SaaS Security:read`
+
+Search Falcon Shield (SaaS Security) alerts for monitored SaaS applications.
+
+Alert types: configuration_drift (a previously passing check now fails),
+check_degraded (check status worsened), integration_failure (connectivity issue
+with a SaaS platform), threat (active threat indicator).
+
+Pagination: use last_id from the last result for cursor-based pagination, or
+use offset for offset-based pagination.
+
+Returns alert objects containing id, type, integration details, timestamp,
+and severity.
+
+**Example prompts:**
+
+- "Show me Shield alerts of type Threat"
+- "Show me the 5 oldest Shield alerts sorted by date"
+
+### `falcon_search_shield_apps`
+
+**Required scopes:** `SaaS Security:read`
+
+List third-party applications (OAuth apps, API tokens, browser extensions,
+service principals) with access to Falcon Shield (SaaS Security) monitored
+platforms.
+
+Use the item_id from results with `get_shield_app_users` to retrieve the users
+of a specific app.
+
+Returns app objects containing item_id, name, type, status, access_level,
+granted scopes, and user count.
+
+**Example prompts:**
+
+- "Find OAuth apps in Shield that haven't been active in 90 days"
+- "List all Shield apps with status 'in review'"
+
+### `falcon_search_shield_checks`
+
+**Required scopes:** `SaaS Security:read`
+
+Search individual Falcon Shield (SaaS Security) posture checks with filtering.
+
+Use the check id from results to call `get_shield_check_affected_entities` for
+violating entities, `get_shield_check_compliance` for compliance mappings, or
+`dismiss_shield_check` to dismiss.
+
+For an aggregated posture summary (total score, status breakdown), use
+`get_shield_posture_metrics` instead.
+
+IMPORTANT: Consult the falcon://shield/search/query-guide resource for valid
+filter parameter values.
+
+Returns check records containing id, name, status, impact level, affected entity
+count, and remediation plan.
+
+**Example prompts:**
+
+- "Show me the failed Shield security checks"
+- "Search for high impact Shield checks related to devices"
+
+### `falcon_search_shield_data_shares`
+
+**Required scopes:** `SaaS Security:read`
+
+List files and resources shared externally across Falcon Shield (SaaS
+Security) monitored SaaS applications.
+
+Use this to identify overshared or externally exposed files (e.g., Google
+Drive documents shared outside the organization).
+
+Returns resource objects containing resource name, type, owner, sharing access
+level, password protection status, and last access/modification timestamps.
+
+**Example prompts:**
+
+- "Find files shared via public link in Shield"
+
+### `falcon_search_shield_devices`
+
+**Required scopes:** `SaaS Security:read`
+
+List devices registered to users in Falcon Shield (SaaS Security) connected
+SaaS applications.
+
+Note: This returns devices from SaaS provider records, not from the Falcon
+sensor inventory. To search Falcon-sensor-enrolled hosts, use `search_hosts`
+instead.
+
+Returns device objects containing device name, owner email, compliance posture,
+and management status.
+
+**Example prompts:**
+
+- "Show me devices in Shield not associated with any known user"
+
+### `falcon_search_shield_users`
+
+**Required scopes:** `SaaS Security:read`
+
+List end-users discovered across Falcon Shield (SaaS Security) connected
+SaaS applications.
+
+Use this to audit user access across your SaaS estate or to identify
+over-privileged or stale accounts.
+
+To list Shield platform administrators instead of SaaS app end-users, use
+`get_shield_system_users`.
+
+Returns user objects containing email, display name, connected application
+details, privilege status, and exposure metrics.
+
+**Example prompts:**
+
+- "List privileged users across my connected SaaS apps in Shield"
+
+## Resources
+
+- **`falcon://shield/search/query-guide`**: Query parameter guide for Falcon Shield (SaaS Security) tools.

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -112,6 +112,8 @@ API_SCOPE_REQUIREMENTS = {
     "GetAssetInventoryV3": ["SaaS Security:read"],
     "GetIntegrationsV3": ["SaaS Security:read"],
     "GetSystemUsersV3": ["SaaS Security:read"],
+    "GetSupportedSaasV3": ["SaaS Security:read"],
+    "GetSystemLogsV3": ["SaaS Security:read"],
     "DismissSecurityCheckV3": ["SaaS Security:write"],
     "DismissAffectedEntityV3": ["SaaS Security:write"],
 }

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -98,7 +98,22 @@ API_SCOPE_REQUIREMENTS = {
     "create_rule": ["Custom IOA Rules:write"],
     "update_rules_v2": ["Custom IOA Rules:write"],
     "delete_rules": ["Custom IOA Rules:write"],
-    # Add more mappings as needed
+    # Shield (SaaS Security) operations
+    "GetSecurityChecksV3": ["SaaS Security:read"],
+    "GetSecurityCheckAffectedV3": ["SaaS Security:read"],
+    "GetMetricsV3": ["SaaS Security:read"],
+    "GetSecurityCheckComplianceV3": ["SaaS Security:read"],
+    "GetAlertsV3": ["SaaS Security:read"],
+    "GetActivityMonitorV3": ["SaaS Security:read"],
+    "GetUserInventoryV3": ["SaaS Security:read"],
+    "GetDeviceInventoryV3": ["SaaS Security:read"],
+    "GetAppInventory": ["SaaS Security:read"],
+    "GetAppInventoryUsers": ["SaaS Security:read"],
+    "GetAssetInventoryV3": ["SaaS Security:read"],
+    "GetIntegrationsV3": ["SaaS Security:read"],
+    "GetSystemUsersV3": ["SaaS Security:read"],
+    "DismissSecurityCheckV3": ["SaaS Security:write"],
+    "DismissAffectedEntityV3": ["SaaS Security:write"],
 }
 
 

--- a/falcon_mcp/modules/shield.py
+++ b/falcon_mcp/modules/shield.py
@@ -130,6 +130,16 @@ class ShieldModule(BaseModule):
         )
         self._add_tool(
             server=server,
+            method=self.get_shield_supported_saas,
+            name="get_shield_supported_saas",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_shield_system_logs,
+            name="get_shield_system_logs",
+        )
+        self._add_tool(
+            server=server,
             method=self.dismiss_shield_check,
             name="dismiss_shield_check",
             annotations=ToolAnnotations(
@@ -174,7 +184,13 @@ class ShieldModule(BaseModule):
         ),
         compliance: bool | None = Field(
             default=None,
-            description="If true, return only checks mapped to a compliance framework (SOC 2, CIS, etc.).",
+            description=(
+                "If true, return only checks that are defined as part of a compliance framework"
+                " (SOC 2, CIS, NIST, etc.) at the catalog level."
+                " Note: a check can be compliance-mapped yet still return no compliance criteria"
+                " via `get_shield_check_compliance` if the tenant has not followed the relevant"
+                " framework or compliance data has not yet been populated."
+            ),
         ),
         check_type: str | None = Field(
             default=None,
@@ -277,7 +293,10 @@ class ShieldModule(BaseModule):
         ),
         compliance: bool | None = Field(
             default=None,
-            description="If true, return only metrics for checks mapped to a compliance framework.",
+            description=(
+                "If true, return only metrics for checks that are defined as part of a compliance"
+                " framework (SOC 2, CIS, NIST, etc.) at the catalog level."
+            ),
         ),
         check_type: str | None = Field(
             default=None,
@@ -345,7 +364,7 @@ class ShieldModule(BaseModule):
         ),
         type: str | None = Field(
             default=None,
-            description="Filter by type: configuration_drift, check_degraded, integration_failure, Threat.",
+            description="Filter by type: configuration_drift, check_degraded, integration_failure, threat.",
         ),
         integration_id: str | None = Field(
             default=None,
@@ -387,7 +406,7 @@ class ShieldModule(BaseModule):
 
         Alert types: configuration_drift (a previously passing check now fails),
         check_degraded (check status worsened), integration_failure (connectivity issue
-        with a SaaS platform), Threat (active threat indicator).
+        with a SaaS platform), threat (active threat indicator).
 
         Pagination: use last_id from the last result for cursor-based pagination, or
         use offset for offset-based pagination.
@@ -639,8 +658,8 @@ class ShieldModule(BaseModule):
             default=None,
             description=(
                 "Filter by time since the app was last active."
-                " Format: 'was N days' (active within N days) or 'was not N days' (inactive for more than N days)."
-                " Example: 'was not 90 days'."
+                " Format: 'was N' (active within N days) or 'was not N' (inactive for more than N days)."
+                " Example: 'was not 90'."
             ),
         ),
         limit: int = Field(
@@ -747,16 +766,16 @@ class ShieldModule(BaseModule):
             default=None,
             description=(
                 "Filter by time since the resource was last accessed."
-                " Format: 'was N days' (within N days) or 'was not N days' (not accessed in more than N days)."
-                " Example: 'was not 30 days'."
+                " Format: 'was N' (within N days) or 'was not N' (not accessed in more than N days)."
+                " Example: 'was not 30'."
             ),
         ),
         last_modified: str | None = Field(
             default=None,
             description=(
                 "Filter by time since the resource was last modified."
-                " Format: 'was N days' (within N days) or 'was not N days' (not modified in more than N days)."
-                " Example: 'was not 30 days'."
+                " Format: 'was N' (within N days) or 'was not N' (not modified in more than N days)."
+                " Example: 'was not 30'."
             ),
         ),
         unmanaged_domain: str | None = Field(
@@ -839,6 +858,67 @@ class ShieldModule(BaseModule):
             operation="GetSystemUsersV3",
             search_params={},
             error_message="Failed to get Shield system users",
+        )
+
+    def get_shield_supported_saas(self) -> list[dict[str, Any]] | dict[str, Any]:
+        """List SaaS platforms supported by Falcon Shield (SaaS Security) for integration.
+
+        Use this to discover which SaaS applications can be connected to Shield
+        before setting up new integrations.
+
+        Returns supported SaaS platform objects including platform name and ID."""
+        return self._search_with_docs(
+            operation="GetSupportedSaasV3",
+            search_params={},
+            error_message="Failed to get supported SaaS platforms",
+        )
+
+    def get_shield_system_logs(
+        self,
+        from_date: str | None = Field(
+            default=None,
+            description="Start date (YYYY-MM-DD).",
+        ),
+        to_date: str | None = Field(
+            default=None,
+            description="End date (YYYY-MM-DD).",
+        ),
+        limit: int = Field(
+            default=100,
+            ge=1,
+            description="Maximum number of results to return (default: 100).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description=(
+                "Zero-based offset for pagination. Omit or set to 0 for the first page."
+                " Increment by limit for subsequent pages."
+            ),
+        ),
+        total_count: bool | None = Field(
+            default=None,
+            description="If true, include total count of matching logs in the response metadata.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve Falcon Shield (SaaS Security) system audit logs. Data retained
+        for 90 days.
+
+        Logs include integration creates/updates, check dismissals, and data syncs.
+
+        Use date range filters to narrow results. Without filters, returns the most
+        recent logs up to the limit.
+
+        Returns log objects containing timestamp, event type, actor, and details."""
+        return self._search_with_docs(
+            operation="GetSystemLogsV3",
+            search_params={
+                "from_date": from_date,
+                "to_date": to_date,
+                "limit": limit,
+                "offset": offset,
+                "total_count": total_count,
+            },
+            error_message="Failed to get Shield system logs",
         )
 
     # --- Mutating tools ---

--- a/falcon_mcp/modules/shield.py
+++ b/falcon_mcp/modules/shield.py
@@ -1,0 +1,882 @@
+"""Falcon Shield (SaaS Security) module for querying SaaS security posture."""
+
+from typing import Any
+
+from mcp.server import FastMCP
+from mcp.server.fastmcp.resources import TextResource
+from mcp.types import ToolAnnotations
+from pydantic import AnyUrl, Field
+
+from falcon_mcp.common.logging import get_logger
+from falcon_mcp.modules.base import BaseModule
+from falcon_mcp.resources.shield import SHIELD_QUERY_DOCUMENTATION
+
+logger = get_logger(__name__)
+
+IMPACT_MAP = {"low": 1, "medium": 2, "high": 3}
+
+
+class ShieldModule(BaseModule):
+    """Module for CrowdStrike Falcon Shield (SaaS Security) API operations."""
+
+    @staticmethod
+    def _map_impact(impact: str | None) -> int | None:
+        if not isinstance(impact, str):
+            return None
+        mapped = IMPACT_MAP.get(impact.lower())
+        if mapped is None:
+            logger.warning(
+                "Unknown impact value '%s'; expected one of: %s", impact, ", ".join(IMPACT_MAP)
+            )
+        return mapped
+
+    def _format_empty_or_error(
+        self,
+        results: list[Any],
+    ) -> dict[str, Any]:
+        if results and "error" in results[0]:
+            hint = "Query error occurred. Review your parameters using the query guide."
+        else:
+            hint = "No results matched your query. Review available parameters in the query guide."
+        return {
+            "results": results,
+            "query_guide": SHIELD_QUERY_DOCUMENTATION,
+            "hint": hint,
+        }
+
+    def _search_with_docs(
+        self,
+        operation: str,
+        search_params: dict[str, Any],
+        error_message: str,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        result = self._base_search_api_call(
+            operation=operation,
+            search_params=search_params,
+            error_message=error_message,
+        )
+        if self._is_error(result):
+            return self._format_empty_or_error([result])
+        if not result:
+            return self._format_empty_or_error([])
+        return result
+
+    def register_tools(self, server: FastMCP) -> None:
+        self._add_tool(
+            server=server,
+            method=self.search_shield_checks,
+            name="search_shield_checks",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_shield_check_affected_entities,
+            name="get_shield_check_affected_entities",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_shield_posture_metrics,
+            name="get_shield_posture_metrics",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_shield_check_compliance,
+            name="get_shield_check_compliance",
+        )
+        self._add_tool(
+            server=server,
+            method=self.search_shield_alerts,
+            name="search_shield_alerts",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_shield_activity_monitor,
+            name="get_shield_activity_monitor",
+        )
+        self._add_tool(
+            server=server,
+            method=self.search_shield_users,
+            name="search_shield_users",
+        )
+        self._add_tool(
+            server=server,
+            method=self.search_shield_devices,
+            name="search_shield_devices",
+        )
+        self._add_tool(
+            server=server,
+            method=self.search_shield_apps,
+            name="search_shield_apps",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_shield_app_users,
+            name="get_shield_app_users",
+        )
+        self._add_tool(
+            server=server,
+            method=self.search_shield_data_shares,
+            name="search_shield_data_shares",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_shield_integrations,
+            name="get_shield_integrations",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_shield_system_users,
+            name="get_shield_system_users",
+        )
+        self._add_tool(
+            server=server,
+            method=self.dismiss_shield_check,
+            name="dismiss_shield_check",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+    def register_resources(self, server: FastMCP) -> None:
+        resource = TextResource(
+            uri=AnyUrl("falcon://shield/search/query-guide"),
+            name="falcon_shield_query_guide",
+            description="Query parameter guide for Falcon Shield (SaaS Security) tools.",
+            text=SHIELD_QUERY_DOCUMENTATION,
+        )
+        self._add_resource(server, resource)
+
+    # --- Read-only tools ---
+
+    def search_shield_checks(
+        self,
+        id: str | None = Field(
+            default=None,
+            description="Specific security check ID.",
+        ),
+        status: str | None = Field(
+            default=None,
+            description="Filter by status: Passed, Failed, Dismissed, Pending, Can't Run, Stale, Not Available.",
+        ),
+        impact: str | None = Field(
+            default=None,
+            description="Filter by impact: Low, Medium, High.",
+        ),
+        integration_id: str | None = Field(
+            default=None,
+            description=(
+                "Comma-separated IDs of SaaS integrations to filter by."
+                " Use `get_shield_integrations` to retrieve available integration IDs."
+            ),
+        ),
+        compliance: bool | None = Field(
+            default=None,
+            description="If true, return only checks mapped to a compliance framework (SOC 2, CIS, etc.).",
+        ),
+        check_type: str | None = Field(
+            default=None,
+            description="Filter by type: apps, devices, users, assets, permissions, custom.",
+        ),
+        check_tags: str | None = Field(
+            default=None,
+            description="Comma-separated tag filters.",
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            description="Maximum number of results to return (default: 10).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description=(
+                "Zero-based offset for pagination. Omit or set to 0 for the first page."
+                " Increment by limit for subsequent pages."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search individual Falcon Shield (SaaS Security) posture checks with filtering.
+
+        Use the check id from results to call `get_shield_check_affected_entities` for
+        violating entities, `get_shield_check_compliance` for compliance mappings, or
+        `dismiss_shield_check` to dismiss.
+
+        For an aggregated posture summary (total score, status breakdown), use
+        `get_shield_posture_metrics` instead.
+
+        IMPORTANT: Consult the falcon://shield/search/query-guide resource for valid
+        filter parameter values.
+
+        Returns check records containing id, name, status, impact level, affected entity
+        count, and remediation plan."""
+        return self._search_with_docs(
+            operation="GetSecurityChecksV3",
+            search_params={
+                "id": id,
+                "status": status,
+                "impact": self._map_impact(impact),
+                "integration_id": integration_id,
+                "compliance": compliance,
+                "check_type": check_type,
+                "check_tags": check_tags,
+                "limit": limit,
+                "offset": offset,
+            },
+            error_message="Failed to search Shield security checks",
+        )
+
+    def get_shield_check_affected_entities(
+        self,
+        id: str = Field(
+            description="Security check ID. Obtain from the id field in results returned by `search_shield_checks`.",
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            description="Maximum number of results to return (default: 10).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description=(
+                "Zero-based offset for pagination. Omit or set to 0 for the first page."
+                " Increment by limit for subsequent pages."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve the specific entities (users, apps, or devices) that are violating
+        a given Falcon Shield (SaaS Security) posture check.
+
+        Use this after `search_shield_checks` to drill into which entities are failing
+        a specific check.
+
+        Returns entity objects with entity name, type, and relevant security details."""
+        return self._search_with_docs(
+            operation="GetSecurityCheckAffectedV3",
+            search_params={"id": id, "limit": limit, "offset": offset},
+            error_message="Failed to get affected entities",
+        )
+
+    def get_shield_posture_metrics(
+        self,
+        status: str | None = Field(
+            default=None,
+            description="Filter by status: Passed, Failed, Dismissed, Pending, Can't Run, Stale.",
+        ),
+        impact: str | None = Field(
+            default=None,
+            description="Filter by impact: Low, Medium, High.",
+        ),
+        integration_id: str | None = Field(
+            default=None,
+            description=(
+                "Comma-separated IDs of SaaS integrations to filter by."
+                " Use `get_shield_integrations` to retrieve available integration IDs."
+            ),
+        ),
+        compliance: bool | None = Field(
+            default=None,
+            description="If true, return only metrics for checks mapped to a compliance framework.",
+        ),
+        check_type: str | None = Field(
+            default=None,
+            description="Filter by type: apps, devices, users, assets, permissions, custom.",
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            description="Maximum number of results to return (default: 10).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description=(
+                "Zero-based offset for pagination. Omit or set to 0 for the first page."
+                " Increment by limit for subsequent pages."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Get aggregated Falcon Shield (SaaS Security) posture metrics.
+
+        Use this for a summary/dashboard view of your security posture. To retrieve
+        individual check records with remediation details, use `search_shield_checks`
+        instead.
+
+        Returns total check counts, overall score percentage, and breakdown of checks
+        by status (Passed, Failed, Dismissed, etc.) across connected SaaS applications."""
+        return self._search_with_docs(
+            operation="GetMetricsV3",
+            search_params={
+                "status": status,
+                "impact": self._map_impact(impact),
+                "integration_id": integration_id,
+                "compliance": compliance,
+                "check_type": check_type,
+                "limit": limit,
+                "offset": offset,
+            },
+            error_message="Failed to get posture metrics",
+        )
+
+    def get_shield_check_compliance(
+        self,
+        id: str = Field(
+            description="Security check ID. Obtain from the id field in results returned by `search_shield_checks`.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve the compliance framework mappings for a specific Falcon Shield
+        (SaaS Security) posture check.
+
+        Use this to understand the regulatory impact of a failing check.
+
+        Returns compliance objects identifying the framework (e.g., SOC 2, CIS, NIST,
+        PCI DSS), control ID, and control description that the check satisfies."""
+        return self._search_with_docs(
+            operation="GetSecurityCheckComplianceV3",
+            search_params={"id": id},
+            error_message="Failed to get compliance data",
+        )
+
+    def search_shield_alerts(
+        self,
+        id: str | None = Field(
+            default=None,
+            description="Specific alert ID.",
+        ),
+        type: str | None = Field(
+            default=None,
+            description="Filter by type: configuration_drift, check_degraded, integration_failure, threat.",
+        ),
+        integration_id: str | None = Field(
+            default=None,
+            description=(
+                "Comma-separated IDs of SaaS integrations to filter by."
+                " Use `get_shield_integrations` to retrieve available integration IDs."
+            ),
+        ),
+        from_date: str | None = Field(
+            default=None,
+            description="Start date (YYYY-MM-DD).",
+        ),
+        to_date: str | None = Field(
+            default=None,
+            description="End date (YYYY-MM-DD).",
+        ),
+        ascending: bool | None = Field(
+            default=None,
+            description="If true, return oldest alerts first. If false or omitted, return newest first.",
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            description="Maximum number of results to return (default: 10).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description=(
+                "Zero-based offset for pagination. Omit or set to 0 for the first page."
+                " Increment by limit for subsequent pages."
+            ),
+        ),
+        last_id: str | None = Field(
+            default=None,
+            description="Cursor-based pagination token from the last result (alternative to offset).",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search Falcon Shield (SaaS Security) alerts for monitored SaaS applications.
+
+        Alert types: configuration_drift (a previously passing check now fails),
+        check_degraded (check status worsened), integration_failure (connectivity issue
+        with a SaaS platform), threat (active threat indicator).
+
+        Pagination: use last_id from the last result for cursor-based pagination, or
+        use offset for offset-based pagination.
+
+        Returns alert objects containing id, type, integration details, timestamp,
+        and severity."""
+        return self._search_with_docs(
+            operation="GetAlertsV3",
+            search_params={
+                "id": id,
+                "type": type,
+                "integration_id": integration_id,
+                "from_date": from_date,
+                "to_date": to_date,
+                "ascending": ascending,
+                "limit": limit,
+                "offset": offset,
+                "last_id": last_id,
+            },
+            error_message="Failed to search Shield alerts",
+        )
+
+    def get_shield_activity_monitor(
+        self,
+        integration_id: str | None = Field(
+            default=None,
+            description=(
+                "Comma-separated IDs of SaaS integrations to filter by."
+                " Use `get_shield_integrations` to retrieve available integration IDs."
+            ),
+        ),
+        actor: str | None = Field(
+            default=None,
+            description=(
+                "Filter by the identity that performed the activity (e.g., user email, service account name)."
+                " This is not a threat actor name."
+            ),
+        ),
+        category: str | None = Field(
+            default=None,
+            description="Comma-separated activity categories: Events, Threat, IoC.",
+        ),
+        projection: str | None = Field(
+            default=None,
+            description=(
+                "Comma-separated list of fields to include in each event."
+                " Valid fields: timestamp_utc, severity, datetime, event_name, actor, integration_id,"
+                " integration_name, type, category, created_by, ip, asn_name, country, browser, os,"
+                " target, object_type, object, status. Omit for default fields."
+            ),
+        ),
+        from_date: str | None = Field(
+            default=None,
+            description="Start datetime (ISO 8601).",
+        ),
+        to_date: str | None = Field(
+            default=None,
+            description="End datetime (ISO 8601).",
+        ),
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=10000,
+            description="Maximum number of results to return (default: 100, max: 10000).",
+        ),
+        skip: int | None = Field(
+            default=None,
+            description=(
+                "Pagination offset. Use meta.pagination.offset from the previous response"
+                " for subsequent pages."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Get events from the Falcon Shield (SaaS Security) activity monitor.
+        Data retained for 180 days.
+
+        Note: When using integration_id, category, or actor filters, the date range
+        (from_date to to_date) must be within 24 hours.
+
+        Pagination: Use meta.pagination.next as to_date and meta.pagination.offset as
+        skip for subsequent pages.
+
+        IMPORTANT: Consult the falcon://shield/search/query-guide resource for valid
+        category, actor, and projection values.
+
+        Returns activity event objects including timestamp, event name, actor identity,
+        integration, category, and location details."""
+        return self._search_with_docs(
+            operation="GetActivityMonitorV3",
+            search_params={
+                "integration_id": integration_id,
+                "actor": actor,
+                "category": category,
+                "projection": projection,
+                "from_date": from_date,
+                "to_date": to_date,
+                "limit": limit,
+                "skip": skip,
+            },
+            error_message="Failed to get activity monitor events",
+        )
+
+    def search_shield_users(
+        self,
+        integration_id: str | None = Field(
+            default=None,
+            description=(
+                "Comma-separated IDs of SaaS integrations to filter by."
+                " Use `get_shield_integrations` to retrieve available integration IDs."
+            ),
+        ),
+        email: str | None = Field(
+            default=None,
+            description="Filter results to users matching this email address.",
+        ),
+        privileged_only: bool | None = Field(
+            default=None,
+            description="If true, return only users with privileged or administrative roles.",
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            description="Maximum number of results to return (default: 10).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description=(
+                "Zero-based offset for pagination. Omit or set to 0 for the first page."
+                " Increment by limit for subsequent pages."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """List end-users discovered across Falcon Shield (SaaS Security) connected
+        SaaS applications.
+
+        Use this to audit user access across your SaaS estate or to identify
+        over-privileged or stale accounts.
+
+        To list Shield platform administrators instead of SaaS app end-users, use
+        `get_shield_system_users`.
+
+        Returns user objects containing email, display name, connected application
+        details, privilege status, and exposure metrics."""
+        return self._search_with_docs(
+            operation="GetUserInventoryV3",
+            search_params={
+                "integration_id": integration_id,
+                "email": email,
+                "privileged_only": privileged_only,
+                "limit": limit,
+                "offset": offset,
+            },
+            error_message="Failed to search Shield users",
+        )
+
+    def search_shield_devices(
+        self,
+        integration_id: str | None = Field(
+            default=None,
+            description=(
+                "Comma-separated IDs of SaaS integrations to filter by."
+                " Use `get_shield_integrations` to retrieve available integration IDs."
+            ),
+        ),
+        email: str | None = Field(
+            default=None,
+            description="Filter by user email associated with the device.",
+        ),
+        privileged_only: bool | None = Field(
+            default=None,
+            description="If true, return only devices belonging to users with privileged roles.",
+        ),
+        unassociated_devices: bool | None = Field(
+            default=None,
+            description="If true, include devices not associated with a known user.",
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            description="Maximum number of results to return (default: 10).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description=(
+                "Zero-based offset for pagination. Omit or set to 0 for the first page."
+                " Increment by limit for subsequent pages."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """List devices registered to users in Falcon Shield (SaaS Security) connected
+        SaaS applications.
+
+        Note: This returns devices from SaaS provider records, not from the Falcon
+        sensor inventory. To search Falcon-sensor-enrolled hosts, use `search_hosts`
+        instead.
+
+        Returns device objects containing device name, owner email, compliance posture,
+        and management status."""
+        return self._search_with_docs(
+            operation="GetDeviceInventoryV3",
+            search_params={
+                "integration_id": integration_id,
+                "email": email,
+                "privileged_only": privileged_only,
+                "unassociated_devices": unassociated_devices,
+                "limit": limit,
+                "offset": offset,
+            },
+            error_message="Failed to search Shield devices",
+        )
+
+    def search_shield_apps(
+        self,
+        type: str | None = Field(
+            default=None,
+            description="App type: oauth, sign_in, api_token, browser_extension, etc.",
+        ),
+        status: str | None = Field(
+            default=None,
+            description="Status: approved, in review, rejected, unclassified.",
+        ),
+        access_level: str | None = Field(
+            default=None,
+            description="Access level: high, medium, low, none.",
+        ),
+        integration_id: str | None = Field(
+            default=None,
+            description=(
+                "Comma-separated IDs of SaaS integrations to filter by."
+                " Use `get_shield_integrations` to retrieve available integration IDs."
+            ),
+        ),
+        scopes: str | None = Field(
+            default=None,
+            description="Comma-separated OAuth scope filter.",
+        ),
+        users: str | None = Field(
+            default=None,
+            description=(
+                "Filter by user association. Format: 'is equal <email>' for exact match,"
+                " or 'contains <value>' for partial match. Example: 'is equal user@example.com'."
+            ),
+        ),
+        groups: str | None = Field(
+            default=None,
+            description="Group filter.",
+        ),
+        last_activity: str | None = Field(
+            default=None,
+            description=(
+                "Filter by time since the app was last active."
+                " Format: 'was N days' (active within N days) or 'was not N days' (inactive for more than N days)."
+                " Example: 'was not 90 days'."
+            ),
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            description="Maximum number of results to return (default: 10).",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """List third-party applications (OAuth apps, API tokens, browser extensions,
+        service principals) with access to Falcon Shield (SaaS Security) monitored
+        platforms.
+
+        Use the item_id from results with `get_shield_app_users` to retrieve the users
+        of a specific app.
+
+        Returns app objects containing item_id, name, type, status, access_level,
+        granted scopes, and user count."""
+        return self._search_with_docs(
+            operation="GetAppInventory",
+            search_params={
+                "type": type,
+                "status": status,
+                "access_level": access_level,
+                "integration_id": integration_id,
+                "scopes": scopes,
+                "users": users,
+                "groups": groups,
+                "last_activity": last_activity,
+                "limit": limit,
+            },
+            error_message="Failed to search Shield apps",
+        )
+
+    def get_shield_app_users(
+        self,
+        item_id: str = Field(
+            description=(
+                "Composite app identifier in the format integration_id|||app_id."
+                " Obtain from the item_id field in results returned by `search_shield_apps`."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve the users who have authorized or are associated with a specific
+        third-party app in Falcon Shield (SaaS Security).
+
+        Use this after `search_shield_apps` to drill into a specific app's user
+        population.
+
+        Returns user objects including email, display name, and granted
+        permissions."""
+        return self._search_with_docs(
+            operation="GetAppInventoryUsers",
+            search_params={"item_id": item_id},
+            error_message="Failed to get app users",
+        )
+
+    def search_shield_data_shares(
+        self,
+        integration_id: str | None = Field(
+            default=None,
+            description=(
+                "Comma-separated IDs of SaaS integrations to filter by."
+                " Use `get_shield_integrations` to retrieve available integration IDs."
+            ),
+        ),
+        resource_type: str | None = Field(
+            default=None,
+            description="File type filter (e.g., PDF, XLSX).",
+        ),
+        access_level: str | None = Field(
+            default=None,
+            description=(
+                "Sharing access level filter (comma-separated)."
+                " Values: public_link, external_user, org_wide, internal."
+            ),
+        ),
+        resource_name: str | None = Field(
+            default=None,
+            description="Filter to resources whose name contains this value.",
+        ),
+        resource_owner: str | None = Field(
+            default=None,
+            description="Filter to resources whose owner name or email contains this value.",
+        ),
+        resource_owner_enabled: bool | None = Field(
+            default=None,
+            description=(
+                "If true, return only resources with an active owner account."
+                " If false, only disabled owner accounts."
+            ),
+        ),
+        password_protected: bool | None = Field(
+            default=None,
+            description="If true, return only password-protected resources. If false, only unprotected resources.",
+        ),
+        last_accessed: str | None = Field(
+            default=None,
+            description=(
+                "Filter by time since the resource was last accessed."
+                " Format: 'was N days' (within N days) or 'was not N days' (not accessed in more than N days)."
+                " Example: 'was not 30 days'."
+            ),
+        ),
+        last_modified: str | None = Field(
+            default=None,
+            description=(
+                "Filter by time since the resource was last modified."
+                " Format: 'was N days' (within N days) or 'was not N days' (not modified in more than N days)."
+                " Example: 'was not 30 days'."
+            ),
+        ),
+        unmanaged_domain: str | None = Field(
+            default=None,
+            description=(
+                "Filter to resources shared with external (non-organization) domains."
+                " Comma-separated domain names (e.g., 'gmail.com,yahoo.com')."
+            ),
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            description="Maximum number of results to return (default: 10).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description=(
+                "Zero-based offset for pagination. Omit or set to 0 for the first page."
+                " Increment by limit for subsequent pages."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """List files and resources shared externally across Falcon Shield (SaaS
+        Security) monitored SaaS applications.
+
+        Use this to identify overshared or externally exposed files (e.g., Google
+        Drive documents shared outside the organization).
+
+        Returns resource objects containing resource name, type, owner, sharing access
+        level, password protection status, and last access/modification timestamps."""
+        return self._search_with_docs(
+            operation="GetAssetInventoryV3",
+            search_params={
+                "integration_id": integration_id,
+                "resource_type": resource_type,
+                "access_level": access_level,
+                "resource_name": resource_name,
+                "resource_owner": resource_owner,
+                "resource_owner_enabled": resource_owner_enabled,
+                "password_protected": password_protected,
+                "last_accessed": last_accessed,
+                "last_modified": last_modified,
+                "unmanaged_domain": unmanaged_domain,
+                "limit": limit,
+                "offset": offset,
+            },
+            error_message="Failed to search Shield data shares",
+        )
+
+    def get_shield_integrations(
+        self,
+        saas_id: str | None = Field(
+            default=None,
+            description="Comma-separated SaaS platform IDs to filter by.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """List all SaaS integrations connected to Falcon Shield (SaaS Security) and
+        their current connection status.
+
+        The integration_id values returned here are used as input to most other Shield
+        tools. Call this tool first when starting a Shield investigation to discover
+        available integrations.
+
+        Returns integration objects containing integration_id, SaaS platform name,
+        connection health, and last sync time."""
+        return self._search_with_docs(
+            operation="GetIntegrationsV3",
+            search_params={"saas_id": saas_id},
+            error_message="Failed to get Shield integrations",
+        )
+
+    def get_shield_system_users(self) -> list[dict[str, Any]] | dict[str, Any]:
+        """List Falcon Shield (SaaS Security) platform administrators.
+
+        These are Shield console administrators, not end-users of connected SaaS
+        applications. For SaaS app end-users, use `search_shield_users`.
+
+        Returns system-level user objects including email, role, and MFA status."""
+        return self._search_with_docs(
+            operation="GetSystemUsersV3",
+            search_params={},
+            error_message="Failed to get Shield system users",
+        )
+
+    # --- Mutating tools ---
+
+    def dismiss_shield_check(
+        self,
+        id: str = Field(
+            description="Security check ID. Obtain from the id field in results returned by `search_shield_checks`.",
+        ),
+        reason: str = Field(
+            description=(
+                "Required explanation for the dismissal."
+                " This is written to the audit log and visible to other administrators."
+            ),
+        ),
+        entities: str | None = Field(
+            default=None,
+            description=(
+                "Comma-separated entity names to dismiss."
+                " If omitted, dismisses the entire check for all entities."
+                " If provided, only the specified entities are dismissed and the check remains active for others."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Dismiss a Falcon Shield (SaaS Security) posture check to suppress it from
+        the failed checks list.
+
+        WARNING: This action is permanent and cannot be undone from the API. The
+        dismissal reason is recorded in audit logs.
+
+        When entities is omitted, the entire check is dismissed for all entities.
+        When entities is provided, only the specified entities are dismissed and the
+        check remains active for others."""
+        if isinstance(entities, str):
+            operation = "DismissAffectedEntityV3"
+            body = {
+                "id": id,
+                "reason": reason,
+                "entities": [e.strip() for e in entities.split(",")],
+            }
+        else:
+            operation = "DismissSecurityCheckV3"
+            body = {"id": id, "reason": reason}
+
+        return self._base_query_api_call(
+            operation=operation,
+            body_params=body,
+            error_message="Failed to dismiss Shield check",
+        )

--- a/falcon_mcp/modules/shield.py
+++ b/falcon_mcp/modules/shield.py
@@ -13,22 +13,23 @@ from falcon_mcp.resources.shield import SHIELD_QUERY_DOCUMENTATION
 
 logger = get_logger(__name__)
 
-IMPACT_MAP = {"low": 1, "medium": 2, "high": 3}
+IMPACT_NAMES = {"low": "Low", "medium": "Medium", "high": "High"}
 
 
 class ShieldModule(BaseModule):
     """Module for CrowdStrike Falcon Shield (SaaS Security) API operations."""
 
     @staticmethod
-    def _map_impact(impact: str | None) -> int | None:
+    def _normalize_impact(impact: str | None) -> str | None:
+        """Normalize impact to title-case for endpoints that accept named values."""
         if not isinstance(impact, str):
             return None
-        mapped = IMPACT_MAP.get(impact.lower())
-        if mapped is None:
+        normalized = IMPACT_NAMES.get(impact.lower())
+        if normalized is None:
             logger.warning(
-                "Unknown impact value '%s'; expected one of: %s", impact, ", ".join(IMPACT_MAP)
+                "Unknown impact value '%s'; expected one of: %s", impact, ", ".join(IMPACT_NAMES)
             )
-        return mapped
+        return normalized
 
     def _format_empty_or_error(
         self,
@@ -158,7 +159,7 @@ class ShieldModule(BaseModule):
         ),
         status: str | None = Field(
             default=None,
-            description="Filter by status: Passed, Failed, Dismissed, Pending, Can't Run, Stale, Not Available.",
+            description="Filter by status: Passed, Failed, Dismissed, Pending, Can't Run, Stale.",
         ),
         impact: str | None = Field(
             default=None,
@@ -177,7 +178,7 @@ class ShieldModule(BaseModule):
         ),
         check_type: str | None = Field(
             default=None,
-            description="Filter by type: apps, devices, users, assets, permissions, custom.",
+            description="Filter by type: apps, devices, users, assets, permissions, custom, Falcon Shield Security Check.",
         ),
         check_tags: str | None = Field(
             default=None,
@@ -215,7 +216,7 @@ class ShieldModule(BaseModule):
             search_params={
                 "id": id,
                 "status": status,
-                "impact": self._map_impact(impact),
+                "impact": self._normalize_impact(impact),
                 "integration_id": integration_id,
                 "compliance": compliance,
                 "check_type": check_type,
@@ -280,7 +281,7 @@ class ShieldModule(BaseModule):
         ),
         check_type: str | None = Field(
             default=None,
-            description="Filter by type: apps, devices, users, assets, permissions, custom.",
+            description="Filter by type: apps, devices, users, assets, permissions, custom, Falcon Shield Security Check.",
         ),
         limit: int = Field(
             default=10,
@@ -307,7 +308,7 @@ class ShieldModule(BaseModule):
             operation="GetMetricsV3",
             search_params={
                 "status": status,
-                "impact": self._map_impact(impact),
+                "impact": self._normalize_impact(impact),
                 "integration_id": integration_id,
                 "compliance": compliance,
                 "check_type": check_type,
@@ -344,7 +345,7 @@ class ShieldModule(BaseModule):
         ),
         type: str | None = Field(
             default=None,
-            description="Filter by type: configuration_drift, check_degraded, integration_failure, threat.",
+            description="Filter by type: configuration_drift, check_degraded, integration_failure, Threat.",
         ),
         integration_id: str | None = Field(
             default=None,
@@ -386,7 +387,7 @@ class ShieldModule(BaseModule):
 
         Alert types: configuration_drift (a previously passing check now fails),
         check_degraded (check status worsened), integration_failure (connectivity issue
-        with a SaaS platform), threat (active threat indicator).
+        with a SaaS platform), Threat (active threat indicator).
 
         Pagination: use last_id from the last result for cursor-based pagination, or
         use offset for offset-based pagination.
@@ -647,6 +648,13 @@ class ShieldModule(BaseModule):
             ge=1,
             description="Maximum number of results to return (default: 10).",
         ),
+        offset: int | None = Field(
+            default=None,
+            description=(
+                "Zero-based offset for pagination. Omit or set to 0 for the first page."
+                " Increment by limit for subsequent pages."
+            ),
+        ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """List third-party applications (OAuth apps, API tokens, browser extensions,
         service principals) with access to Falcon Shield (SaaS Security) monitored
@@ -669,6 +677,7 @@ class ShieldModule(BaseModule):
                 "groups": groups,
                 "last_activity": last_activity,
                 "limit": limit,
+                "offset": offset,
             },
             error_message="Failed to search Shield apps",
         )
@@ -688,8 +697,7 @@ class ShieldModule(BaseModule):
         Use this after `search_shield_apps` to drill into a specific app's user
         population.
 
-        Returns user objects including email, display name, and granted
-        permissions."""
+        Returns user objects including email, display name, and granted permissions."""
         return self._search_with_docs(
             operation="GetAppInventoryUsers",
             search_params={"item_id": item_id},
@@ -867,16 +875,16 @@ class ShieldModule(BaseModule):
         if isinstance(entities, str):
             operation = "DismissAffectedEntityV3"
             body = {
-                "id": id,
                 "reason": reason,
                 "entities": [e.strip() for e in entities.split(",")],
             }
         else:
             operation = "DismissSecurityCheckV3"
-            body = {"id": id, "reason": reason}
+            body = {"reason": reason}
 
         return self._base_query_api_call(
             operation=operation,
+            query_params={"id": id},
             body_params=body,
             error_message="Failed to dismiss Shield check",
         )

--- a/falcon_mcp/resources/shield.py
+++ b/falcon_mcp/resources/shield.py
@@ -7,14 +7,14 @@ SHIELD_COMMON_PARAMS = [
     (
         "status",
         "String",
-        "Passed, Failed, Dismissed, Pending, Can't Run, Stale, Not Available",
+        "Passed, Failed, Dismissed, Pending, Can't Run, Stale",
         "shield_checks, shield_posture_metrics",
     ),
     ("impact", "String", "Low, Medium, High", "shield_checks, shield_posture_metrics"),
     (
         "check_type",
         "String",
-        "apps, devices, users, assets, permissions, custom",
+        "apps, devices, users, assets, permissions, custom, Falcon Shield Security Check",
         "shield_checks, shield_posture_metrics",
     ),
     (
@@ -38,7 +38,7 @@ SHIELD_QUERY_DOCUMENTATION = f"""# Falcon Shield Query Parameter Guide
 {generate_md_table(SHIELD_COMMON_PARAMS)}
 
 ## Alert Types
-configuration_drift, check_degraded, integration_failure, threat
+configuration_drift, check_degraded, integration_failure, Threat
 
 ## App Types
 oauth, sign_in, api_token, App Registration, Connected Apps, browser_extension, Portal, Service Principal

--- a/falcon_mcp/resources/shield.py
+++ b/falcon_mcp/resources/shield.py
@@ -1,0 +1,64 @@
+"""Falcon Shield (SaaS Security) query parameter documentation."""
+
+from falcon_mcp.common.utils import generate_md_table
+
+SHIELD_COMMON_PARAMS = [
+    ("Parameter", "Type", "Values", "Used By"),
+    (
+        "status",
+        "String",
+        "Passed, Failed, Dismissed, Pending, Can't Run, Stale, Not Available",
+        "shield_checks, shield_posture_metrics",
+    ),
+    ("impact", "String", "Low, Medium, High", "shield_checks, shield_posture_metrics"),
+    (
+        "check_type",
+        "String",
+        "apps, devices, users, assets, permissions, custom",
+        "shield_checks, shield_posture_metrics",
+    ),
+    (
+        "integration_id",
+        "String",
+        "Comma-separated integration IDs",
+        "Most tools",
+    ),
+    (
+        "compliance",
+        "Boolean",
+        "true/false",
+        "shield_checks, shield_posture_metrics",
+    ),
+]
+
+SHIELD_QUERY_DOCUMENTATION = f"""# Falcon Shield Query Parameter Guide
+
+## Common Parameters
+
+{generate_md_table(SHIELD_COMMON_PARAMS)}
+
+## Alert Types
+configuration_drift, check_degraded, integration_failure, threat
+
+## App Types
+oauth, sign_in, api_token, App Registration, Connected Apps, browser_extension, Portal, Service Principal
+
+## App Statuses
+approved, in review, rejected, unclassified
+
+## Activity Monitor Categories
+Events, Threat, IoC
+
+## Activity Monitor Projection Fields
+timestamp_utc, severity, datetime, event_name, actor, integration_id, integration_name, type, category, \
+created_by, ip, asn_name, country, browser, os, target, object_type, object, status
+
+## Supported SaaS Platforms
+Use `GetSupportedSaasV3` via the API to get the current list of platforms available for integration.
+
+## Pagination Notes
+- `meta.pagination.total` is always null — iterate until empty results
+- Activity Monitor: use `meta.pagination.next` as `to_date` and `meta.pagination.offset` as `skip`
+- Alerts: use `last_id` for cursor-based pagination (alternative to offset)
+- Activity Monitor has 24-hour date range limit when using integration_id/category/actor filters
+"""

--- a/falcon_mcp/resources/shield.py
+++ b/falcon_mcp/resources/shield.py
@@ -26,7 +26,7 @@ SHIELD_COMMON_PARAMS = [
     (
         "compliance",
         "Boolean",
-        "true/false",
+        "true/false (filters on catalog-level framework mapping, not populated compliance data)",
         "shield_checks, shield_posture_metrics",
     ),
 ]
@@ -38,13 +38,20 @@ SHIELD_QUERY_DOCUMENTATION = f"""# Falcon Shield Query Parameter Guide
 {generate_md_table(SHIELD_COMMON_PARAMS)}
 
 ## Alert Types
-configuration_drift, check_degraded, integration_failure, Threat
+configuration_drift, check_degraded, integration_failure, threat
 
 ## App Types
 oauth, sign_in, api_token, App Registration, Connected Apps, browser_extension, Portal, Service Principal
 
 ## App Statuses
 approved, in review, rejected, unclassified
+
+## Time-Based Filters
+Format: 'was N' (within N days) or 'was not N' (not within N days). N is an integer — do NOT append 'days'.
+- last_activity — used by shield_apps
+- last_accessed — used by shield_data_shares
+- last_modified — used by shield_data_shares
+Examples: 'was not 90' (inactive >90 days), 'was 30' (active within 30 days)
 
 ## Activity Monitor Categories
 Events, Threat, IoC

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -47,6 +47,9 @@ MODULE_METADATA: dict[str, dict[str, Any]] = {
     "serverless": {
         "title": "Serverless",
     },
+    "shield": {
+        "title": "Shield",
+    },
 }
 
 # Natural language prompt examples for each tool, shown in generated docs
@@ -207,6 +210,58 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     # Serverless
     "falcon_search_serverless_vulnerabilities": [
         "Find HIGH severity vulnerabilities in AWS Lambda functions",
+    ],
+    # Shield
+    "falcon_search_shield_checks": [
+        "Show me the failed Shield security checks",
+        "Search for high impact Shield checks related to devices",
+    ],
+    "falcon_get_shield_check_affected_entities": [
+        "Show me the entities affected by a failed Shield check",
+    ],
+    "falcon_get_shield_posture_metrics": [
+        "Show me my overall Falcon Shield posture metrics",
+    ],
+    "falcon_get_shield_check_compliance": [
+        "Find a Shield check with compliance framework mappings",
+    ],
+    "falcon_search_shield_alerts": [
+        "Show me Shield alerts of type Threat",
+        "Show me the 5 oldest Shield alerts sorted by date",
+    ],
+    "falcon_get_shield_activity_monitor": [
+        "Show me Shield activity events from the last 24 hours",
+    ],
+    "falcon_search_shield_users": [
+        "List privileged users across my connected SaaS apps in Shield",
+    ],
+    "falcon_search_shield_devices": [
+        "Show me devices in Shield not associated with any known user",
+    ],
+    "falcon_search_shield_apps": [
+        "Find OAuth apps in Shield that haven't been active in 90 days",
+        "List all Shield apps with status 'in review'",
+    ],
+    "falcon_get_shield_app_users": [
+        "Show me which users have authorized Shield app abc123",
+    ],
+    "falcon_search_shield_data_shares": [
+        "Find files shared via public link in Shield",
+    ],
+    "falcon_get_shield_integrations": [
+        "List all connected SaaS integrations in Falcon Shield",
+    ],
+    "falcon_get_shield_system_users": [
+        "Show me the Falcon Shield platform administrators and their MFA status",
+    ],
+    "falcon_get_shield_supported_saas": [
+        "List all SaaS platforms supported by Falcon Shield",
+    ],
+    "falcon_get_shield_system_logs": [
+        "Show me the last 10 Falcon Shield system audit logs",
+    ],
+    "falcon_dismiss_shield_check": [
+        "Dismiss a low-impact Shield check entity with reason 'No longer applicable'",
     ],
     # Spotlight
     "falcon_search_vulnerabilities": [

--- a/tests/integration/test_shield.py
+++ b/tests/integration/test_shield.py
@@ -13,7 +13,7 @@ class TestShieldIntegration(BaseIntegrationTest):
     Validates:
     - Correct FalconPy operation names for all 13 read-only tools
     - Direct GET endpoints return full entity details (no two-step pattern)
-    - Impact string-to-int mapping works against real API
+    - Impact string normalization works against real API
     - Dismiss tool (DismissSecurityCheckV3/DismissAffectedEntityV3) is skipped
       — write operations are not run in integration tests
 
@@ -37,7 +37,7 @@ class TestShieldIntegration(BaseIntegrationTest):
             self.assert_valid_list_response(result, min_length=0, context="search_shield_checks")
 
     def test_search_shield_checks_with_impact_filter(self):
-        """Validate impact string-to-int mapping works against real API."""
+        """Validate impact string normalization works against real API."""
         result = self.call_method(
             self.module.search_shield_checks,
             impact="High",

--- a/tests/integration/test_shield.py
+++ b/tests/integration/test_shield.py
@@ -11,7 +11,7 @@ class TestShieldIntegration(BaseIntegrationTest):
     """Integration tests for Shield module with real API calls.
 
     Validates:
-    - Correct FalconPy operation names for all 13 read-only tools
+    - Correct FalconPy operation names for all 15 read-only tools
     - Direct GET endpoints return full entity details (no two-step pattern)
     - Impact string normalization works against real API
     - Dismiss tool (DismissSecurityCheckV3/DismissAffectedEntityV3) is skipped
@@ -213,10 +213,30 @@ class TestShieldIntegration(BaseIntegrationTest):
                 result, min_length=0, context="get_shield_system_users"
             )
 
+    def test_get_shield_supported_saas(self):
+        """Validate GetSupportedSaasV3 operation name and response shape."""
+        result = self.call_method(self.module.get_shield_supported_saas)
+
+        self.assert_no_error(result, context="get_shield_supported_saas")
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result, min_length=0, context="get_shield_supported_saas"
+            )
+
+    def test_get_shield_system_logs(self):
+        """Validate GetSystemLogsV3 operation name and response shape."""
+        result = self.call_method(self.module.get_shield_system_logs, limit=5)
+
+        self.assert_no_error(result, context="get_shield_system_logs")
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result, min_length=0, context="get_shield_system_logs"
+            )
+
     # --- Cross-tool validation ---
 
     def test_all_read_operation_names_are_correct(self):
-        """Validate all 13 read-only operation names produce no errors.
+        """Validate all 15 read-only operation names produce no errors.
 
         If any operation name is wrong (typo), the FalconPy client.command()
         call will fail with an error response. This test covers both
@@ -263,13 +283,21 @@ class TestShieldIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.get_shield_system_users)
         self.assert_no_error(result, context="GetSystemUsersV3")
 
+        # 11. GetSupportedSaasV3
+        result = self.call_method(self.module.get_shield_supported_saas)
+        self.assert_no_error(result, context="GetSupportedSaasV3")
+
+        # 12. GetSystemLogsV3
+        result = self.call_method(self.module.get_shield_system_logs, limit=1)
+        self.assert_no_error(result, context="GetSystemLogsV3")
+
         # ID-dependent operations — need a real check ID from step 1
         check_id = None
         if isinstance(checks, list) and len(checks) > 0:
             check_id = self.get_first_id(checks, id_field="id")
 
         if check_id:
-            # 11. GetSecurityCheckAffectedV3
+            # 13. GetSecurityCheckAffectedV3
             result = self.call_method(
                 self.module.get_shield_check_affected_entities,
                 id=check_id,
@@ -277,7 +305,7 @@ class TestShieldIntegration(BaseIntegrationTest):
             )
             self.assert_no_error(result, context="GetSecurityCheckAffectedV3")
 
-            # 12. GetSecurityCheckComplianceV3
+            # 14. GetSecurityCheckComplianceV3
             result = self.call_method(
                 self.module.get_shield_check_compliance,
                 id=check_id,
@@ -290,7 +318,7 @@ class TestShieldIntegration(BaseIntegrationTest):
             if isinstance(first_app, dict):
                 app_item_id = first_app.get("item_id") or first_app.get("id")
                 if app_item_id:
-                    # 13. GetAppInventoryUsers
+                    # 15. GetAppInventoryUsers
                     result = self.call_method(
                         self.module.get_shield_app_users,
                         item_id=app_item_id,

--- a/tests/integration/test_shield.py
+++ b/tests/integration/test_shield.py
@@ -1,0 +1,298 @@
+"""Integration tests for the Shield (SaaS Security) module."""
+
+import pytest
+
+from falcon_mcp.modules.shield import ShieldModule
+from tests.integration.utils.base_integration_test import BaseIntegrationTest
+
+
+@pytest.mark.integration
+class TestShieldIntegration(BaseIntegrationTest):
+    """Integration tests for Shield module with real API calls.
+
+    Validates:
+    - Correct FalconPy operation names for all 13 read-only tools
+    - Direct GET endpoints return full entity details (no two-step pattern)
+    - Impact string-to-int mapping works against real API
+    - Dismiss tool (DismissSecurityCheckV3/DismissAffectedEntityV3) is skipped
+      — write operations are not run in integration tests
+
+    Note: SaaS Security endpoints may return empty results if no SaaS
+    integrations are configured. Tests accept empty lists as valid.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_module(self, falcon_client):
+        """Set up the Shield module with a real client."""
+        self.module = ShieldModule(falcon_client)
+
+    # --- Core posture tools ---
+
+    def test_search_shield_checks(self):
+        """Validate GetSecurityChecksV3 operation name and response shape."""
+        result = self.call_method(self.module.search_shield_checks, limit=5)
+
+        self.assert_no_error(result, context="search_shield_checks")
+        if isinstance(result, list):
+            self.assert_valid_list_response(result, min_length=0, context="search_shield_checks")
+
+    def test_search_shield_checks_with_impact_filter(self):
+        """Validate impact string-to-int mapping works against real API."""
+        result = self.call_method(
+            self.module.search_shield_checks,
+            impact="High",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="search_shield_checks with impact")
+
+    def test_get_shield_check_affected_entities(self):
+        """Validate GetSecurityCheckAffectedV3 with a real check ID."""
+        checks = self.call_method(self.module.search_shield_checks, limit=1)
+
+        if not isinstance(checks, list) or len(checks) == 0:
+            self.skip_with_warning(
+                "No security checks available",
+                context="get_shield_check_affected_entities",
+            )
+
+        check_id = self.get_first_id(checks, id_field="id")
+        if not check_id:
+            self.skip_with_warning(
+                "Could not extract check ID",
+                context="get_shield_check_affected_entities",
+            )
+
+        result = self.call_method(
+            self.module.get_shield_check_affected_entities,
+            id=check_id,
+            limit=5,
+        )
+
+        self.assert_no_error(result, context="get_shield_check_affected_entities")
+
+    def test_get_shield_posture_metrics(self):
+        """Validate GetMetricsV3 operation name and response shape."""
+        result = self.call_method(self.module.get_shield_posture_metrics, limit=5)
+
+        self.assert_no_error(result, context="get_shield_posture_metrics")
+
+    def test_get_shield_check_compliance(self):
+        """Validate GetSecurityCheckComplianceV3 with a real check ID."""
+        checks = self.call_method(self.module.search_shield_checks, limit=1)
+
+        if not isinstance(checks, list) or len(checks) == 0:
+            self.skip_with_warning(
+                "No security checks available",
+                context="get_shield_check_compliance",
+            )
+
+        check_id = self.get_first_id(checks, id_field="id")
+        if not check_id:
+            self.skip_with_warning(
+                "Could not extract check ID",
+                context="get_shield_check_compliance",
+            )
+
+        result = self.call_method(
+            self.module.get_shield_check_compliance,
+            id=check_id,
+        )
+
+        self.assert_no_error(result, context="get_shield_check_compliance")
+
+    # --- Alerts & activity ---
+
+    def test_search_shield_alerts(self):
+        """Validate GetAlertsV3 operation name and response shape."""
+        result = self.call_method(self.module.search_shield_alerts, limit=5)
+
+        self.assert_no_error(result, context="search_shield_alerts")
+        if isinstance(result, list):
+            self.assert_valid_list_response(result, min_length=0, context="search_shield_alerts")
+
+    def test_get_shield_activity_monitor(self):
+        """Validate GetActivityMonitorV3 operation name and response shape."""
+        result = self.call_method(self.module.get_shield_activity_monitor, limit=5)
+
+        self.assert_no_error(result, context="get_shield_activity_monitor")
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result, min_length=0, context="get_shield_activity_monitor"
+            )
+
+    # --- Inventory tools ---
+
+    def test_search_shield_users(self):
+        """Validate GetUserInventoryV3 operation name and response shape."""
+        result = self.call_method(self.module.search_shield_users, limit=5)
+
+        self.assert_no_error(result, context="search_shield_users")
+        if isinstance(result, list):
+            self.assert_valid_list_response(result, min_length=0, context="search_shield_users")
+
+    def test_search_shield_devices(self):
+        """Validate GetDeviceInventoryV3 operation name and response shape."""
+        result = self.call_method(self.module.search_shield_devices, limit=5)
+
+        self.assert_no_error(result, context="search_shield_devices")
+        if isinstance(result, list):
+            self.assert_valid_list_response(result, min_length=0, context="search_shield_devices")
+
+    def test_search_shield_apps(self):
+        """Validate GetAppInventory operation name and response shape."""
+        result = self.call_method(self.module.search_shield_apps, limit=5)
+
+        self.assert_no_error(result, context="search_shield_apps")
+        if isinstance(result, list):
+            self.assert_valid_list_response(result, min_length=0, context="search_shield_apps")
+
+    def test_get_shield_app_users(self):
+        """Validate GetAppInventoryUsers with a real app ID.
+
+        Requires apps to exist; skips gracefully if none configured.
+        """
+        apps = self.call_method(self.module.search_shield_apps, limit=1)
+
+        if not isinstance(apps, list) or len(apps) == 0:
+            self.skip_with_warning(
+                "No apps available to test app users",
+                context="get_shield_app_users",
+            )
+
+        first_app = apps[0]
+        if not isinstance(first_app, dict):
+            self.skip_with_warning(
+                "Unexpected app response shape",
+                context="get_shield_app_users",
+            )
+
+        item_id = first_app.get("item_id") or first_app.get("id")
+        if not item_id:
+            self.skip_with_warning(
+                "Could not extract app item_id",
+                context="get_shield_app_users",
+            )
+
+        result = self.call_method(
+            self.module.get_shield_app_users,
+            item_id=item_id,
+        )
+
+        self.assert_no_error(result, context="get_shield_app_users")
+
+    def test_search_shield_data_shares(self):
+        """Validate GetAssetInventoryV3 operation name and response shape."""
+        result = self.call_method(self.module.search_shield_data_shares, limit=5)
+
+        self.assert_no_error(result, context="search_shield_data_shares")
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result, min_length=0, context="search_shield_data_shares"
+            )
+
+    # --- Platform management tools ---
+
+    def test_get_shield_integrations(self):
+        """Validate GetIntegrationsV3 operation name and response shape."""
+        result = self.call_method(self.module.get_shield_integrations)
+
+        self.assert_no_error(result, context="get_shield_integrations")
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result, min_length=0, context="get_shield_integrations"
+            )
+
+    def test_get_shield_system_users(self):
+        """Validate GetSystemUsersV3 operation name and response shape."""
+        result = self.call_method(self.module.get_shield_system_users)
+
+        self.assert_no_error(result, context="get_shield_system_users")
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result, min_length=0, context="get_shield_system_users"
+            )
+
+    # --- Cross-tool validation ---
+
+    def test_all_read_operation_names_are_correct(self):
+        """Validate all 13 read-only operation names produce no errors.
+
+        If any operation name is wrong (typo), the FalconPy client.command()
+        call will fail with an error response. This test covers both
+        parameterless tools and ID-dependent tools to catch typos in every
+        operation name used by the module.
+        """
+        # 1. GetSecurityChecksV3
+        checks = self.call_method(self.module.search_shield_checks, limit=1)
+        self.assert_no_error(checks, context="GetSecurityChecksV3")
+
+        # 2. GetMetricsV3
+        result = self.call_method(self.module.get_shield_posture_metrics, limit=1)
+        self.assert_no_error(result, context="GetMetricsV3")
+
+        # 3. GetAlertsV3
+        result = self.call_method(self.module.search_shield_alerts, limit=1)
+        self.assert_no_error(result, context="GetAlertsV3")
+
+        # 4. GetActivityMonitorV3
+        result = self.call_method(self.module.get_shield_activity_monitor, limit=1)
+        self.assert_no_error(result, context="GetActivityMonitorV3")
+
+        # 5. GetUserInventoryV3
+        result = self.call_method(self.module.search_shield_users, limit=1)
+        self.assert_no_error(result, context="GetUserInventoryV3")
+
+        # 6. GetDeviceInventoryV3
+        result = self.call_method(self.module.search_shield_devices, limit=1)
+        self.assert_no_error(result, context="GetDeviceInventoryV3")
+
+        # 7. GetAppInventory
+        apps = self.call_method(self.module.search_shield_apps, limit=1)
+        self.assert_no_error(apps, context="GetAppInventory")
+
+        # 8. GetAssetInventoryV3
+        result = self.call_method(self.module.search_shield_data_shares, limit=1)
+        self.assert_no_error(result, context="GetAssetInventoryV3")
+
+        # 9. GetIntegrationsV3
+        result = self.call_method(self.module.get_shield_integrations)
+        self.assert_no_error(result, context="GetIntegrationsV3")
+
+        # 10. GetSystemUsersV3
+        result = self.call_method(self.module.get_shield_system_users)
+        self.assert_no_error(result, context="GetSystemUsersV3")
+
+        # ID-dependent operations — need a real check ID from step 1
+        check_id = None
+        if isinstance(checks, list) and len(checks) > 0:
+            check_id = self.get_first_id(checks, id_field="id")
+
+        if check_id:
+            # 11. GetSecurityCheckAffectedV3
+            result = self.call_method(
+                self.module.get_shield_check_affected_entities,
+                id=check_id,
+                limit=1,
+            )
+            self.assert_no_error(result, context="GetSecurityCheckAffectedV3")
+
+            # 12. GetSecurityCheckComplianceV3
+            result = self.call_method(
+                self.module.get_shield_check_compliance,
+                id=check_id,
+            )
+            self.assert_no_error(result, context="GetSecurityCheckComplianceV3")
+
+        # ID-dependent: GetAppInventoryUsers — needs a real app item_id
+        if isinstance(apps, list) and len(apps) > 0:
+            first_app = apps[0]
+            if isinstance(first_app, dict):
+                app_item_id = first_app.get("item_id") or first_app.get("id")
+                if app_item_id:
+                    # 13. GetAppInventoryUsers
+                    result = self.call_method(
+                        self.module.get_shield_app_users,
+                        item_id=app_item_id,
+                    )
+                    self.assert_no_error(result, context="GetAppInventoryUsers")

--- a/tests/modules/test_shield.py
+++ b/tests/modules/test_shield.py
@@ -19,7 +19,7 @@ class TestShieldModule(TestModules):
     # --- Registration tests ---
 
     def test_register_tools(self):
-        """Test registering all 14 tools with the server."""
+        """Test registering all 16 tools with the server."""
         expected_tools = [
             "falcon_search_shield_checks",
             "falcon_get_shield_check_affected_entities",
@@ -34,6 +34,8 @@ class TestShieldModule(TestModules):
             "falcon_search_shield_data_shares",
             "falcon_get_shield_integrations",
             "falcon_get_shield_system_users",
+            "falcon_get_shield_supported_saas",
+            "falcon_get_shield_system_logs",
             "falcon_dismiss_shield_check",
         ]
         self.assert_tools_registered(expected_tools)
@@ -100,6 +102,14 @@ class TestShieldModule(TestModules):
     def test_get_shield_system_users_has_read_only_annotations(self):
         self.module.register_tools(self.mock_server)
         self.assert_tool_annotations("falcon_get_shield_system_users", READ_ONLY_ANNOTATIONS)
+
+    def test_get_shield_supported_saas_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_get_shield_supported_saas", READ_ONLY_ANNOTATIONS)
+
+    def test_get_shield_system_logs_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_get_shield_system_logs", READ_ONLY_ANNOTATIONS)
 
     def test_dismiss_shield_check_has_destructive_annotations(self):
         self.module.register_tools(self.mock_server)
@@ -438,6 +448,80 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetSystemUsersV3")
         self.assertEqual(len(result), 1)
+
+    # --- Functional tests: get_shield_supported_saas ---
+
+    def test_get_shield_supported_saas_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{"id": "google", "name": "Google Workspace"}]
+            },
+        }
+
+        result = self.module.get_shield_supported_saas()
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetSupportedSaasV3")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "google")
+
+    def test_get_shield_supported_saas_empty(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.get_shield_supported_saas()
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+
+    # --- Functional tests: get_shield_system_logs ---
+
+    def test_get_shield_system_logs_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"timestamp": "2026-04-29T10:00:00Z", "event_type": "integration_created"}
+                ]
+            },
+        }
+
+        result = self.module.get_shield_system_logs(
+            from_date="2026-04-01", to_date="2026-04-30", limit=50
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetSystemLogsV3")
+        self.assertEqual(call_args[1]["parameters"]["from_date"], "2026-04-01")
+        self.assertEqual(call_args[1]["parameters"]["to_date"], "2026-04-30")
+        self.assertEqual(call_args[1]["parameters"]["limit"], 50)
+        self.assertEqual(len(result), 1)
+
+    def test_get_shield_system_logs_empty(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.get_shield_system_logs()
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+
+    def test_get_shield_system_logs_api_error(self):
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid date format"}]},
+        }
+
+        result = self.module.get_shield_system_logs(from_date="bad-date")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result["results"][0])
+        self.assertIn("query_guide", result)
 
     # --- Functional tests: dismiss_shield_check ---
 

--- a/tests/modules/test_shield.py
+++ b/tests/modules/test_shield.py
@@ -5,7 +5,7 @@ import unittest
 from mcp.types import ToolAnnotations
 
 from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
-from falcon_mcp.modules.shield import IMPACT_MAP, ShieldModule
+from falcon_mcp.modules.shield import IMPACT_NAMES, ShieldModule
 from tests.modules.utils.test_modules import TestModules
 
 
@@ -115,31 +115,31 @@ class TestShieldModule(TestModules):
 
     # --- Impact mapping tests ---
 
-    def test_impact_map_values(self):
-        self.assertEqual(IMPACT_MAP["low"], 1)
-        self.assertEqual(IMPACT_MAP["medium"], 2)
-        self.assertEqual(IMPACT_MAP["high"], 3)
+    def test_impact_names_values(self):
+        self.assertEqual(IMPACT_NAMES["low"], "Low")
+        self.assertEqual(IMPACT_NAMES["medium"], "Medium")
+        self.assertEqual(IMPACT_NAMES["high"], "High")
 
-    def test_map_impact_low(self):
-        self.assertEqual(self.module._map_impact("Low"), 1)
+    def test_normalize_impact_low(self):
+        self.assertEqual(self.module._normalize_impact("Low"), "Low")
 
-    def test_map_impact_high(self):
-        self.assertEqual(self.module._map_impact("High"), 3)
+    def test_normalize_impact_high(self):
+        self.assertEqual(self.module._normalize_impact("High"), "High")
 
-    def test_map_impact_none(self):
-        self.assertIsNone(self.module._map_impact(None))
+    def test_normalize_impact_none(self):
+        self.assertIsNone(self.module._normalize_impact(None))
 
-    def test_map_impact_case_insensitive(self):
-        self.assertEqual(self.module._map_impact("low"), 1)
-        self.assertEqual(self.module._map_impact("MEDIUM"), 2)
-        self.assertEqual(self.module._map_impact("high"), 3)
+    def test_normalize_impact_case_insensitive(self):
+        self.assertEqual(self.module._normalize_impact("low"), "Low")
+        self.assertEqual(self.module._normalize_impact("MEDIUM"), "Medium")
+        self.assertEqual(self.module._normalize_impact("high"), "High")
 
-    def test_map_impact_invalid_string_returns_none(self):
-        self.assertIsNone(self.module._map_impact("critical"))
+    def test_normalize_impact_invalid_string_returns_none(self):
+        self.assertIsNone(self.module._normalize_impact("critical"))
 
-    def test_map_impact_invalid_string_logs_warning(self):
+    def test_normalize_impact_invalid_string_logs_warning(self):
         with self.assertLogs("falcon_mcp.modules.shield", level="WARNING") as cm:
-            self.module._map_impact("critical")
+            self.module._normalize_impact("critical")
         self.assertTrue(any("critical" in msg for msg in cm.output))
 
     # --- Functional tests: search_shield_checks ---
@@ -160,7 +160,7 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetSecurityChecksV3")
         self.assertEqual(call_args[1]["parameters"]["status"], "Failed")
-        self.assertEqual(call_args[1]["parameters"]["impact"], 3)
+        self.assertEqual(call_args[1]["parameters"]["impact"], "High")
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["id"], "check-1")
 
@@ -233,7 +233,7 @@ class TestShieldModule(TestModules):
 
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetMetricsV3")
-        self.assertEqual(call_args[1]["parameters"]["impact"], 2)
+        self.assertEqual(call_args[1]["parameters"]["impact"], "Medium")
         self.assertEqual(len(result), 1)
 
     # --- Functional tests: get_shield_check_compliance ---
@@ -268,6 +268,18 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetAlertsV3")
         self.assertEqual(call_args[1]["parameters"]["type"], "configuration_drift")
+        self.assertEqual(len(result), 1)
+
+    def test_search_shield_alerts_threat_type(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "alert-1", "alert_type": "Threat"}]},
+        }
+
+        result = self.module.search_shield_alerts(type="Threat")
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["parameters"]["type"], "Threat")
         self.assertEqual(len(result), 1)
 
     def test_search_shield_alerts_empty(self):
@@ -344,6 +356,21 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetAppInventory")
         self.assertEqual(call_args[1]["parameters"]["type"], "oauth")
+        self.assertEqual(len(result), 1)
+
+    def test_search_shield_apps_with_offset(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{"app_name": "Slack", "app_type": "oauth", "access_level": "high"}]
+            },
+        }
+
+        result = self.module.search_shield_apps(offset=10)
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetAppInventory")
+        self.assertEqual(call_args[1]["parameters"]["offset"], 10)
         self.assertEqual(len(result), 1)
 
     # --- Functional tests: get_shield_app_users ---
@@ -425,8 +452,9 @@ class TestShieldModule(TestModules):
 
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "DismissSecurityCheckV3")
-        self.assertEqual(call_args[1]["body"]["id"], "check-1")
-        self.assertEqual(call_args[1]["body"]["reason"], "Accepted risk")
+        self.assertEqual(call_args[1]["parameters"]["id"], "check-1")
+        self.assertEqual(call_args[1]["body"], {"reason": "Accepted risk"})
+        self.assertNotIn("id", call_args[1]["body"])
         self.assertEqual(len(result), 1)
 
     def test_dismiss_shield_check_specific_entities(self):
@@ -442,9 +470,10 @@ class TestShieldModule(TestModules):
 
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "DismissAffectedEntityV3")
-        self.assertEqual(call_args[1]["body"]["id"], "check-1")
+        self.assertEqual(call_args[1]["parameters"]["id"], "check-1")
         self.assertEqual(call_args[1]["body"]["reason"], "User exception")
         self.assertEqual(call_args[1]["body"]["entities"], ["user@ex.com", "admin@ex.com"])
+        self.assertNotIn("id", call_args[1]["body"])
         self.assertEqual(len(result), 1)
 
     def test_dismiss_shield_check_api_error(self):
@@ -509,6 +538,20 @@ class TestShieldModule(TestModules):
 
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[1]["parameters"]["check_tags"], long_value)
+
+    def test_search_shield_checks_falcon_shield_security_check_type(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "check-1", "check_type": "Falcon Shield Security Check"}]},
+        }
+
+        result = self.module.search_shield_checks(check_type="Falcon Shield Security Check")
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(
+            call_args[1]["parameters"]["check_type"], "Falcon Shield Security Check"
+        )
+        self.assertEqual(len(result), 1)
 
 
 if __name__ == "__main__":

--- a/tests/modules/test_shield.py
+++ b/tests/modules/test_shield.py
@@ -1,0 +1,515 @@
+"""Tests for the Shield (SaaS Security) module."""
+
+import unittest
+
+from mcp.types import ToolAnnotations
+
+from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
+from falcon_mcp.modules.shield import IMPACT_MAP, ShieldModule
+from tests.modules.utils.test_modules import TestModules
+
+
+class TestShieldModule(TestModules):
+    """Test cases for the Shield module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(ShieldModule)
+
+    # --- Registration tests ---
+
+    def test_register_tools(self):
+        """Test registering all 14 tools with the server."""
+        expected_tools = [
+            "falcon_search_shield_checks",
+            "falcon_get_shield_check_affected_entities",
+            "falcon_get_shield_posture_metrics",
+            "falcon_get_shield_check_compliance",
+            "falcon_search_shield_alerts",
+            "falcon_get_shield_activity_monitor",
+            "falcon_search_shield_users",
+            "falcon_search_shield_devices",
+            "falcon_search_shield_apps",
+            "falcon_get_shield_app_users",
+            "falcon_search_shield_data_shares",
+            "falcon_get_shield_integrations",
+            "falcon_get_shield_system_users",
+            "falcon_dismiss_shield_check",
+        ]
+        self.assert_tools_registered(expected_tools)
+
+    def test_register_resources(self):
+        """Test registering the query parameter guide resource."""
+        expected_resources = [
+            "falcon_shield_query_guide",
+        ]
+        self.assert_resources_registered(expected_resources)
+
+    # --- Annotation tests ---
+
+    def test_search_shield_checks_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_search_shield_checks", READ_ONLY_ANNOTATIONS)
+
+    def test_get_shield_check_affected_entities_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations(
+            "falcon_get_shield_check_affected_entities", READ_ONLY_ANNOTATIONS
+        )
+
+    def test_get_shield_posture_metrics_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_get_shield_posture_metrics", READ_ONLY_ANNOTATIONS)
+
+    def test_get_shield_check_compliance_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_get_shield_check_compliance", READ_ONLY_ANNOTATIONS)
+
+    def test_search_shield_alerts_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_search_shield_alerts", READ_ONLY_ANNOTATIONS)
+
+    def test_get_shield_activity_monitor_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_get_shield_activity_monitor", READ_ONLY_ANNOTATIONS)
+
+    def test_search_shield_users_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_search_shield_users", READ_ONLY_ANNOTATIONS)
+
+    def test_search_shield_devices_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_search_shield_devices", READ_ONLY_ANNOTATIONS)
+
+    def test_search_shield_apps_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_search_shield_apps", READ_ONLY_ANNOTATIONS)
+
+    def test_get_shield_app_users_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_get_shield_app_users", READ_ONLY_ANNOTATIONS)
+
+    def test_search_shield_data_shares_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_search_shield_data_shares", READ_ONLY_ANNOTATIONS)
+
+    def test_get_shield_integrations_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_get_shield_integrations", READ_ONLY_ANNOTATIONS)
+
+    def test_get_shield_system_users_has_read_only_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations("falcon_get_shield_system_users", READ_ONLY_ANNOTATIONS)
+
+    def test_dismiss_shield_check_has_destructive_annotations(self):
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations(
+            "falcon_dismiss_shield_check",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+    # --- Impact mapping tests ---
+
+    def test_impact_map_values(self):
+        self.assertEqual(IMPACT_MAP["low"], 1)
+        self.assertEqual(IMPACT_MAP["medium"], 2)
+        self.assertEqual(IMPACT_MAP["high"], 3)
+
+    def test_map_impact_low(self):
+        self.assertEqual(self.module._map_impact("Low"), 1)
+
+    def test_map_impact_high(self):
+        self.assertEqual(self.module._map_impact("High"), 3)
+
+    def test_map_impact_none(self):
+        self.assertIsNone(self.module._map_impact(None))
+
+    def test_map_impact_case_insensitive(self):
+        self.assertEqual(self.module._map_impact("low"), 1)
+        self.assertEqual(self.module._map_impact("MEDIUM"), 2)
+        self.assertEqual(self.module._map_impact("high"), 3)
+
+    def test_map_impact_invalid_string_returns_none(self):
+        self.assertIsNone(self.module._map_impact("critical"))
+
+    def test_map_impact_invalid_string_logs_warning(self):
+        with self.assertLogs("falcon_mcp.modules.shield", level="WARNING") as cm:
+            self.module._map_impact("critical")
+        self.assertTrue(any("critical" in msg for msg in cm.output))
+
+    # --- Functional tests: search_shield_checks ---
+
+    def test_search_shield_checks_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "check-1", "name": "MFA Enabled", "status": "Failed", "impact": 3}
+                ]
+            },
+        }
+
+        result = self.module.search_shield_checks(status="Failed", impact="High", limit=10)
+
+        self.mock_client.command.assert_called_once()
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetSecurityChecksV3")
+        self.assertEqual(call_args[1]["parameters"]["status"], "Failed")
+        self.assertEqual(call_args[1]["parameters"]["impact"], 3)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "check-1")
+
+    def test_search_shield_checks_empty_results(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.search_shield_checks()
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+        self.assertIn("query_guide", result)
+
+    def test_search_shield_checks_api_error(self):
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Bad Request"}]},
+        }
+
+        result = self.module.search_shield_checks()
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["results"]), 1)
+        self.assertIn("error", result["results"][0])
+        self.assertIn("query_guide", result)
+
+    # --- Functional tests: get_shield_check_affected_entities ---
+
+    def test_get_shield_check_affected_entities_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"entity_name": "user@example.com", "type": "user", "dismissed": False}
+                ]
+            },
+        }
+
+        result = self.module.get_shield_check_affected_entities(id="check-1", limit=10)
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetSecurityCheckAffectedV3")
+        self.assertEqual(call_args[1]["parameters"]["id"], "check-1")
+        self.assertEqual(len(result), 1)
+
+    def test_get_shield_check_affected_entities_empty(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.get_shield_check_affected_entities(id="check-1")
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+
+    # --- Functional tests: get_shield_posture_metrics ---
+
+    def test_get_shield_posture_metrics_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{"total_security_checks_count": 50, "total_score_percentage": 72}]
+            },
+        }
+
+        result = self.module.get_shield_posture_metrics(impact="Medium")
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetMetricsV3")
+        self.assertEqual(call_args[1]["parameters"]["impact"], 2)
+        self.assertEqual(len(result), 1)
+
+    # --- Functional tests: get_shield_check_compliance ---
+
+    def test_get_shield_check_compliance_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"standard": "SOC 2", "control": "CC6.1", "requirement": "Logical access"}
+                ]
+            },
+        }
+
+        result = self.module.get_shield_check_compliance(id="check-1")
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetSecurityCheckComplianceV3")
+        self.assertEqual(call_args[1]["parameters"]["id"], "check-1")
+        self.assertEqual(len(result), 1)
+
+    # --- Functional tests: search_shield_alerts ---
+
+    def test_search_shield_alerts_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "alert-1", "alert_type": "configuration_drift"}]},
+        }
+
+        result = self.module.search_shield_alerts(type="configuration_drift", limit=5)
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetAlertsV3")
+        self.assertEqual(call_args[1]["parameters"]["type"], "configuration_drift")
+        self.assertEqual(len(result), 1)
+
+    def test_search_shield_alerts_empty(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.search_shield_alerts()
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+
+    # --- Functional tests: get_shield_activity_monitor ---
+
+    def test_get_shield_activity_monitor_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"event_name": "file_shared", "actor": "user@example.com"}]},
+        }
+
+        result = self.module.get_shield_activity_monitor(category="Events", limit=100)
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetActivityMonitorV3")
+        self.assertEqual(call_args[1]["parameters"]["category"], "Events")
+        self.assertEqual(len(result), 1)
+
+    # --- Functional tests: search_shield_users ---
+
+    def test_search_shield_users_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"email": "admin@example.com", "privileged": True}]},
+        }
+
+        result = self.module.search_shield_users(privileged_only=True, limit=10)
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetUserInventoryV3")
+        self.assertEqual(call_args[1]["parameters"]["privileged_only"], True)
+        self.assertEqual(len(result), 1)
+
+    # --- Functional tests: search_shield_devices ---
+
+    def test_search_shield_devices_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"device_name": "laptop-01", "os": "macOS", "globally_compliant": True}
+                ]
+            },
+        }
+
+        result = self.module.search_shield_devices(limit=10)
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetDeviceInventoryV3")
+        self.assertEqual(len(result), 1)
+
+    # --- Functional tests: search_shield_apps ---
+
+    def test_search_shield_apps_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{"app_name": "Slack", "app_type": "oauth", "access_level": "high"}]
+            },
+        }
+
+        result = self.module.search_shield_apps(type="oauth", access_level="high")
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetAppInventory")
+        self.assertEqual(call_args[1]["parameters"]["type"], "oauth")
+        self.assertEqual(len(result), 1)
+
+    # --- Functional tests: get_shield_app_users ---
+
+    def test_get_shield_app_users_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{"username": "user@example.com", "permission_grant_id": "grant-1"}]
+            },
+        }
+
+        result = self.module.get_shield_app_users(item_id="integration-1|||app-1")
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetAppInventoryUsers")
+        self.assertEqual(call_args[1]["parameters"]["item_id"], "integration-1|||app-1")
+        self.assertEqual(len(result), 1)
+
+    # --- Functional tests: search_shield_data_shares ---
+
+    def test_search_shield_data_shares_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"resource_name": "report.xlsx", "access_level": "external"}]},
+        }
+
+        result = self.module.search_shield_data_shares(resource_type="XLSX", limit=10)
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetAssetInventoryV3")
+        self.assertEqual(call_args[1]["parameters"]["resource_type"], "XLSX")
+        self.assertEqual(len(result), 1)
+
+    # --- Functional tests: get_shield_integrations ---
+
+    def test_get_shield_integrations_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "int-1", "alias": "Production Google", "saas_name": "Google Workspace"}
+                ]
+            },
+        }
+
+        result = self.module.get_shield_integrations()
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetIntegrationsV3")
+        self.assertEqual(len(result), 1)
+
+    # --- Functional tests: get_shield_system_users ---
+
+    def test_get_shield_system_users_success(self):
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [{"email": "admin@cs.com", "role": "admin", "mfa_enabled": True}]
+            },
+        }
+
+        result = self.module.get_shield_system_users()
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "GetSystemUsersV3")
+        self.assertEqual(len(result), 1)
+
+    # --- Functional tests: dismiss_shield_check ---
+
+    def test_dismiss_shield_check_whole_check(self):
+        """Without entities, dismisses the entire check via DismissSecurityCheckV3."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "check-1", "status": "Dismissed"}]},
+        }
+
+        result = self.module.dismiss_shield_check(id="check-1", reason="Accepted risk")
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "DismissSecurityCheckV3")
+        self.assertEqual(call_args[1]["body"]["id"], "check-1")
+        self.assertEqual(call_args[1]["body"]["reason"], "Accepted risk")
+        self.assertEqual(len(result), 1)
+
+    def test_dismiss_shield_check_specific_entities(self):
+        """With entities, dismisses specific entities via DismissAffectedEntityV3."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "check-1", "dismissed_entities": ["user@ex.com"]}]},
+        }
+
+        result = self.module.dismiss_shield_check(
+            id="check-1", reason="User exception", entities="user@ex.com,admin@ex.com"
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "DismissAffectedEntityV3")
+        self.assertEqual(call_args[1]["body"]["id"], "check-1")
+        self.assertEqual(call_args[1]["body"]["reason"], "User exception")
+        self.assertEqual(call_args[1]["body"]["entities"], ["user@ex.com", "admin@ex.com"])
+        self.assertEqual(len(result), 1)
+
+    def test_dismiss_shield_check_api_error(self):
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied"}]},
+        }
+
+        result = self.module.dismiss_shield_check(id="check-1", reason="Test")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    # --- Security validation tests ---
+
+    def test_search_shield_checks_special_characters_pass_through(self):
+        """Special characters in filter params pass through unchanged."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        self.module.search_shield_checks(
+            id="check-';DROP TABLE--", check_type="<script>alert(1)</script>"
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["parameters"]["id"], "check-';DROP TABLE--")
+        self.assertEqual(call_args[1]["parameters"]["check_type"], "<script>alert(1)</script>")
+
+    def test_search_shield_checks_invalid_id_returns_api_error(self):
+        self.mock_client.command.return_value = {
+            "status_code": 404,
+            "body": {"errors": [{"message": "Not found"}]},
+        }
+
+        result = self.module.search_shield_checks(id="not-a-real-id-!!!")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result["results"][0])
+
+    def test_search_shield_checks_permission_error(self):
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied"}]},
+        }
+
+        result = self.module.search_shield_checks()
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result["results"][0])
+
+    def test_search_shield_checks_long_input_not_truncated(self):
+        """Long input values pass through without truncation."""
+        long_value = "a" * 10000
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        self.module.search_shield_checks(check_tags=long_value)
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["parameters"]["check_tags"], long_value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
New module for Falcon Shield (SaaS Security). 14 tools for posture checks, alerts, activity monitor, user/device/app/data-share inventories, integrations, and check dismissal. Also adds a query parameter guide resource since Shield doesn't use FQL — it has its own named parameters instead. Unit and integration tests included, plus API scope mappings for all 15 operations.