### PR TITLE
feat(modules/rtr): add audit and command wait workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Full docs are available at **[crowdstrike.github.io/falcon-mcp](https://crowdstr
 | [Intel](https://crowdstrike.github.io/falcon-mcp/modules/intel/) | Research threat actors, IOCs, and intelligence reports |
 | [IOC](https://crowdstrike.github.io/falcon-mcp/modules/ioc/) | Search, create, and remove custom indicators of compromise |
 | [NGSIEM](https://crowdstrike.github.io/falcon-mcp/modules/ngsiem/) | Execute CQL queries against Next-Gen SIEM |
-| [Real Time Response](https://crowdstrike.github.io/falcon-mcp/modules/rtr/) | Initialize RTR sessions and execute read-only triage commands |
+| [Real Time Response](https://crowdstrike.github.io/falcon-mcp/modules/rtr/) | Audit, summarize, and run read-only RTR triage workflows |
 | [Scheduled Reports](https://crowdstrike.github.io/falcon-mcp/modules/scheduled-reports/) | Manage scheduled reports and download report files |
 | [Sensor Usage](https://crowdstrike.github.io/falcon-mcp/modules/sensor-usage/) | Access and analyze sensor usage data |
 | [Serverless](https://crowdstrike.github.io/falcon-mcp/modules/serverless/) | Search for vulnerabilities in serverless functions |

--- a/docs-site/src/content/docs/modules/cloud.md
+++ b/docs-site/src/content/docs/modules/cloud.md
@@ -25,7 +25,7 @@ Count Kubernetes containers matching filter criteria.
 
 Use this for aggregate counts without returning full container details. Consult
 falcon://cloud/kubernetes-containers/fql-guide before constructing filter
-expressions. Returns the count as a single-element list.
+expressions. Returns the matching container count as an integer.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/idp.md
+++ b/docs-site/src/content/docs/modules/idp.md
@@ -17,7 +17,7 @@ Accessing and managing CrowdStrike Falcon Identity Protection capabilities
 
 ## Tools
 
-### `falcon_investigate_entity`
+### `falcon_idp_investigate_entity`
 
 **Required scopes:** `Identity Protection Assessment:read`, `Identity Protection Detections:read`, `Identity Protection Entities:read`, `Identity Protection Timeline:read`, `Identity Protection GraphQL:write`
 
@@ -28,3 +28,8 @@ assessments; at least one identifier must be supplied, and multiple identifiers 
 combined with AND logic (email and IP cannot be combined — email takes precedence).
 Returns a structured response with an investigation_summary, resolved entity IDs,
 and results keyed by each requested investigation type.
+
+**Example prompts:**
+
+- "Investigate user john.doe@company.com and show their risk assessment"
+- "Look up entity Administrator in domain CORP.LOCAL"

--- a/docs-site/src/content/docs/modules/intel.md
+++ b/docs-site/src/content/docs/modules/intel.md
@@ -29,7 +29,7 @@ decoded string; CSV format returns CSV text.
 
 - "Generate MITRE ATT&CK report for FANCY BEAR"
 
-### `falcon_query_actor_entities`
+### `falcon_search_actors`
 
 **Required scopes:** `Actors (Falcon Intelligence):read`
 
@@ -39,7 +39,12 @@ Use this to search actors by name, target countries/industries, or activity date
 Consult falcon://intel/actors/fql-guide before constructing filter expressions.
 Returns full actor profiles including aliases, motivations, and targeting details.
 
-### `falcon_query_indicator_entities`
+**Example prompts:**
+
+- "Find threat actors targeting financial services"
+- "Search for BEAR adversary groups"
+
+### `falcon_search_indicators`
 
 **Required scopes:** `Indicators (Falcon Intelligence):read`
 
@@ -49,7 +54,11 @@ Use this to find indicators by type, publish date, malware family, or threat act
 association. Consult falcon://intel/indicators/fql-guide before constructing filter
 expressions. Returns full indicator details including labels, relations, and kill chain stage.
 
-### `falcon_query_report_entities`
+**Example prompts:**
+
+- "Find intelligence IOCs of type domain published this year"
+
+### `falcon_search_reports`
 
 **Required scopes:** `Reports (Falcon Intelligence):read`
 
@@ -58,6 +67,10 @@ Search CrowdStrike intelligence publications and threat reports.
 Use this to find reports by name, target industry, threat type, or publication date.
 Consult falcon://intel/reports/fql-guide before constructing filter expressions.
 Returns full report metadata including title, description, and target details.
+
+**Example prompts:**
+
+- "Find intelligence reports published in the last 30 days"
 
 ## Resources
 

--- a/docs-site/src/content/docs/modules/overview.md
+++ b/docs-site/src/content/docs/modules/overview.md
@@ -21,7 +21,7 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 | [Intel](/falcon-mcp/modules/intel/) | `Actors (Falcon Intelligence):read`, `Indicators (Falcon Intelligence):read`, `Reports (Falcon Intelligence):read` | Accessing and analyzing CrowdStrike Falcon intelligence data |
 | [IOC](/falcon-mcp/modules/ioc/) | `IOC Management:read`, `IOC Management:write` | Searching, creating, and deleting custom IOCs using Falcon IOC Service Collection endpoints |
 | [NGSIEM](/falcon-mcp/modules/ngsiem/) | `NGSIEM:read`, `NGSIEM:write` | Running search queries against CrowdStrike's Next-Gen SIEM via the asynchronous job-based search API |
-| [Real Time Response](/falcon-mcp/modules/rtr/) | `Real time response:read`, `Real time response:write` | Initiating and inspecting RTR sessions and for executing read-only RTR commands during host investigations |
+| [Real Time Response](/falcon-mcp/modules/rtr/) | `Real time response:read`, `real-time-response-audit:read`, `Real time response:write` | Initiating and inspecting RTR sessions and for executing read-only RTR commands during host investigations |
 | [Scheduled Reports](/falcon-mcp/modules/scheduled-reports/) | `Scheduled Reports:read` | Accessing and managing CrowdStrike Falcon scheduled reports and scheduled searches |
 | [Sensor Usage](/falcon-mcp/modules/sensor-usage/) | `Sensor Usage:read` | Accessing CrowdStrike Falcon sensor usage data |
 | [Serverless](/falcon-mcp/modules/serverless/) | `Falcon Container Image:read` | Accessing and managing CrowdStrike Falcon Serverless Vulnerabilities |

--- a/docs-site/src/content/docs/modules/rtr.md
+++ b/docs-site/src/content/docs/modules/rtr.md
@@ -199,5 +199,5 @@ Returns session metadata including host info, commands executed, and status.
 
 - **`falcon://rtr/sessions/search/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_rtr_sessions` tool.
 - **`falcon://rtr/audit/sessions/search/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_rtr_audit_sessions` tool.
-- **`falcon://rtr/sessions/aggregate/guide`**: Explains how to summarize RTR session activity with the `falcon_aggregate_rtr_sessions` tool.
-- **`falcon://rtr/workflows/read-only-investigation-guide`**: Provides a safe read-only RTR workflow for endpoint investigation tools.
+- **`falcon://rtr/sessions/aggregate-guide`**: Explains how to summarize RTR session activity with the `falcon_aggregate_rtr_sessions` tool.
+- **`falcon://rtr/workflows/investigation-guide`**: Provides a safe read-only RTR workflow for endpoint investigation tools.

--- a/docs-site/src/content/docs/modules/rtr.md
+++ b/docs-site/src/content/docs/modules/rtr.md
@@ -10,11 +10,28 @@ Initiating and inspecting RTR sessions and for executing read-only RTR commands 
 ## API Scopes
 
 - `Real time response:read`
+- `real-time-response-audit:read`
 - `Real time response:write`
 
 ## Tools
 
-### `falcon_check_command_status`
+### `falcon_aggregate_rtr_sessions`
+
+**Required scopes:** `Real time response:read`
+
+Summarize RTR session activity with Falcon aggregation buckets.
+
+Use this before detailed searches when the user asks which hosts,
+users, origins, commands, or time windows account for RTR activity.
+This is read-only summary visibility; it does not open sessions, run
+commands, or return every session record.
+
+**Example prompts:**
+
+- "Summarize RTR sessions by command for the last 30 days"
+- "Which hosts have the most RTR activity this week?"
+
+### `falcon_check_rtr_command_status`
 
 **Required scopes:** `Real time response:read`
 
@@ -23,7 +40,15 @@ Get the status and output for an RTR command execution.
 Poll this after falcon_execute_rtr_read_only_command to retrieve command
 output. Use sequence_id to paginate through large output chunks.
 
-### `falcon_delete_session`
+**Example prompts:**
+
+- "Check the status of RTR command request abc123"
+
+### `falcon_delete_rtr_session`
+
+:::caution
+This tool performs destructive operations.
+:::
 
 **Required scopes:** `Real time response:read`
 
@@ -31,7 +56,15 @@ Close an RTR session and release the host connection.
 
 Use this when investigation is complete to free up session resources.
 
-### `falcon_execute_read_only_command`
+**Example prompts:**
+
+- "End the RTR session abc123"
+
+### `falcon_execute_rtr_read_only_command`
+
+:::note
+This tool modifies data.
+:::
 
 **Required scopes:** `Real time response:read`
 
@@ -41,7 +74,12 @@ Limited to read-only commands (ls, ps, cat, filehash, reg) for hunt and triage
 workflows. Does not expose admin or remediation commands. Returns command records
 containing a cloud_request_id for polling output via falcon_check_rtr_command_status.
 
-### `falcon_get_session_details`
+**Example prompts:**
+
+- "Run 'ps' on this host via RTR"
+- "List running processes on host xyz"
+
+### `falcon_get_rtr_session_details`
 
 **Required scopes:** `Real time response:read`
 
@@ -51,7 +89,15 @@ Use when you already have session IDs from search results. For discovering
 sessions by criteria, use falcon_search_rtr_sessions instead. Returns full
 session records.
 
-### `falcon_init_session`
+**Example prompts:**
+
+- "Get details for RTR session abc123"
+
+### `falcon_init_rtr_session`
+
+:::note
+This tool modifies data.
+:::
 
 **Required scopes:** `Real time response:read`
 
@@ -61,7 +107,11 @@ Opens a live connection to the specified device for executing RTR commands.
 Use queue_offline=True if the host may be offline. Returns session records
 containing the session_id needed for subsequent commands.
 
-### `falcon_list_session_files`
+**Example prompts:**
+
+- "Start an RTR session on host xyz"
+
+### `falcon_list_rtr_session_files`
 
 **Required scopes:** `Real time response:write`
 
@@ -70,7 +120,15 @@ List files extracted during an RTR session.
 Returns file metadata for artifacts captured during the session, such as
 files pulled with the `get` command.
 
-### `falcon_pulse_session`
+**Example prompts:**
+
+- "List files extracted during RTR session abc123"
+
+### `falcon_pulse_rtr_session`
+
+:::note
+This tool modifies data.
+:::
 
 **Required scopes:** `Real time response:read`
 
@@ -79,7 +137,50 @@ Refresh an RTR session timeout for a single host.
 Keeps an existing session alive by resetting its inactivity timer. Use this
 to prevent session expiration during long investigations.
 
-### `falcon_search_sessions`
+**Example prompts:**
+
+- "Refresh the RTR session to keep it alive"
+
+### `falcon_run_rtr_read_only_command_and_wait`
+
+:::note
+This tool modifies data.
+:::
+
+**Required scopes:** `Real time response:read`
+
+Execute a read-only RTR command and poll until completion.
+
+Use this for simple, focused RTR evidence collection when the user
+wants the command output directly and does not need to manually manage
+a cloud request ID. This polls command status until completion or
+timeout, accumulating output chunks into one result. It still executes
+an RTR command and creates RTR command activity, but it does not expose
+RTR Admin or remediation APIs.
+
+**Example prompts:**
+
+- "Run 'ps' via RTR and return the output when it completes"
+- "Check C:\Windows\win.ini on this RTR session and wait for the result"
+
+### `falcon_search_rtr_audit_sessions`
+
+**Required scopes:** `real-time-response-audit:read`
+
+Search RTR audit sessions for accountability and timeline evidence.
+
+Use this when you need to understand who used RTR, when they used it,
+which host was targeted, or which command activity Falcon recorded.
+This is read-only audit visibility; it does not open sessions or run
+commands. Consult falcon://rtr/audit/sessions/search/fql-guide before
+constructing filter expressions.
+
+**Example prompts:**
+
+- "Show me RTR audit activity from the last 7 days"
+- "Who used RTR against host BRR-WB-LIB-22?"
+
+### `falcon_search_rtr_sessions`
 
 **Required scopes:** `Real time response:read`
 
@@ -89,6 +190,14 @@ Use this to find sessions by hostname, agent ID, user, or creation time. Consult
 falcon://rtr/sessions/search/fql-guide before constructing filter expressions.
 Returns session metadata including host info, commands executed, and status.
 
+**Example prompts:**
+
+- "Find all active RTR sessions"
+- "Show me RTR sessions for host abc123"
+
 ## Resources
 
 - **`falcon://rtr/sessions/search/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_rtr_sessions` tool.
+- **`falcon://rtr/audit/sessions/search/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_rtr_audit_sessions` tool.
+- **`falcon://rtr/sessions/aggregate/guide`**: Explains how to summarize RTR session activity with the `falcon_aggregate_rtr_sessions` tool.
+- **`falcon://rtr/workflows/read-only-investigation-guide`**: Provides a safe read-only RTR workflow for endpoint investigation tools.

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -88,6 +88,8 @@ API_SCOPE_REQUIREMENTS = {
     "RTR_CheckCommandStatus": ["Real time response:read"],
     "RTR_ExecuteCommand": ["Real time response:read"],
     "RTR_ListFilesV2": ["Real time response:write"],
+    "RTRAuditSessions": ["real-time-response-audit:read"],
+    "RTR_AggregateSessions": ["Real time response:read"],
     # Custom IOA operations
     "query_rule_groups_full": ["Custom IOA Rules:read"],
     "query_platformsMixin0": ["Custom IOA Rules:read"],

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -659,7 +659,8 @@ class RTRModule(BaseModule):
                     timed_out=True,
                 )
 
-            sequence_id += 1
+            if status_chunks:
+                sequence_id = status_chunks[-1].get("sequence_id", sequence_id)
             time.sleep(poll_interval_seconds)
 
     def list_session_files(

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -166,7 +166,7 @@ class RTRModule(BaseModule):
         )
 
         aggregate_rtr_sessions_resource = TextResource(
-            uri=AnyUrl("falcon://rtr/sessions/aggregate/guide"),
+            uri=AnyUrl("falcon://rtr/sessions/aggregate-guide"),
             name="falcon_aggregate_rtr_sessions_guide",
             description="Explains how to summarize RTR session activity with the `falcon_aggregate_rtr_sessions` tool.",
             text=AGGREGATE_RTR_SESSIONS_GUIDE,
@@ -178,7 +178,7 @@ class RTRModule(BaseModule):
         )
 
         read_only_rtr_investigation_resource = TextResource(
-            uri=AnyUrl("falcon://rtr/workflows/read-only-investigation-guide"),
+            uri=AnyUrl("falcon://rtr/workflows/investigation-guide"),
             name="falcon_rtr_read_only_investigation_guide",
             description="Provides a safe read-only RTR workflow for endpoint investigation tools.",
             text=READ_ONLY_RTR_INVESTIGATION_GUIDE,

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -5,17 +5,25 @@ This module provides tools for initiating and inspecting RTR sessions and for
 executing read-only RTR commands during host investigations.
 """
 
+import time
 from textwrap import dedent
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
 from mcp.types import ToolAnnotations
 from pydantic import AnyUrl, Field
 
+from falcon_mcp.common.errors import handle_api_response
 from falcon_mcp.common.logging import get_logger
+from falcon_mcp.common.utils import prepare_api_parameters
 from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.resources.rtr import (
+    AGGREGATE_RTR_SESSIONS_GUIDE,
+    AUDIT_RTR_SESSIONS_EMBEDDED_FQL_SYNTAX,
+    EMBEDDED_FQL_SYNTAX,
+    READ_ONLY_RTR_INVESTIGATION_GUIDE,
+    SEARCH_RTR_AUDIT_SESSIONS_FQL_DOCUMENTATION,
     SEARCH_RTR_SESSIONS_FQL_DOCUMENTATION,
 )
 
@@ -35,6 +43,18 @@ class RTRModule(BaseModule):
             server=server,
             method=self.search_sessions,
             name="search_rtr_sessions",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.search_audit_sessions,
+            name="search_rtr_audit_sessions",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.aggregate_sessions,
+            name="aggregate_rtr_sessions",
         )
 
         self._add_tool(
@@ -71,6 +91,18 @@ class RTRModule(BaseModule):
             server=server,
             method=self.execute_read_only_command,
             name="execute_rtr_read_only_command",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.run_read_only_command_and_wait,
+            name="run_rtr_read_only_command_and_wait",
             annotations=ToolAnnotations(
                 readOnlyHint=False,
                 destructiveHint=False,
@@ -119,6 +151,42 @@ class RTRModule(BaseModule):
         self._add_resource(
             server,
             search_rtr_sessions_fql_resource,
+        )
+
+        search_rtr_audit_sessions_fql_resource = TextResource(
+            uri=AnyUrl("falcon://rtr/audit/sessions/search/fql-guide"),
+            name="falcon_search_rtr_audit_sessions_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_rtr_audit_sessions` tool.",
+            text=SEARCH_RTR_AUDIT_SESSIONS_FQL_DOCUMENTATION,
+        )
+
+        self._add_resource(
+            server,
+            search_rtr_audit_sessions_fql_resource,
+        )
+
+        aggregate_rtr_sessions_resource = TextResource(
+            uri=AnyUrl("falcon://rtr/sessions/aggregate/guide"),
+            name="falcon_aggregate_rtr_sessions_guide",
+            description="Explains how to summarize RTR session activity with the `falcon_aggregate_rtr_sessions` tool.",
+            text=AGGREGATE_RTR_SESSIONS_GUIDE,
+        )
+
+        self._add_resource(
+            server,
+            aggregate_rtr_sessions_resource,
+        )
+
+        read_only_rtr_investigation_resource = TextResource(
+            uri=AnyUrl("falcon://rtr/workflows/read-only-investigation-guide"),
+            name="falcon_rtr_read_only_investigation_guide",
+            description="Provides a safe read-only RTR workflow for endpoint investigation tools.",
+            text=READ_ONLY_RTR_INVESTIGATION_GUIDE,
+        )
+
+        self._add_resource(
+            server,
+            read_only_rtr_investigation_resource,
         )
 
     def search_sessions(
@@ -185,6 +253,134 @@ class RTRModule(BaseModule):
             return [details]
 
         return details
+
+    def search_audit_sessions(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description=AUDIT_RTR_SESSIONS_EMBEDDED_FQL_SYNTAX,
+            examples=["created_at:>'now-7d'", "hostname:'BRR-WB-LIB-22'+created_at:>'now-7d'"],
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            le=1000,
+            description="Maximum number of RTR audit session records to return. Max: 1000.",
+        ),
+        offset: int | None = Field(
+            default=None,
+            ge=0,
+            description="Starting index of the audit result set.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description=dedent("""
+                Sort RTR audit sessions by a supported audit property using pipe syntax:
+                `created_at|desc`, `updated_at|asc`, or `deleted_at|desc`.
+            """).strip(),
+            examples=["created_at|desc", "updated_at|asc"],
+        ),
+        with_command_info: bool = Field(
+            default=False,
+            description="Include command IDs and command log fields in the audit response.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search RTR audit sessions for accountability and timeline evidence.
+
+        Use this when you need to understand who used RTR, when they used it,
+        which host was targeted, or which command activity Falcon recorded.
+        This is read-only audit visibility; it does not open sessions or run
+        commands. Consult falcon://rtr/audit/sessions/search/fql-guide before
+        constructing filter expressions.
+        """
+        audit_sessions = self._base_search_api_call(
+            operation="RTRAuditSessions",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+                "with_command_info": with_command_info,
+            },
+            error_message="Failed to search RTR audit sessions",
+        )
+
+        if self._is_error(audit_sessions):
+            return self._format_fql_error_response(
+                [audit_sessions], filter, SEARCH_RTR_AUDIT_SESSIONS_FQL_DOCUMENTATION
+            )
+
+        if not audit_sessions:
+            return self._format_fql_error_response(
+                [], filter, SEARCH_RTR_AUDIT_SESSIONS_FQL_DOCUMENTATION
+            )
+
+        return audit_sessions
+
+    def aggregate_sessions(
+        self,
+        field: str = Field(
+            description="RTR session field to aggregate, such as `hostname`, `user_id`, `origin`, `base_command`, or `created_at`.",
+            examples=["base_command", "hostname", "user_id", "created_at"],
+        ),
+        aggregate_type: Literal["terms", "date_range"] = Field(
+            default="terms",
+            description="Aggregation type to run. Use `terms` for top values and `date_range` for time buckets.",
+        ),
+        name: str = Field(
+            default="rtr_session_aggregation",
+            description="Friendly name for the aggregation returned by Falcon.",
+        ),
+        filter: str | None = Field(
+            default=None,
+            description=EMBEDDED_FQL_SYNTAX,
+            examples=["created_at:>'now-7d'", "hostname:'DC*'"],
+        ),
+        size: int | None = Field(
+            default=10,
+            ge=1,
+            le=1000,
+            description="Maximum buckets to return for terms aggregations.",
+        ),
+        interval: str | None = Field(
+            default=None,
+            description="Optional interval for date range aggregations, such as `day` or `hour`.",
+            examples=["day", "hour"],
+        ),
+        date_ranges: list[dict[str, str]] | None = Field(
+            default=None,
+            description="Date ranges for date_range aggregations, for example `[{'from': 'now-7d', 'to': 'now'}]`.",
+            examples=[[{"from": "now-7d", "to": "now"}]],
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Summarize RTR session activity with Falcon aggregation buckets.
+
+        Use this before detailed searches when the user asks which hosts,
+        users, origins, commands, or time windows account for RTR activity.
+        This is read-only summary visibility; it does not open sessions, run
+        commands, or return every session record.
+        """
+        operation = "RTR_AggregateSessions"
+        body_params = {
+            "date_ranges": date_ranges,
+            "field": field,
+            "filter": filter,
+            "interval": interval,
+            "name": name,
+            "size": size,
+            "type": aggregate_type,
+        }
+        prepared_body = prepare_api_parameters(body_params)
+
+        logger.debug("Executing %s with body: %s", operation, prepared_body)
+        response = self.client.command(operation, body=[prepared_body])
+
+        return handle_api_response(
+            response,
+            operation=operation,
+            error_message="Failed to aggregate RTR sessions",
+            default_result=[],
+        )
 
     def get_session_details(
         self,
@@ -343,6 +539,129 @@ class RTRModule(BaseModule):
             error_message="Failed to check RTR command status",
         )
 
+    def run_read_only_command_and_wait(
+        self,
+        session_id: str = Field(
+            description="RTR session ID returned from falcon_init_rtr_session or falcon_search_rtr_sessions.",
+        ),
+        base_command: str = Field(
+            description="Read-only RTR base command to execute, such as `ls`, `ps`, `cat`, `filehash`, or `reg`.",
+            examples=["ls", "ps", "filehash"],
+        ),
+        command_string: str | None = Field(
+            default=None,
+            description="Optional full command line to execute. Example: `cat C:\\Windows\\win.ini`.",
+        ),
+        persist: bool = Field(
+            default=False,
+            description="Persist the read-only command in the RTR session history.",
+        ),
+        timeout_seconds: int = Field(
+            default=60,
+            ge=1,
+            le=600,
+            description="Maximum time to wait for command completion. Max: 600 seconds.",
+        ),
+        poll_interval_seconds: float = Field(
+            default=2.0,
+            ge=0.5,
+            le=30.0,
+            description="Seconds to wait between command status checks.",
+        ),
+    ) -> dict[str, Any]:
+        """Execute a read-only RTR command and poll until completion.
+
+        Use this for simple, focused RTR evidence collection when the user
+        wants the command output directly and does not need to manually manage
+        a cloud request ID. This polls command status until completion or
+        timeout, accumulating output chunks into one result. It still executes
+        an RTR command and creates RTR command activity, but it does not expose
+        RTR Admin or remediation APIs.
+        """
+        execute_result = self._base_query_api_call(
+            operation="RTR_ExecuteCommand",
+            body_params={
+                "session_id": session_id,
+                "base_command": base_command,
+                "command_string": command_string,
+                "persist": persist,
+            },
+            error_message="Failed to execute RTR read-only command",
+        )
+
+        if self._is_error(execute_result):
+            execute_result["phase"] = "execute"
+            return execute_result
+
+        if not isinstance(execute_result, list) or not execute_result:
+            return {
+                "error": "RTR command execution did not return a command request.",
+                "phase": "execute",
+                "results": execute_result,
+            }
+
+        command_request = execute_result[0]
+        if not isinstance(command_request, dict):
+            return {
+                "error": "RTR command execution returned an unexpected response shape.",
+                "phase": "execute",
+                "results": execute_result,
+            }
+
+        cloud_request_id = command_request.get("cloud_request_id")
+        if not cloud_request_id:
+            return {
+                "error": "RTR command execution did not return a cloud_request_id.",
+                "phase": "execute",
+                "execution": command_request,
+            }
+
+        deadline = time.monotonic() + timeout_seconds
+        status_chunks: list[dict[str, Any]] = []
+        sequence_id = 0
+
+        while True:
+            status_result = self._base_query_api_call(
+                operation="RTR_CheckCommandStatus",
+                query_params={
+                    "cloud_request_id": cloud_request_id,
+                    "sequence_id": sequence_id,
+                },
+                error_message="Failed to check RTR command status",
+            )
+
+            if self._is_error(status_result):
+                status_result["phase"] = "status"
+                status_result["cloud_request_id"] = cloud_request_id
+                return status_result
+
+            if isinstance(status_result, list):
+                status_chunks.extend(
+                    chunk for chunk in status_result if isinstance(chunk, dict)
+                )
+
+            complete = any(chunk.get("complete") is True for chunk in status_chunks)
+            if complete:
+                return self._format_wait_result(
+                    cloud_request_id=cloud_request_id,
+                    command_request=command_request,
+                    status_chunks=status_chunks,
+                    complete=True,
+                    timed_out=False,
+                )
+
+            if time.monotonic() >= deadline:
+                return self._format_wait_result(
+                    cloud_request_id=cloud_request_id,
+                    command_request=command_request,
+                    status_chunks=status_chunks,
+                    complete=False,
+                    timed_out=True,
+                )
+
+            sequence_id += 1
+            time.sleep(poll_interval_seconds)
+
     def list_session_files(
         self,
         session_id: str = Field(
@@ -375,3 +694,34 @@ class RTRModule(BaseModule):
             query_params={"session_id": session_id},
             error_message="Failed to delete RTR session",
         )
+
+    def _format_wait_result(
+        self,
+        cloud_request_id: str,
+        command_request: dict[str, Any],
+        status_chunks: list[dict[str, Any]],
+        complete: bool,
+        timed_out: bool,
+    ) -> dict[str, Any]:
+        """Format command-and-wait output for model-friendly consumption."""
+        stdout = "".join(
+            str(chunk.get("stdout", "")) for chunk in status_chunks if chunk.get("stdout")
+        )
+        stderr = "".join(
+            str(chunk.get("stderr", "")) for chunk in status_chunks if chunk.get("stderr")
+        )
+
+        result: dict[str, Any] = {
+            "cloud_request_id": cloud_request_id,
+            "complete": complete,
+            "timed_out": timed_out,
+            "execution": command_request,
+            "status": status_chunks,
+            "stdout": stdout,
+            "stderr": stderr,
+        }
+
+        if timed_out:
+            result["warning"] = "Timed out waiting for RTR command completion."
+
+        return result

--- a/falcon_mcp/resources/rtr.py
+++ b/falcon_mcp/resources/rtr.py
@@ -4,6 +4,59 @@ Contains RTR (Real Time Response) resources.
 
 from falcon_mcp.common.utils import generate_md_table
 
+# Concise FQL syntax for embedding in tool parameter descriptions
+EMBEDDED_FQL_SYNTAX = """FQL filter string for querying RTR sessions.
+
+SYNTAX:
+- Equals: field:'value'
+- Not equals: field:!'value'
+- Comparison: field:>50, field:>=50, field:<50, field:<=50
+- Contains (case-insensitive): field:~'partial'
+- Wildcard: field:'prefix*', field:'*suffix'
+
+COMBINING:
+- AND (all must match): field1:'value1'+field2:'value2'
+- OR (any can match): field:'value1',field:'value2'
+- Grouping: (field1:'v1',field1:'v2')+field2:'v3'
+
+COMMON FIELDS:
+- aid: Host agent ID
+- hostname: Host name
+- user_id: API user who created the session ('@me' for current user)
+- origin: Session origin label (e.g., 'falcon-mcp')
+- created_at: Session creation timestamp (ISO 8601)
+- updated_at: Last update timestamp (ISO 8601)
+- base_command: RTR command name (e.g., 'ls', 'ps', 'cat')
+- command_string: Full command line executed
+- offline_queued: Whether session was queued offline (true/false)
+
+EXAMPLES:
+- Sessions for a host: hostname:'BRR-WB-LIB-22'
+- Sessions by agent ID: aid:'2c5c4e7738004deaa9dfcdb86f633f3e'
+- Current user sessions: user_id:'@me'
+- Offline-queued sessions: offline_queued:true+hostname:'DC*'
+"""
+
+AUDIT_RTR_SESSIONS_EMBEDDED_FQL_SYNTAX = """FQL filter string for querying RTR audit sessions.
+
+SYNTAX:
+- Equals: field:'value'
+- Not equals: field:!'value'
+- Comparison: field:>'2025-01-01T00:00:00Z'
+- Contains (case-insensitive): field:~'partial'
+- Wildcard: field:'prefix*', field:'*suffix'
+
+COMMON STARTING POINTS:
+- Use created_at or updated_at filters to keep audit searches time-bound.
+- Set with_command_info=true when you need command IDs and command log context.
+- If a field is rejected by Falcon, reduce to a timestamp-bounded search and inspect returned fields.
+
+EXAMPLES:
+- Recent RTR audit sessions: created_at:>'now-7d'
+- RTR audit sessions for a host pattern: hostname:'DC*'+created_at:>'now-7d'
+- RTR audit sessions for current API user: user_id:'@me'+created_at:>'now-7d'
+"""
+
 # List of tuples containing filter options data: (name, type, description)
 SEARCH_RTR_SESSIONS_FQL_FILTERS = [
     (
@@ -119,6 +172,99 @@ SEARCH_RTR_SESSIONS_FQL_FILTERS = [
     ),
 ]
 
+SEARCH_RTR_AUDIT_SESSIONS_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Description",
+    ),
+    (
+        "created_at",
+        "Timestamp",
+        """
+        When the audited RTR session was created. Use this to keep audit
+        searches bounded.
+        Ex: 2025-03-15T10:30:00Z
+        """,
+    ),
+    (
+        "updated_at",
+        "Timestamp",
+        """
+        When the audited RTR session was last updated.
+        Ex: 2025-03-15T11:00:00Z
+        """,
+    ),
+    (
+        "deleted_at",
+        "Timestamp",
+        """
+        When the audited RTR session was deleted.
+        Ex: 2025-03-15T12:00:00Z
+        """,
+    ),
+    (
+        "aid",
+        "String",
+        """
+        Host agent ID associated with the audited RTR activity.
+        Ex: 2c5c4e7738004deaa9dfcdb86f633f3e
+        """,
+    ),
+    (
+        "hostname",
+        "String",
+        """
+        Hostname associated with the audited RTR activity.
+        Ex: BRR-WB-LIB-22
+        """,
+    ),
+    (
+        "user_id",
+        "String",
+        """
+        Falcon user or API client associated with the RTR session.
+        Some Falcon environments support '@me' for the current user.
+        Ex: user@example.com
+        """,
+    ),
+    (
+        "origin",
+        "String",
+        """
+        Origin label for the RTR session.
+        Ex: falcon-mcp
+        """,
+    ),
+    (
+        "cloud_request_id",
+        "String",
+        """
+        Cloud request ID associated with command execution. This is most
+        useful when with_command_info=true is enabled.
+        Ex: a1b2c3d4-5678-90ab-cdef-1234567890ab
+        """,
+    ),
+    (
+        "base_command",
+        "String",
+        """
+        RTR base command name. This is most useful when with_command_info=true
+        is enabled.
+        Ex: ps
+        """,
+    ),
+    (
+        "command_string",
+        "String",
+        """
+        Full RTR command line string. This is most useful when
+        with_command_info=true is enabled.
+        Ex: cat C:\\Windows\\win.ini
+        """,
+    ),
+]
+
 SEARCH_RTR_SESSIONS_FQL_DOCUMENTATION = r"""Falcon Query Language (FQL) - Search RTR Sessions Guide
 
 === BASIC SYNTAX ===
@@ -188,6 +334,125 @@ origin:'falcon-mcp'+user_id:'@me'
 # Recent sessions for a host with queued commands
 commands_queued:true+created_at:>'2025-03-10T00:00:00Z'
 
-# Exclude deleted sessions for an agent
-deleted_at:!'*'+aid:'2c5c4e7738004deaa9dfcdb86f633f3e'
+# Deleted sessions after a timestamp for an agent
+deleted_at:>'2025-03-10T00:00:00Z'+aid:'2c5c4e7738004deaa9dfcdb86f633f3e'
+"""
+
+SEARCH_RTR_AUDIT_SESSIONS_FQL_DOCUMENTATION = r"""Falcon Query Language (FQL) - Search RTR Audit Sessions Guide
+
+=== PURPOSE ===
+Use falcon_search_rtr_audit_sessions when you need accountability and timeline evidence:
+who used RTR, when, against which host, and optionally which command activity is recorded.
+
+=== BASIC SYNTAX ===
+field_name:[operator]'value'
+
+=== OPERATORS ===
+• = (default): field_name:'value'
+• !: field_name:!'value' (not equal)
+• >, >=, <, <=: field_name:>'2025-01-01T00:00:00Z' (comparison)
+• ~: field_name:~'partial' (text match, case insensitive)
+• !~: field_name:!~'exclude' (not text match)
+• *: field_name:'prefix*' or field_name:'*suffix*' (wildcards)
+
+=== SORT OPTIONS ===
+Available audit sort fields: created_at, updated_at, deleted_at.
+
+The RTR audit API uses pipe-style sort examples such as:
+• created_at|desc
+• updated_at|asc
+• deleted_at|desc
+
+=== COMMAND INFO ===
+Set with_command_info=true when the investigation needs cloud request IDs and command log fields.
+Leave it false for lighter timeline searches.
+
+=== falcon_search_rtr_audit_sessions FQL filter fields ===
+
+""" + generate_md_table(SEARCH_RTR_AUDIT_SESSIONS_FQL_FILTERS) + """
+
+=== EXAMPLES ===
+
+# Recent RTR audit sessions
+created_at:>'now-7d'
+
+# RTR audit sessions for a host pattern
+hostname:'DC*'+created_at:>'now-7d'
+
+# Current user's RTR audit sessions
+user_id:'@me'+created_at:>'now-7d'
+
+# Command-focused audit search
+base_command:'ps'+created_at:>'now-7d'
+
+# Audit search for a command request
+cloud_request_id:'a1b2c3d4-5678-90ab-cdef-1234567890ab'
+"""
+
+AGGREGATE_RTR_SESSIONS_GUIDE = """RTR Session Aggregation Guide
+
+Use falcon_aggregate_rtr_sessions to summarize RTR session activity without pulling every
+individual session record.
+
+Recommended aggregation fields:
+- hostname: Which hosts have the most RTR activity
+- aid: Which host agent IDs have RTR activity
+- user_id: Which Falcon users or API clients created sessions
+- origin: Which integration or source created sessions
+- base_command: Which RTR commands are most common
+- created_at: Time-based activity buckets with aggregate_type=date_range
+
+Recommended filters:
+- created_at:>'now-7d'
+- user_id:'@me'
+- hostname:'DC*'
+- offline_queued:true
+- commands_queued:true
+
+Example terms aggregation:
+- aggregate_type: terms
+- field: base_command
+- filter: created_at:>'now-7d'
+- size: 10
+
+Example date range aggregation:
+- aggregate_type: date_range
+- field: created_at
+- date_ranges: [{"from": "now-7d", "to": "now"}]
+
+Use this before detailed searches when the user asks "how much", "which hosts", "which users",
+or "what commands" across many RTR sessions.
+"""
+
+READ_ONLY_RTR_INVESTIGATION_GUIDE = """Read-only RTR Investigation Guide
+
+This guide helps agents use RTR safely for endpoint triage. The current RTR MCP module exposes
+the read-only RTR command endpoint for host investigation. It does not expose RTR Admin,
+Active Responder, remediation, or arbitrary script execution.
+
+Recommended sequence:
+1. Use Falcon detections, incidents, hosts, or NGSIEM to identify the host AID.
+2. Use falcon_init_rtr_session to open or reuse a single-host RTR session.
+3. Use falcon_run_rtr_read_only_command_and_wait for simple focused evidence collection.
+4. Use falcon_execute_rtr_read_only_command plus falcon_check_rtr_command_status when you
+   need manual control over request IDs, polling, or output sequence chunks.
+5. Use falcon_search_rtr_audit_sessions when accountability or session history matters.
+6. Use falcon_delete_rtr_session when the session is no longer needed.
+
+Useful read-only command patterns:
+- Processes: base_command=ps, command_string="ps"
+- Directory listing: base_command=ls, command_string="ls C:\\Path"
+- File hash: base_command=filehash, command_string="filehash C:\\Path\\file.exe"
+- File preview: base_command=cat, command_string="cat C:\\Path\\file.txt"
+- Registry query: base_command=reg, command_string="reg query HKLM\\Software\\..."
+- Network state: base_command=netstat, command_string="netstat"
+- Event log review: base_command=eventlog, command_string="eventlog view Security 50"
+
+Model behavior guidance:
+- Prefer one host and one question at a time.
+- Keep commands narrow and explain what evidence each command is collecting.
+- Use audit and aggregation tools before broad RTR activity conclusions.
+- Treat offline or queued behavior as a telemetry state, not proof the host is powered off.
+- Do not attempt remediation, deletion, script execution, or active-response behavior through
+  the read-only RTR tool.
 """

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -17,11 +17,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from falcon_mcp.common.api_scopes import API_SCOPE_REQUIREMENTS
-
 # Ensure project root is on sys.path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
+
+from falcon_mcp.common.api_scopes import API_SCOPE_REQUIREMENTS  # noqa: E402
 
 OUTPUT_DIR = PROJECT_ROOT / "docs-site" / "src" / "content" / "docs" / "modules"
 
@@ -321,6 +321,14 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
         "Find all active RTR sessions",
         "Show me RTR sessions for host abc123",
     ],
+    "falcon_search_rtr_audit_sessions": [
+        "Show me RTR audit activity from the last 7 days",
+        "Who used RTR against host BRR-WB-LIB-22?",
+    ],
+    "falcon_aggregate_rtr_sessions": [
+        "Summarize RTR sessions by command for the last 30 days",
+        "Which hosts have the most RTR activity this week?",
+    ],
     "falcon_get_rtr_session_details": [
         "Get details for RTR session abc123",
     ],
@@ -333,6 +341,10 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     "falcon_execute_rtr_read_only_command": [
         "Run 'ps' on this host via RTR",
         "List running processes on host xyz",
+    ],
+    "falcon_run_rtr_read_only_command_and_wait": [
+        "Run 'ps' via RTR and return the output when it completes",
+        "Check C:\\Windows\\win.ini on this RTR session and wait for the result",
     ],
     "falcon_check_rtr_command_status": [
         "Check the status of RTR command request abc123",
@@ -497,6 +509,40 @@ def extract_tool_info(method: Any) -> dict[str, Any]:
     }
 
 
+def extract_registered_tool_names(module_cls: type) -> dict[str, str]:
+    """Extract method-to-tool-name mappings from register_tools.
+
+    Registered MCP tool names can differ from Python method names. The docs
+    should show the actual tool names exposed to MCP clients.
+    """
+    try:
+        source = inspect.getsource(module_cls.register_tools)  # type: ignore[attr-defined]
+    except (AttributeError, TypeError):
+        return {}
+
+    registered: dict[str, str] = {}
+
+    # Find each _add_tool( block and collect its full call by tracking parens.
+    for match in re.finditer(r"self\._add_tool\(", source):
+        start = match.end()
+        depth = 1
+        pos = start
+        while pos < len(source) and depth > 0:
+            if source[pos] == "(":
+                depth += 1
+            elif source[pos] == ")":
+                depth -= 1
+            pos += 1
+        block = source[start : pos - 1]
+
+        method_match = re.search(r"method=self\.(\w+)", block)
+        name_match = re.search(r'name=["\']([^"\']+)["\']', block)
+        if method_match and name_match:
+            registered[method_match.group(1)] = name_match.group(1)
+
+    return registered
+
+
 def extract_resource_info(module_cls: type) -> list[dict[str, str]]:
     """Extract resource URIs and descriptions by inspecting register_resources."""
     try:
@@ -568,6 +614,7 @@ def generate_module_page(module_key: str, module_cls: type, auto_title: str, aut
     # Extract tools
     tools = []
     tool_annotations = extract_tool_annotations(module_cls)
+    registered_tool_names = extract_registered_tool_names(module_cls)
 
     for attr_name in dir(module_cls):
         method = getattr(module_cls, attr_name)
@@ -576,17 +623,16 @@ def generate_module_page(module_key: str, module_cls: type, auto_title: str, aut
             and not attr_name.startswith("_")
             and attr_name not in ("register_tools", "register_resources")
         ):
-            # Check if this method is registered as a tool
-            source = inspect.getsource(module_cls.register_tools)  # type: ignore[attr-defined]
-            if attr_name in source:
+            registered_name = registered_tool_names.get(attr_name)
+            if registered_name:
                 info = extract_tool_info(method)
-                info["name"] = f"falcon_{attr_name}"
-                info["raw_name"] = attr_name
+                info["name"] = f"falcon_{registered_name}"
+                info["raw_name"] = registered_name
                 info["method"] = method
 
                 # Get annotations
-                if attr_name in tool_annotations:
-                    info["annotations"] = tool_annotations[attr_name]
+                if registered_name in tool_annotations:
+                    info["annotations"] = tool_annotations[registered_name]
                 else:
                     info["annotations"] = {
                         "readOnlyHint": True,

--- a/tests/integration/test_rtr.py
+++ b/tests/integration/test_rtr.py
@@ -50,6 +50,25 @@ class TestRTRIntegration(BaseIntegrationTest):
                 f"FQL field rejected by API ({context}): filter={field_filter!r}, hint={hint}"
             )
 
+    def _skip_if_scope_error(self, result, scope_hint: str, context: str) -> None:
+        """Skip gracefully when the tenant API client lacks an optional RTR scope."""
+        error_text = ""
+        if isinstance(result, dict) and "error" in result:
+            error_text = str(result)
+        elif isinstance(result, list) and result and isinstance(result[0], dict):
+            if "error" in result[0]:
+                error_text = str(result[0])
+
+        if not error_text:
+            return
+
+        scope_error_markers = ["403", "permission", "scope", "authorization", "access denied"]
+        if any(marker in error_text.lower() for marker in scope_error_markers):
+            self.skip_with_warning(
+                f"{context} requires {scope_hint}; API client returned {error_text}",
+                context=context,
+            )
+
     # ------------------------------------------------------------------
     # Existing tests
     # ------------------------------------------------------------------
@@ -117,6 +136,54 @@ class TestRTRIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_sessions, limit=1)
         self.assert_no_error(result, context="RTR operation name validation")
 
+    def test_search_rtr_audit_sessions(self):
+        """Validate the RTR audit search operation and parameter shape."""
+        result = self.call_method(
+            self.module.search_audit_sessions,
+            limit=1,
+            sort="created_at|desc",
+            with_command_info=False,
+        )
+
+        self._skip_if_scope_error(
+            result,
+            "real-time-response-audit:read",
+            "search_rtr_audit_sessions",
+        )
+        self.assert_no_error(result, context="search_rtr_audit_sessions")
+
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result,
+                min_length=0,
+                context="search_rtr_audit_sessions",
+            )
+
+    def test_aggregate_rtr_sessions(self):
+        """Validate RTR session aggregation operation and request body shape."""
+        result = self.call_method(
+            self.module.aggregate_sessions,
+            field="base_command",
+            aggregate_type="terms",
+            name="commands",
+            filter="created_at:>'now-30d'",
+            size=5,
+        )
+
+        self._skip_if_scope_error(
+            result,
+            "Real time response:read",
+            "aggregate_rtr_sessions",
+        )
+        self.assert_no_error(result, context="aggregate_rtr_sessions")
+
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result,
+                min_length=0,
+                context="aggregate_rtr_sessions",
+            )
+
     # ------------------------------------------------------------------
     # FQL filter tests
     # ------------------------------------------------------------------
@@ -182,11 +249,11 @@ class TestRTRIntegration(BaseIntegrationTest):
             context="user_id @me special token",
         )
 
-    def test_fql_example_deleted_at_not_wildcard(self):
-        """Validate deleted_at:!'*' wildcard exclusion syntax."""
+    def test_fql_example_deleted_at_future_timestamp(self):
+        """Validate deleted_at timestamp comparison syntax."""
         self._assert_fql_field_accepted(
-            "deleted_at:!'*'",
-            context="deleted_at not-wildcard",
+            "deleted_at:>'2099-01-01T00:00:00Z'",
+            context="deleted_at future timestamp",
         )
 
     def test_fql_example_compound_filter(self):
@@ -407,6 +474,44 @@ class TestRTRLifecycleIntegration(BaseIntegrationTest):
 
         assert cloud_request_id, f"Expected cloud_request_id in execute response. Got: {result}"
         self.__class__._cloud_request_id = cloud_request_id
+
+    def test_run_read_only_command_and_wait(self):
+        """Validate the command-and-wait helper against a real RTR session."""
+        result = self.call_method(
+            self.module.run_read_only_command_and_wait,
+            session_id=self.__class__._session_id,
+            base_command="pwd",
+            command_string="pwd",
+            timeout_seconds=30,
+            poll_interval_seconds=2,
+        )
+
+        if isinstance(result, dict) and "error" in result:
+            self.skip_with_warning(
+                "run_read_only_command_and_wait returned error (host likely offline)",
+                context="test_run_read_only_command_and_wait",
+            )
+
+        self.assert_no_error(result, context="run_read_only_command_and_wait")
+
+        assert isinstance(result, dict), (
+            f"Expected dict response from run_read_only_command_and_wait, got {type(result)}"
+        )
+        assert result.get("cloud_request_id"), (
+            f"Expected cloud_request_id in command-and-wait response. Got: {result}"
+        )
+        assert "complete" in result, (
+            f"Expected complete flag in command-and-wait response. Got: {result}"
+        )
+        assert "timed_out" in result, (
+            f"Expected timed_out flag in command-and-wait response. Got: {result}"
+        )
+
+        if result.get("timed_out"):
+            self.skip_with_warning(
+                "RTR command did not complete before the helper timeout",
+                context="test_run_read_only_command_and_wait",
+            )
 
     def test_check_command_status(self):
         """Validate RTR_CheckCommandStatus returns output for a known request."""

--- a/tests/modules/test_rtr.py
+++ b/tests/modules/test_rtr.py
@@ -20,10 +20,13 @@ class TestRTRModule(TestModules):
         """Test registering tools with the server."""
         expected_tools = [
             "falcon_search_rtr_sessions",
+            "falcon_search_rtr_audit_sessions",
+            "falcon_aggregate_rtr_sessions",
             "falcon_get_rtr_session_details",
             "falcon_init_rtr_session",
             "falcon_pulse_rtr_session",
             "falcon_execute_rtr_read_only_command",
+            "falcon_run_rtr_read_only_command_and_wait",
             "falcon_check_rtr_command_status",
             "falcon_list_rtr_session_files",
             "falcon_delete_rtr_session",
@@ -35,6 +38,8 @@ class TestRTRModule(TestModules):
         self.module.register_tools(self.mock_server)
 
         self.assert_tool_annotations("falcon_search_rtr_sessions", READ_ONLY_ANNOTATIONS)
+        self.assert_tool_annotations("falcon_search_rtr_audit_sessions", READ_ONLY_ANNOTATIONS)
+        self.assert_tool_annotations("falcon_aggregate_rtr_sessions", READ_ONLY_ANNOTATIONS)
         self.assert_tool_annotations("falcon_get_rtr_session_details", READ_ONLY_ANNOTATIONS)
         self.assert_tool_annotations(
             "falcon_init_rtr_session",
@@ -63,6 +68,15 @@ class TestRTRModule(TestModules):
                 openWorldHint=True,
             ),
         )
+        self.assert_tool_annotations(
+            "falcon_run_rtr_read_only_command_and_wait",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
         self.assert_tool_annotations("falcon_check_rtr_command_status", READ_ONLY_ANNOTATIONS)
         self.assert_tool_annotations("falcon_list_rtr_session_files", READ_ONLY_ANNOTATIONS)
         self.assert_tool_annotations(
@@ -79,6 +93,9 @@ class TestRTRModule(TestModules):
         """Test registering resources with the server."""
         expected_resources = [
             "falcon_search_rtr_sessions_fql_guide",
+            "falcon_search_rtr_audit_sessions_fql_guide",
+            "falcon_aggregate_rtr_sessions_guide",
+            "falcon_rtr_read_only_investigation_guide",
         ]
         self.assert_resources_registered(expected_resources)
 
@@ -121,6 +138,158 @@ class TestRTRModule(TestModules):
 
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["id"], "session-1")
+
+    def test_search_audit_sessions(self):
+        """Test searching RTR audit sessions."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "id": "audit-session-1",
+                        "hostname": "BRR-WB-LIB-22",
+                        "user_id": "user@example.com",
+                    }
+                ]
+            },
+        }
+
+        result = self.module.search_audit_sessions(
+            filter="created_at:>'now-7d'",
+            limit=25,
+            offset=0,
+            sort="created_at|desc",
+            with_command_info=True,
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "RTRAuditSessions",
+            parameters={
+                "filter": "created_at:>'now-7d'",
+                "limit": 25,
+                "offset": 0,
+                "sort": "created_at|desc",
+                "with_command_info": True,
+            },
+        )
+        self.assertEqual(result[0]["id"], "audit-session-1")
+
+    def test_search_audit_sessions_error_returns_fql_guide(self):
+        """Test audit search with API error returns the RTR audit FQL guide."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid filter"}]},
+        }
+
+        result = self.module.search_audit_sessions(
+            filter="invalid:::filter",
+            limit=10,
+            offset=None,
+            sort=None,
+            with_command_info=False,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("fql_guide", result)
+        self.assertIn("RTR Audit Sessions", result["fql_guide"])
+        self.assertIn("Filter error occurred", result["hint"])
+
+    def test_search_audit_sessions_empty_returns_fql_guide(self):
+        """Test audit search with no results returns the RTR audit FQL guide."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.search_audit_sessions(
+            filter="created_at:>'2099-01-01T00:00:00Z'",
+            limit=10,
+            offset=None,
+            sort=None,
+            with_command_info=False,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("fql_guide", result)
+        self.assertIn("No results matched", result["hint"])
+
+    def test_aggregate_sessions_terms(self):
+        """Test RTR session terms aggregation."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "name": "commands",
+                        "buckets": [{"key": "ps", "count": 5}],
+                    }
+                ]
+            },
+        }
+
+        result = self.module.aggregate_sessions(
+            field="base_command",
+            aggregate_type="terms",
+            name="commands",
+            filter="created_at:>'now-7d'",
+            size=5,
+            interval=None,
+            date_ranges=None,
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_AggregateSessions",
+            body=[
+                {
+                    "field": "base_command",
+                    "filter": "created_at:>'now-7d'",
+                    "name": "commands",
+                    "size": 5,
+                    "type": "terms",
+                }
+            ],
+        )
+        self.assertEqual(result[0]["name"], "commands")
+
+    def test_aggregate_sessions_date_range(self):
+        """Test RTR session date range aggregation."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "name": "activity_by_day",
+                        "buckets": [{"key": "now-7d_now", "count": 3}],
+                    }
+                ]
+            },
+        }
+
+        result = self.module.aggregate_sessions(
+            field="created_at",
+            aggregate_type="date_range",
+            name="activity_by_day",
+            filter=None,
+            size=None,
+            interval="day",
+            date_ranges=[{"from": "now-7d", "to": "now"}],
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_AggregateSessions",
+            body=[
+                {
+                    "date_ranges": [{"from": "now-7d", "to": "now"}],
+                    "field": "created_at",
+                    "interval": "day",
+                    "name": "activity_by_day",
+                    "type": "date_range",
+                }
+            ],
+        )
+        self.assertEqual(result[0]["name"], "activity_by_day")
 
     def test_get_session_details_empty_ids(self):
         """Test get_session_details returns early for empty input."""
@@ -182,6 +351,132 @@ class TestRTRModule(TestModules):
             },
         )
         self.assertEqual(result[0]["cloud_request_id"], "req-123")
+
+    def test_run_read_only_command_and_wait(self):
+        """Test RTR read-only command execution with status polling."""
+        execute_response = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-123", "session_id": "session-1"}]},
+        }
+        status_response = {
+            "status_code": 200,
+            "body": {"resources": [{"complete": True, "stdout": "ok"}]},
+        }
+        self.mock_client.command.side_effect = [execute_response, status_response]
+
+        result = self.module.run_read_only_command_and_wait(
+            session_id="session-1",
+            base_command="cat",
+            command_string=r"cat C:\Windows\win.ini",
+            persist=False,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+        self.mock_client.command.assert_any_call(
+            "RTR_ExecuteCommand",
+            body={
+                "session_id": "session-1",
+                "base_command": "cat",
+                "command_string": r"cat C:\Windows\win.ini",
+                "persist": False,
+            },
+        )
+        self.mock_client.command.assert_any_call(
+            "RTR_CheckCommandStatus",
+            parameters={"cloud_request_id": "req-123", "sequence_id": 0},
+        )
+        self.assertEqual(result["cloud_request_id"], "req-123")
+        self.assertTrue(result["complete"])
+        self.assertFalse(result["timed_out"])
+        self.assertEqual(result["stdout"], "ok")
+
+    def test_run_read_only_command_and_wait_advances_sequence_chunks(self):
+        """Test command-and-wait polls the next sequence chunk until complete."""
+        execute_response = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-123", "session_id": "session-1"}]},
+        }
+        first_chunk_response = {
+            "status_code": 200,
+            "body": {"resources": [{"complete": False, "stdout": "part1"}]},
+        }
+        second_chunk_response = {
+            "status_code": 200,
+            "body": {"resources": [{"complete": True, "stdout": "part2"}]},
+        }
+        self.mock_client.command.side_effect = [
+            execute_response,
+            first_chunk_response,
+            second_chunk_response,
+        ]
+
+        result = self.module.run_read_only_command_and_wait(
+            session_id="session-1",
+            base_command="cat",
+            command_string=r"cat C:\Windows\win.ini",
+            persist=False,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+        self.mock_client.command.assert_any_call(
+            "RTR_CheckCommandStatus",
+            parameters={"cloud_request_id": "req-123", "sequence_id": 0},
+        )
+        self.mock_client.command.assert_any_call(
+            "RTR_CheckCommandStatus",
+            parameters={"cloud_request_id": "req-123", "sequence_id": 1},
+        )
+        self.assertEqual(result["stdout"], "part1part2")
+        self.assertTrue(result["complete"])
+
+    def test_run_read_only_command_and_wait_execute_error(self):
+        """Test command-and-wait returns execute phase on execute failure."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Session ID is invalid"}]},
+        }
+
+        result = self.module.run_read_only_command_and_wait(
+            session_id="not-a-real-session",
+            base_command="ps",
+            command_string="ps",
+            persist=False,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+        self.assertEqual(result["phase"], "execute")
+
+    def test_run_read_only_command_and_wait_timeout(self):
+        """Test command-and-wait returns partial status on timeout."""
+        execute_response = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-123", "session_id": "session-1"}]},
+        }
+        status_response = {
+            "status_code": 200,
+            "body": {"resources": [{"complete": False, "stdout": ""}]},
+        }
+        self.mock_client.command.side_effect = [execute_response, status_response]
+
+        result = self.module.run_read_only_command_and_wait(
+            session_id="session-1",
+            base_command="ps",
+            command_string="ps",
+            persist=False,
+            timeout_seconds=0,
+            poll_interval_seconds=0,
+        )
+
+        self.assertEqual(result["cloud_request_id"], "req-123")
+        self.assertFalse(result["complete"])
+        self.assertTrue(result["timed_out"])
+        self.assertIn("warning", result)
 
     def test_check_command_status(self):
         """Test retrieving RTR command status."""

--- a/tests/modules/test_rtr.py
+++ b/tests/modules/test_rtr.py
@@ -393,14 +393,14 @@ class TestRTRModule(TestModules):
         self.assertEqual(result["stdout"], "ok")
 
     def test_run_read_only_command_and_wait_advances_sequence_chunks(self):
-        """Test command-and-wait polls the next sequence chunk until complete."""
+        """Test command-and-wait reads sequence_id from response for next poll."""
         execute_response = {
             "status_code": 200,
             "body": {"resources": [{"cloud_request_id": "req-123", "session_id": "session-1"}]},
         }
         first_chunk_response = {
             "status_code": 200,
-            "body": {"resources": [{"complete": False, "stdout": "part1"}]},
+            "body": {"resources": [{"complete": False, "stdout": "part1", "sequence_id": 3}]},
         }
         second_chunk_response = {
             "status_code": 200,
@@ -427,7 +427,7 @@ class TestRTRModule(TestModules):
         )
         self.mock_client.command.assert_any_call(
             "RTR_CheckCommandStatus",
-            parameters={"cloud_request_id": "req-123", "sequence_id": 1},
+            parameters={"cloud_request_id": "req-123", "sequence_id": 3},
         )
         self.assertEqual(result["stdout"], "part1part2")
         self.assertTrue(result["complete"])

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -46,6 +46,7 @@ MUTATING_TOOL_ALLOWLIST: set[str] = {
     "falcon_init_rtr_session",
     "falcon_pulse_rtr_session",
     "falcon_execute_rtr_read_only_command",
+    "falcon_run_rtr_read_only_command_and_wait",
     "falcon_delete_rtr_session",
     # shield module
     "falcon_dismiss_shield_check",


### PR DESCRIPTION
## Summary

Adds a focused RTR workflow improvement set:
- search RTR audit sessions for accountability and timeline context
- aggregate RTR session activity by host, user, command, or time window
- run a read-only RTR command and wait for the first result in one tool call
- add RTR guidance resources so agents understand the safe read-only workflow and boundaries
- fix generated module docs to show the actual registered MCP tool names

## Notes

This intentionally stays in the read-only RTR lane. It does not add RTR Admin, Active Responder, arbitrary script execution, or queued-session management.

## Testing

- `python -m ruff check . --select I`
- `python -m ruff check .`
- `python -m pytest tests/modules/test_rtr.py tests/common/test_api_scopes.py tests/test_server.py`
- `python -m pytest tests/integration/test_rtr.py::TestRTRIntegration --run-integration`
- `python -m pytest tests/integration/test_rtr.py::TestRTRLifecycleIntegration::test_run_read_only_command_and_wait --run-integration`
- `python -m pytest tests --ignore=tests/e2e`