### PR TITLE
feat(modules/cloud): add CSPM findings query and suppression tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Full docs are available at **[crowdstrike.github.io/falcon-mcp](https://crowdstr
 | Module | Description |
 |--------|-------------|
 | Core | Basic connectivity and system information |
-| [Cloud Security](https://crowdstrike.github.io/falcon-mcp/modules/cloud/) | Kubernetes containers, image vulnerabilities, CSPM asset inventory, IOM/IOA findings, and suppression rules |
+| [Cloud Security](https://crowdstrike.github.io/falcon-mcp/modules/cloud/) | Kubernetes containers, image vulnerabilities, CSPM asset inventory, IOM findings, and suppression rules |
 | [Custom IOA](https://crowdstrike.github.io/falcon-mcp/modules/custom-ioa/) | Create and manage Custom IOA behavioral detection rules and rule groups |
 | [Detections](https://crowdstrike.github.io/falcon-mcp/modules/detections/) | Find and analyze detections to understand malicious activity |
 | [Discover](https://crowdstrike.github.io/falcon-mcp/modules/discover/) | Search application inventory and discover unmanaged assets |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Full docs are available at **[crowdstrike.github.io/falcon-mcp](https://crowdstr
 | Module | Description |
 |--------|-------------|
 | Core | Basic connectivity and system information |
-| [Cloud Security](https://crowdstrike.github.io/falcon-mcp/modules/cloud/) | Kubernetes containers, image vulnerabilities, and CSPM asset inventory |
+| [Cloud Security](https://crowdstrike.github.io/falcon-mcp/modules/cloud/) | Kubernetes containers, image vulnerabilities, CSPM asset inventory, IOM/IOA findings, and suppression rules |
 | [Custom IOA](https://crowdstrike.github.io/falcon-mcp/modules/custom-ioa/) | Create and manage Custom IOA behavioral detection rules and rule groups |
 | [Detections](https://crowdstrike.github.io/falcon-mcp/modules/detections/) | Find and analyze detections to understand malicious activity |
 | [Discover](https://crowdstrike.github.io/falcon-mcp/modules/discover/) | Search application inventory and discover unmanaged assets |

--- a/docs-site/src/content/docs/modules/cloud.md
+++ b/docs-site/src/content/docs/modules/cloud.md
@@ -55,8 +55,8 @@ with details on failure.
 
 **Example prompts:**
 
-- "Suppress that S3 encryption finding in the dev account as accepted risk"
-- "Create a suppression rule for the IAM password policy finding as false positive"
+- "Create a CSPM suppression rule for the S3 encryption finding in the dev account as accepted risk"
+- "Suppress the IAM password policy IOM finding as a false positive, expiring in 30 days"
 
 ### `falcon_delete_cspm_suppression_rules`
 
@@ -77,8 +77,8 @@ Returns a confirmation response on success, or an error dict on failure.
 
 **Example prompts:**
 
-- "Delete the suppression rule we just created"
-- "Remove suppression rule abc-123"
+- "Delete CSPM suppression rule abc-123"
+- "Remove the CSPM IOM suppression rule for the S3 public access finding"
 
 ### `falcon_search_cspm_assets`
 
@@ -116,8 +116,8 @@ created_at, created_by. Returns an empty list if no rules exist.
 
 **Example prompts:**
 
-- "Show me all CSPM suppression rules"
-- "What findings are being suppressed and why?"
+- "List all CSPM IOM suppression rules and their reasons"
+- "Show me which CSPM findings are being suppressed and why"
 
 ### `falcon_search_images_vulnerabilities`
 
@@ -150,8 +150,8 @@ Requires at least the cloud_provider parameter.
 
 **Example prompts:**
 
-- "Show me IOA events in AWS from the last 24 hours"
-- "Are there any critical IOA detections in Azure?"
+- "Show me CSPM IOA behavior detections in AWS from the last 24 hours"
+- "Are there any critical cloud IOA detections in Azure?"
 
 ### `falcon_search_iom_findings`
 
@@ -174,9 +174,9 @@ Returns a list of IOM finding entities with nested structure:
 
 **Example prompts:**
 
-- "Show me critical open CSPM findings in AWS"
-- "Find misconfiguration findings for S3 buckets"
-- "What IOM findings are suppressed as accepted risk?"
+- "Show me critical open CSPM misconfiguration findings in AWS"
+- "Find IOM findings for S3 buckets with public access"
+- "What CSPM IOM findings are suppressed as accepted risk?"
 
 ### `falcon_search_kubernetes_containers`
 

--- a/docs-site/src/content/docs/modules/cloud.md
+++ b/docs-site/src/content/docs/modules/cloud.md
@@ -1,15 +1,19 @@
 ---
 title: Cloud Security
-description: Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets
+description: Accessing and analyzing CrowdStrike Falcon cloud resources including Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets, CSPM Findings, and Suppression Rules
 sidebar:
   order: 10
 ---
 
-Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets
+Accessing and analyzing CrowdStrike Falcon cloud resources including Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets, CSPM Findings, and Suppression Rules
 
 ## API Scopes
 
 - `Cloud Security API Assets:read`
+- `Cloud Security API Detections:read`
+- `Cloud Security Policies:read`
+- `Cloud Security Policies:write`
+- `CSPM Registration:read`
 - `Falcon Container Image:read`
 
 ## Tools
@@ -42,6 +46,102 @@ managed by CrowdStrike CSPM. Supports comprehensive FQL filtering including:
 
 - "Find all AWS EC2 instances in my cloud inventory"
 
+### `falcon_search_iom_findings`
+
+**Required scopes:** `Cloud Security API Detections:read`
+
+Search for CSPM Indicators of Misconfiguration (IOM) findings. Retrieves cloud security
+posture findings that identify misconfigurations in your cloud environment (AWS, Azure, GCP).
+Findings map to compliance frameworks (CIS, NIST, SOC2) and MITRE ATT&CK techniques.
+
+Supports filtering by suppression state to view which findings have been accepted as risk,
+marked as false positives, or have compensating controls.
+
+Returns IOM finding entities with nested structure: `id`, `cloud` (account, provider, region),
+`evaluation` (severity, status, rule, attack_types), `resource` (resource_id, type, service).
+
+**Example prompts:**
+
+- "Show me critical open CSPM findings in AWS"
+- "Find misconfiguration findings for S3 buckets"
+- "What IOM findings are suppressed as accepted risk?"
+- "Show me high severity findings detected in the last week"
+
+### `falcon_search_ioa_findings`
+
+**Required scopes:** `CSPM Registration:read`
+
+Search for CSPM Indicators of Attack (IOA) behavior detections. Retrieves cloud security
+behavior detections that identify active attack patterns in your cloud environment. IOAs
+detect runtime threats like unauthorized API calls, suspicious credential usage, and
+lateral movement.
+
+This tool uses direct parameter filtering, not FQL. Pass parameters directly rather than
+building a filter query string.
+
+**Example prompts:**
+
+- "Show me IOA events in AWS from the last 24 hours"
+- "Are there any critical IOA detections in Azure?"
+- "Find IOA events related to IAM in AWS"
+
+### `falcon_search_cspm_suppression_rules`
+
+**Required scopes:** `Cloud Security Policies:read`
+
+Lists suppression rules that control which IOM findings are suppressed. Suppression rules
+define which rules and assets are excluded from generating active findings, along with the
+reason and optional expiration date.
+
+Returns suppression rule objects containing: id, name, domain, subdomain, rule_selection_type,
+scope_type, suppression_reason, created_at, created_by.
+
+**Example prompts:**
+
+- "Show me all CSPM suppression rules"
+- "What findings are being suppressed and why?"
+
+### `falcon_create_cspm_suppression_rule`
+
+**Required scopes:** `Cloud Security Policies:write`
+
+Create a CSPM IOM suppression rule to suppress matching findings. This creates a rule that
+hides matching IOM findings from compliance scores and active finding views. Suppressed
+findings are still assessed but not surfaced.
+
+A suppression rule defines:
+- **WHICH rules** to suppress (by ID, name, or severity)
+- **WHICH assets** to suppress them for (by cloud provider, account, region, resource)
+- **WHY** (accept-risk, compensating-control, false-positive)
+- **WHEN** it expires (strongly recommended)
+
+:::caution
+This is a destructive operation. Creating a suppression rule will hide matching findings
+from compliance visibility. Requires the modern "Cloud Security Posture Rules" mode.
+:::
+
+**Example prompts:**
+
+- "Suppress that S3 encryption finding in the dev account as accepted risk"
+- "Create a suppression rule for the IAM password policy finding as a false positive, expires in 30 days"
+
+### `falcon_delete_cspm_suppression_rules`
+
+**Required scopes:** `Cloud Security Policies:write`
+
+Delete CSPM IOM suppression rules by ID. Deleting a suppression rule will re-activate all
+findings that were previously suppressed by that rule.
+
+:::caution
+This is a destructive operation. Deleted suppression rules will cause previously suppressed
+findings to reappear as open findings.
+:::
+
+**Example prompts:**
+
+- "Delete the suppression rule we just created"
+- "Remove suppression rule abc-123"
+
 ### `falcon_search_images_vulnerabilities`
 
 **Required scopes:** `Falcon Container Image:read`
@@ -65,6 +165,7 @@ Search for kubernetes containers in your CrowdStrike Kubernetes & Containers Inv
 
 ## Resources
 
+- **`falcon://cloud/cspm-iom-findings/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_iom_findings` tool.
 - **`falcon://cloud/kubernetes-containers/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_kubernetes_containers` and `falcon_count_kubernetes_containers` tools.
 - **`falcon://cloud/images-vulnerabilities/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_images_vulnerabilities` tool.
 - **`falcon://cloud/cspm-assets/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_cspm_assets` tool.

--- a/docs-site/src/content/docs/modules/cloud.md
+++ b/docs-site/src/content/docs/modules/cloud.md
@@ -9,7 +9,6 @@ Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Con
 
 ## API Scopes
 
-- `CSPM Registration:read`
 - `Cloud Security API Assets:read`
 - `Cloud Security API Detections:read`
 - `Cloud Security Policies:read`
@@ -128,30 +127,6 @@ Search for images vulnerabilities in your CrowdStrike Image Assessments
 **Example prompts:**
 
 - "Find image vulnerabilities with CVSS score above 7"
-
-### `falcon_search_ioa_findings`
-
-**Required scopes:** `CSPM Registration:read`
-
-Search for CSPM Indicators of Attack (IOA) behavior detections.
-
-Retrieves cloud security behavior detections that identify active attack
-patterns in your cloud environment. IOAs detect runtime threats like
-unauthorized API calls, suspicious credential usage, and lateral movement.
-
-NOTE: This tool uses direct parameter filtering, NOT FQL. Pass parameters
-directly rather than building a filter query string.
-
-Returns a list of IOA event objects with cloud context including event type,
-severity, cloud provider details, and associated resource information.
-Returns an empty list if no events match the criteria.
-
-Requires at least the cloud_provider parameter.
-
-**Example prompts:**
-
-- "Show me CSPM IOA behavior detections in AWS from the last 24 hours"
-- "Are there any critical cloud IOA detections in Azure?"
 
 ### `falcon_search_iom_findings`
 

--- a/docs-site/src/content/docs/modules/cloud.md
+++ b/docs-site/src/content/docs/modules/cloud.md
@@ -1,20 +1,20 @@
 ---
 title: Cloud Security
-description: Accessing and analyzing CrowdStrike Falcon cloud resources including Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets, CSPM Findings, and Suppression Rules
+description: Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets
 sidebar:
   order: 10
 ---
 
-Accessing and analyzing CrowdStrike Falcon cloud resources including Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets, CSPM Findings, and Suppression Rules
+Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets
 
 ## API Scopes
 
+- `CSPM Registration:read`
 - `Cloud Security API Assets:read`
 - `Cloud Security API Detections:read`
 - `Cloud Security Policies:read`
-- `Cloud Security Policies:write`
-- `CSPM Registration:read`
 - `Falcon Container Image:read`
+- `Cloud Security Policies:write`
 
 ## Tools
 
@@ -27,6 +27,58 @@ Count kubernetes containers in your CrowdStrike Kubernetes & Containers Inventor
 **Example prompts:**
 
 - "How many containers are running in Azure?"
+
+### `falcon_create_cspm_suppression_rule`
+
+:::caution
+This tool performs destructive operations.
+:::
+
+**Required scopes:** `Cloud Security Policies:write`
+
+Create a CSPM IOM suppression rule to suppress matching findings.
+
+WARNING: This creates a suppression rule that will hide matching IOM findings
+from compliance scores and active finding views. Suppressed findings are still
+assessed but not surfaced. Use carefully and prefer narrow scope.
+
+A suppression rule defines:
+- WHICH rules to suppress (by ID, name, or severity)
+- WHICH assets to suppress them for (by cloud provider, account, region, resource)
+- WHY (accept-risk, compensating-control, false-positive)
+- WHEN it expires (strongly recommended)
+
+Requires the modern 'Cloud Security Posture Rules' mode (not legacy policies).
+
+Returns the created suppression rule object on success, or an error dict
+with details on failure.
+
+**Example prompts:**
+
+- "Suppress that S3 encryption finding in the dev account as accepted risk"
+- "Create a suppression rule for the IAM password policy finding as false positive"
+
+### `falcon_delete_cspm_suppression_rules`
+
+:::caution
+This tool performs destructive operations.
+:::
+
+**Required scopes:** `Cloud Security Policies:write`
+
+Delete CSPM IOM suppression rules by ID.
+
+WARNING: Deleting a suppression rule will re-activate all findings that were
+previously suppressed by that rule. They will appear as open findings again.
+
+Use falcon_search_cspm_suppression_rules first to identify which rules to delete.
+
+Returns a confirmation response on success, or an error dict on failure.
+
+**Example prompts:**
+
+- "Delete the suppression rule we just created"
+- "Remove suppression rule abc-123"
 
 ### `falcon_search_cspm_assets`
 
@@ -46,101 +98,26 @@ managed by CrowdStrike CSPM. Supports comprehensive FQL filtering including:
 
 - "Find all AWS EC2 instances in my cloud inventory"
 
-### `falcon_search_iom_findings`
-
-**Required scopes:** `Cloud Security API Detections:read`
-
-Search for CSPM Indicators of Misconfiguration (IOM) findings. Retrieves cloud security
-posture findings that identify misconfigurations in your cloud environment (AWS, Azure, GCP).
-Findings map to compliance frameworks (CIS, NIST, SOC2) and MITRE ATT&CK techniques.
-
-Supports filtering by suppression state to view which findings have been accepted as risk,
-marked as false positives, or have compensating controls.
-
-Returns IOM finding entities with nested structure: `id`, `cloud` (account, provider, region),
-`evaluation` (severity, status, rule, attack_types), `resource` (resource_id, type, service).
-
-**Example prompts:**
-
-- "Show me critical open CSPM findings in AWS"
-- "Find misconfiguration findings for S3 buckets"
-- "What IOM findings are suppressed as accepted risk?"
-- "Show me high severity findings detected in the last week"
-
-### `falcon_search_ioa_findings`
-
-**Required scopes:** `CSPM Registration:read`
-
-Search for CSPM Indicators of Attack (IOA) behavior detections. Retrieves cloud security
-behavior detections that identify active attack patterns in your cloud environment. IOAs
-detect runtime threats like unauthorized API calls, suspicious credential usage, and
-lateral movement.
-
-This tool uses direct parameter filtering, not FQL. Pass parameters directly rather than
-building a filter query string.
-
-**Example prompts:**
-
-- "Show me IOA events in AWS from the last 24 hours"
-- "Are there any critical IOA detections in Azure?"
-- "Find IOA events related to IAM in AWS"
-
 ### `falcon_search_cspm_suppression_rules`
 
 **Required scopes:** `Cloud Security Policies:read`
 
-Lists suppression rules that control which IOM findings are suppressed. Suppression rules
-define which rules and assets are excluded from generating active findings, along with the
-reason and optional expiration date.
+Search for CSPM IOM suppression rules.
 
-Returns suppression rule objects containing: id, name, domain, subdomain, rule_selection_type,
-scope_type, suppression_reason, created_at, created_by.
+Lists suppression rules that control which IOM findings are suppressed.
+Suppression rules define which rules and assets are excluded from generating
+active findings, along with the reason and optional expiration date.
+
+Use this to review existing suppressions before creating new ones.
+
+Returns a list of suppression rule objects containing: id, name, domain,
+subdomain, disabled, rule_selection_type, scope_type, suppression_reason,
+created_at, created_by. Returns an empty list if no rules exist.
 
 **Example prompts:**
 
 - "Show me all CSPM suppression rules"
 - "What findings are being suppressed and why?"
-
-### `falcon_create_cspm_suppression_rule`
-
-**Required scopes:** `Cloud Security Policies:write`
-
-Create a CSPM IOM suppression rule to suppress matching findings. This creates a rule that
-hides matching IOM findings from compliance scores and active finding views. Suppressed
-findings are still assessed but not surfaced.
-
-A suppression rule defines:
-- **WHICH rules** to suppress (by ID, name, or severity)
-- **WHICH assets** to suppress them for (by cloud provider, account, region, resource)
-- **WHY** (accept-risk, compensating-control, false-positive)
-- **WHEN** it expires (strongly recommended)
-
-:::caution
-This is a destructive operation. Creating a suppression rule will hide matching findings
-from compliance visibility. Requires the modern "Cloud Security Posture Rules" mode.
-:::
-
-**Example prompts:**
-
-- "Suppress that S3 encryption finding in the dev account as accepted risk"
-- "Create a suppression rule for the IAM password policy finding as a false positive, expires in 30 days"
-
-### `falcon_delete_cspm_suppression_rules`
-
-**Required scopes:** `Cloud Security Policies:write`
-
-Delete CSPM IOM suppression rules by ID. Deleting a suppression rule will re-activate all
-findings that were previously suppressed by that rule.
-
-:::caution
-This is a destructive operation. Deleted suppression rules will cause previously suppressed
-findings to reappear as open findings.
-:::
-
-**Example prompts:**
-
-- "Delete the suppression rule we just created"
-- "Remove suppression rule abc-123"
 
 ### `falcon_search_images_vulnerabilities`
 
@@ -151,6 +128,55 @@ Search for images vulnerabilities in your CrowdStrike Image Assessments
 **Example prompts:**
 
 - "Find image vulnerabilities with CVSS score above 7"
+
+### `falcon_search_ioa_findings`
+
+**Required scopes:** `CSPM Registration:read`
+
+Search for CSPM Indicators of Attack (IOA) behavior detections.
+
+Retrieves cloud security behavior detections that identify active attack
+patterns in your cloud environment. IOAs detect runtime threats like
+unauthorized API calls, suspicious credential usage, and lateral movement.
+
+NOTE: This tool uses direct parameter filtering, NOT FQL. Pass parameters
+directly rather than building a filter query string.
+
+Returns a list of IOA event objects with cloud context including event type,
+severity, cloud provider details, and associated resource information.
+Returns an empty list if no events match the criteria.
+
+Requires at least the cloud_provider parameter.
+
+**Example prompts:**
+
+- "Show me IOA events in AWS from the last 24 hours"
+- "Are there any critical IOA detections in Azure?"
+
+### `falcon_search_iom_findings`
+
+**Required scopes:** `Cloud Security API Detections:read`
+
+Search for CSPM Indicators of Misconfiguration (IOM) findings.
+
+Retrieves cloud security posture findings that identify misconfigurations
+in your cloud environment (AWS, Azure, GCP). Findings map to compliance
+frameworks (CIS, NIST, SOC2) and MITRE ATT&CK techniques.
+
+Supports filtering by suppression state to view which findings have been
+accepted as risk, marked as false positives, or have compensating controls.
+
+Returns a list of IOM finding entities with nested structure:
+- id: Unique finding identifier
+- cloud: {account_id, account_name, provider, region}
+- evaluation: {severity, status, attack_types, rule, created, url}
+- resource: {resource_id, resource_type, service, service_category}
+
+**Example prompts:**
+
+- "Show me critical open CSPM findings in AWS"
+- "Find misconfiguration findings for S3 buckets"
+- "What IOM findings are suppressed as accepted risk?"
 
 ### `falcon_search_kubernetes_containers`
 
@@ -165,7 +191,7 @@ Search for kubernetes containers in your CrowdStrike Kubernetes & Containers Inv
 
 ## Resources
 
-- **`falcon://cloud/cspm-iom-findings/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_iom_findings` tool.
 - **`falcon://cloud/kubernetes-containers/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_kubernetes_containers` and `falcon_count_kubernetes_containers` tools.
 - **`falcon://cloud/images-vulnerabilities/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_images_vulnerabilities` tool.
 - **`falcon://cloud/cspm-assets/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_cspm_assets` tool.
+- **`falcon://cloud/cspm-iom-findings/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_iom_findings` tool.

--- a/docs-site/src/content/docs/modules/overview.md
+++ b/docs-site/src/content/docs/modules/overview.md
@@ -9,7 +9,7 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 
 | Module | API Scopes | Description |
 |--------|-------------------|-------------|
-| [Cloud Security](/falcon-mcp/modules/cloud/) | `Cloud Security API Assets:read`, `Falcon Container Image:read` | Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets |
+| [Cloud Security](/falcon-mcp/modules/cloud/) | `CSPM Registration:read`, `Cloud Security API Assets:read`, `Cloud Security API Detections:read`, `Cloud Security Policies:read`, `Falcon Container Image:read`, `Cloud Security Policies:write` | Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets |
 | [Custom IOA](/falcon-mcp/modules/custom-ioa/) | `Custom IOA Rules:read`, `Custom IOA Rules:write` | Searching, creating, updating, and deleting Custom IOA (Indicators of Attack) behavioral rules and rule groups using Falcon Custom IOA Service Collection endpoints |
 | [Detections](/falcon-mcp/modules/detections/) | `Alerts:read` | Accessing and analyzing CrowdStrike Falcon detections |
 | [Discover](/falcon-mcp/modules/discover/) | `Assets:read` | Accessing and managing CrowdStrike Falcon Discover applications and unmanaged assets |

--- a/docs-site/src/content/docs/modules/overview.md
+++ b/docs-site/src/content/docs/modules/overview.md
@@ -9,7 +9,7 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 
 | Module | API Scopes | Description |
 |--------|-------------------|-------------|
-| [Cloud Security](/falcon-mcp/modules/cloud/) | `CSPM Registration:read`, `Cloud Security API Assets:read`, `Cloud Security API Detections:read`, `Cloud Security Policies:read`, `Falcon Container Image:read`, `Cloud Security Policies:write` | Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets |
+| [Cloud Security](/falcon-mcp/modules/cloud/) | `Cloud Security API Assets:read`, `Cloud Security API Detections:read`, `Cloud Security Policies:read`, `Falcon Container Image:read`, `Cloud Security Policies:write` | Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets |
 | [Custom IOA](/falcon-mcp/modules/custom-ioa/) | `Custom IOA Rules:read`, `Custom IOA Rules:write` | Searching, creating, updating, and deleting Custom IOA (Indicators of Attack) behavioral rules and rule groups using Falcon Custom IOA Service Collection endpoints |
 | [Detections](/falcon-mcp/modules/detections/) | `Alerts:read` | Accessing and analyzing CrowdStrike Falcon detections |
 | [Discover](/falcon-mcp/modules/discover/) | `Assets:read` | Accessing and managing CrowdStrike Falcon Discover applications and unmanaged assets |

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -47,6 +47,16 @@ API_SCOPE_REQUIREMENTS = {
     # CSPM Assets operations
     "cloud_security_assets_queries": ["Cloud Security API Assets:read"],
     "cloud_security_assets_entities_get": ["Cloud Security API Assets:read"],
+    # CSPM IOM Findings operations (CloudSecurityDetections)
+    "cspm_evaluations_iom_queries": ["Cloud Security API Detections:read"],
+    "cspm_evaluations_iom_entities": ["Cloud Security API Detections:read"],
+    # CSPM IOA Behavior Detections (CSPMRegistration)
+    "GetBehaviorDetections": ["CSPM Registration:read"],
+    # CSPM Suppression Rules (override endpoints)
+    "QuerySuppressionRules": ["Cloud Security Policies:read"],
+    "GetSuppressionRules": ["Cloud Security Policies:read"],
+    "CreateSuppressionRule": ["Cloud Security Policies:write"],
+    "DeleteSuppressionRules": ["Cloud Security Policies:write"],
     # Identity Protection operations
     "api_preempt_proxy_post_graphql": [
         "Identity Protection Entities:read",

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -50,8 +50,6 @@ API_SCOPE_REQUIREMENTS = {
     # CSPM IOM Findings operations (CloudSecurityDetections)
     "cspm_evaluations_iom_queries": ["Cloud Security API Detections:read"],
     "cspm_evaluations_iom_entities": ["Cloud Security API Detections:read"],
-    # CSPM IOA Behavior Detections (CSPMRegistration)
-    "GetBehaviorDetections": ["CSPM Registration:read"],
     # CSPM Suppression Rules (override endpoints)
     "QuerySuppressionRules": ["Cloud Security Policies:read"],
     "GetSuppressionRules": ["Cloud Security Policies:read"],

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -413,7 +413,7 @@ class CloudModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        return [self._slim_cspm_asset(asset) for asset in details]
 
     def _batch_get_cspm_assets(self, asset_ids: list[str]) -> list[dict[str, Any]] | dict[str, Any]:
         """Fetch CSPM asset details in batches of 100 (API limit).
@@ -449,6 +449,91 @@ class CloudModule(BaseModule):
                 all_assets.extend(result)
 
         return all_assets
+
+    def _slim_cspm_asset(self, asset: dict[str, Any]) -> dict[str, Any]:
+        """Strip bloated fields from a CSPM asset record to reduce response size.
+
+        Raw CSPM asset records can be 100+ KB each due to compliance benchmark
+        details and raw configuration blobs. This keeps actionable fields and
+        security posture data while dropping internal/verbose data.
+        """
+        KEEP_TOP_LEVEL = {
+            "id",
+            "arn",
+            "resource_id",
+            "resource_name",
+            "resource_type",
+            "resource_type_name",
+            "account_id",
+            "account_name",
+            "region",
+            "zone",
+            "cloud_provider",
+            "service",
+            "service_category",
+            "active",
+            "first_seen",
+            "updated_at",
+            "creation_time",
+            "tags",
+            "resource_url",
+            "relationships",
+        }
+
+        slimmed = {k: v for k, v in asset.items() if k in KEEP_TOP_LEVEL}
+
+        cloud_context = asset.get("cloud_context")
+        if isinstance(cloud_context, dict):
+            slimmed["cloud_context"] = self._slim_cloud_context(cloud_context)
+
+        return slimmed
+
+    def _slim_cloud_context(self, ctx: dict[str, Any]) -> dict[str, Any]:
+        """Keep security-relevant summary from cloud_context, strip benchmark bloat."""
+        slimmed: dict[str, Any] = {}
+
+        # Scalar fields worth keeping
+        for key in (
+            "cspm_license",
+            "publicly_exposed",
+            "managed_by",
+            "has_tags",
+            "instance_id",
+            "instance_state",
+            "open_cloud_risks",
+            "scan_type",
+            "data_classifications",
+        ):
+            if key in ctx:
+                slimmed[key] = ctx[key]
+
+        # Host info (platform, OS, state) — small and useful
+        if "host" in ctx:
+            slimmed["host"] = ctx["host"]
+
+        # Detections — keep counts/severity, strip rule IDs and benchmark objects
+        detections = ctx.get("detections")
+        if isinstance(detections, dict):
+            slimmed["detections"] = {
+                k: detections[k]
+                for k in (
+                    "iom_counts",
+                    "ioa_counts",
+                    "severities",
+                    "highest_severity",
+                    "resource_url",
+                )
+                if k in detections
+            }
+
+        # Insights — keep external boolean flags, drop verbose details
+        insights = ctx.get("insights")
+        if isinstance(insights, dict):
+            external = insights.get("external")
+            if external:
+                slimmed["insights"] = {"external": external}
+
+        return slimmed
 
     def search_iom_findings(
         self,

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -857,10 +857,31 @@ class CloudModule(BaseModule):
             body=body,
         )
 
-        return handle_api_response(
+        create_result = handle_api_response(
             response,
             operation="CreateSuppressionRule",
             error_message="Failed to create suppression rule",
+            default_result=[],
+        )
+
+        if self._is_error(create_result):
+            return create_result
+
+        if not create_result:
+            return []
+
+        # API returns list of created rule IDs — fetch full details
+        detail_params = prepare_api_parameters({"ids": create_result})
+        detail_response = self.client.command(
+            "GetSuppressionRules",
+            override="GET,/cloud-policies/entities/suppression-rules/v1",
+            parameters=detail_params,
+        )
+
+        return handle_api_response(
+            detail_response,
+            operation="GetSuppressionRules",
+            error_message="Failed to get created suppression rule details",
             default_result=[],
         )
 

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -10,9 +10,8 @@ from typing import Any
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
-from pydantic import AnyUrl, Field
-
 from mcp.types import ToolAnnotations
+from pydantic import AnyUrl, Field
 
 from falcon_mcp.common.errors import handle_api_response
 from falcon_mcp.common.logging import get_logger

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -12,11 +12,14 @@ from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
 from pydantic import AnyUrl, Field
 
+from mcp.types import ToolAnnotations
+
 from falcon_mcp.common.errors import handle_api_response
 from falcon_mcp.common.logging import get_logger
 from falcon_mcp.common.utils import prepare_api_parameters
 from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.resources.cloud import (
+    CSPM_IOM_FINDINGS_FQL_DOCUMENTATION,
     IMAGES_VULNERABILITIES_FQL_DOCUMENTATION,
     KUBERNETES_CONTAINERS_FQL_DOCUMENTATION,
     SEARCH_CSPM_ASSETS_FQL_DOCUMENTATION,
@@ -60,6 +63,48 @@ class CloudModule(BaseModule):
             name="search_cspm_assets",
         )
 
+        self._add_tool(
+            server=server,
+            method=self.search_iom_findings,
+            name="search_iom_findings",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.search_ioa_findings,
+            name="search_ioa_findings",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.search_cspm_suppression_rules,
+            name="search_cspm_suppression_rules",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.create_cspm_suppression_rule,
+            name="create_cspm_suppression_rule",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.delete_cspm_suppression_rules,
+            name="delete_cspm_suppression_rules",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
     def register_resources(self, server: FastMCP) -> None:
         """Register resources with the MCP server.
         Args:
@@ -79,6 +124,20 @@ class CloudModule(BaseModule):
             text=IMAGES_VULNERABILITIES_FQL_DOCUMENTATION,
         )
 
+        cspm_assets_fql_resource = TextResource(
+            uri=AnyUrl("falcon://cloud/cspm-assets/fql-guide"),
+            name="falcon_search_cspm_assets_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_cspm_assets` tool.",
+            text=SEARCH_CSPM_ASSETS_FQL_DOCUMENTATION,
+        )
+
+        cspm_iom_findings_fql_resource = TextResource(
+            uri=AnyUrl("falcon://cloud/cspm-iom-findings/fql-guide"),
+            name="falcon_search_iom_findings_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_iom_findings` tool.",
+            text=CSPM_IOM_FINDINGS_FQL_DOCUMENTATION,
+        )
+
         self._add_resource(
             server,
             kubernetes_containers_fql_resource,
@@ -88,16 +147,14 @@ class CloudModule(BaseModule):
             images_vulnerabilities_fql_resource,
         )
 
-        cspm_assets_fql_resource = TextResource(
-            uri=AnyUrl("falcon://cloud/cspm-assets/fql-guide"),
-            name="falcon_search_cspm_assets_fql_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_cspm_assets` tool.",
-            text=SEARCH_CSPM_ASSETS_FQL_DOCUMENTATION,
+        self._add_resource(
+            server,
+            cspm_assets_fql_resource,
         )
 
         self._add_resource(
             server,
-            cspm_assets_fql_resource,
+            cspm_iom_findings_fql_resource,
         )
 
     def search_kubernetes_containers(
@@ -392,3 +449,461 @@ class CloudModule(BaseModule):
                 all_assets.extend(result)
 
         return all_assets
+
+    def search_iom_findings(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description=(
+                "FQL Syntax formatted string used to limit the results."
+                " IMPORTANT: use the `falcon://cloud/cspm-iom-findings/fql-guide`"
+                " resource when building this filter parameter."
+            ),
+            examples=["severity:'critical'+status:'open'", "cloud_provider:'aws'+service:'S3'"],
+        ),
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=1000,
+            description=(
+                "The maximum number of IOM findings to return (default: 100; max: 1000)."
+                " Use with the offset parameter to manage pagination."
+            ),
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index of overall result set from which to return findings.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description=dedent(
+                """
+                Sort IOM findings. Use |asc or |desc suffix to specify direction.
+
+                Common sort fields:
+                severity: Finding severity level
+                first_detected: When the finding was first detected
+                last_detected: When the finding was last seen
+                cloud_provider: Cloud provider name
+                service: Cloud service name
+                status: Finding status
+
+                Examples: 'severity|desc', 'last_detected|desc', 'first_detected|asc'
+            """
+            ).strip(),
+            examples=["severity|desc", "last_detected|desc"],
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search for CSPM Indicators of Misconfiguration (IOM) findings.
+
+        Retrieves cloud security posture findings that identify misconfigurations
+        in your cloud environment (AWS, Azure, GCP). Findings map to compliance
+        frameworks (CIS, NIST, SOC2) and MITRE ATT&CK techniques.
+
+        Supports filtering by suppression state to view which findings have been
+        accepted as risk, marked as false positives, or have compensating controls.
+
+        IMPORTANT: You must use the `falcon://cloud/cspm-iom-findings/fql-guide` resource
+        when you need to use the `filter` parameter.
+
+        Returns a list of IOM finding entities with nested structure:
+        - id: Unique finding identifier
+        - cloud: {account_id, account_name, provider, region}
+        - evaluation: {severity, status, attack_types, rule, created, url}
+        - resource: {resource_id, resource_type, service, service_category}
+
+        Returns FQL syntax guide on error or empty results to help refine queries.
+        """
+        # Step 1: Query for IOM IDs
+        iom_ids = self._base_search_api_call(
+            operation="cspm_evaluations_iom_queries",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+            },
+            error_message="Failed to query IOM findings",
+        )
+
+        # Handle search error - return with FQL guide
+        if self._is_error(iom_ids):
+            return self._format_fql_error_response(
+                [iom_ids],
+                filter,
+                CSPM_IOM_FINDINGS_FQL_DOCUMENTATION,
+            )
+
+        # Handle empty results - return with FQL guide
+        if not iom_ids:
+            return self._format_fql_error_response(
+                [],
+                filter,
+                CSPM_IOM_FINDINGS_FQL_DOCUMENTATION,
+            )
+
+        # Step 2: Fetch full IOM entity details (GET with query params, max 100 per call)
+        return self._batch_get_iom_entities(iom_ids)
+
+    def _batch_get_iom_entities(self, iom_ids: list[str]) -> list[dict[str, Any]] | dict[str, Any]:
+        """Fetch IOM entity details in batches of 100 (API limit).
+
+        Args:
+            iom_ids: List of IOM finding IDs to fetch
+
+        Returns:
+            List of IOM entity details or error dict
+        """
+        BATCH_SIZE = 100
+        all_entities: list[dict[str, Any]] = []
+
+        for i in range(0, len(iom_ids), BATCH_SIZE):
+            batch = iom_ids[i : i + BATCH_SIZE]
+            result = self._base_get_by_ids(
+                operation="cspm_evaluations_iom_entities",
+                ids=batch,
+                id_key="ids",
+                use_params=True,
+            )
+
+            if self._is_error(result):
+                return result
+
+            if isinstance(result, list):
+                all_entities.extend(result)
+
+        return all_entities
+
+    def search_ioa_findings(
+        self,
+        cloud_provider: str = Field(
+            description=(
+                "Cloud provider to search for IOA events. Required."
+                " Values: 'aws', 'azure', 'gcp'."
+            ),
+            examples=["aws", "azure", "gcp"],
+        ),
+        since: str = Field(
+            default="24h",
+            description=(
+                "Time window for IOA events as a duration string."
+                " Default: '24h'. Examples: '1h', '12h', '24h', '168h' (7 days)."
+            ),
+            examples=["1h", "12h", "24h", "168h"],
+        ),
+        severity: str | None = Field(
+            default=None,
+            description=(
+                "Filter by severity level."
+                " Values: 'Critical', 'High', 'Medium', 'Informational'."
+            ),
+            examples=["Critical", "High", "Medium"],
+        ),
+        state: str | None = Field(
+            default=None,
+            description="Filter by event state. Values: 'open', 'closed'.",
+            examples=["open", "closed"],
+        ),
+        service: str | None = Field(
+            default=None,
+            description=dedent(
+                """
+                Filter by cloud service. Examples: EC2, S3, IAM, Lambda, VPC,
+                KeyVault, Compute Engine, Cloud Storage, BigQuery.
+                See the full list of supported services in CrowdStrike documentation.
+            """
+            ).strip(),
+            examples=["EC2", "S3", "IAM", "Lambda"],
+        ),
+        account_id: str | None = Field(
+            default=None,
+            description=(
+                "Filter by cloud account ID"
+                " (AWS Account ID, Azure Subscription ID, GCP Project ID)."
+            ),
+        ),
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=500,
+            description="Maximum number of IOA events to return (default: 100; max: 500).",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search for CSPM Indicators of Attack (IOA) behavior detections.
+
+        Retrieves cloud security behavior detections that identify active attack
+        patterns in your cloud environment. IOAs detect runtime threats like
+        unauthorized API calls, suspicious credential usage, and lateral movement.
+
+        NOTE: This tool uses direct parameter filtering, NOT FQL. Pass parameters
+        directly rather than building a filter query string.
+
+        Returns a list of IOA event objects with cloud context including event type,
+        severity, cloud provider details, and associated resource information.
+        Returns an empty list if no events match the criteria.
+
+        Requires at least the cloud_provider parameter.
+        """
+        params = prepare_api_parameters(
+            {
+                "cloud_provider": cloud_provider,
+                "since": since,
+                "severity": severity,
+                "state": state,
+                "service": service,
+                "account_id": account_id,
+                "limit": limit,
+            }
+        )
+
+        response = self.client.command("GetBehaviorDetections", parameters=params)
+
+        return handle_api_response(
+            response,
+            operation="GetBehaviorDetections",
+            error_message="Failed to search IOA findings",
+            default_result=[],
+        )
+
+    def search_cspm_suppression_rules(
+        self,
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=500,
+            description="Maximum number of suppression rules to return (default: 100; max: 500).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index for pagination.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search for CSPM IOM suppression rules.
+
+        Lists suppression rules that control which IOM findings are suppressed.
+        Suppression rules define which rules and assets are excluded from generating
+        active findings, along with the reason and optional expiration date.
+
+        Use this to review existing suppressions before creating new ones.
+
+        Returns a list of suppression rule objects containing: id, name, domain,
+        subdomain, disabled, rule_selection_type, scope_type, suppression_reason,
+        created_at, created_by. Returns an empty list if no rules exist.
+        """
+        # Step 1: Query suppression rule IDs
+        params = prepare_api_parameters({"limit": limit, "offset": offset})
+        query_response = self.client.command(
+            "QuerySuppressionRules",
+            override="GET,/cloud-policies/queries/suppression-rules/v1",
+            parameters=params,
+        )
+
+        query_result = handle_api_response(
+            query_response,
+            operation="QuerySuppressionRules",
+            error_message="Failed to query suppression rules",
+            default_result=[],
+        )
+
+        if self._is_error(query_result):
+            return query_result
+
+        if not query_result:
+            return []
+
+        # Step 2: Fetch suppression rule details
+        detail_params = prepare_api_parameters({"ids": query_result})
+        detail_response = self.client.command(
+            "GetSuppressionRules",
+            override="GET,/cloud-policies/entities/suppression-rules/v1",
+            parameters=detail_params,
+        )
+
+        return handle_api_response(
+            detail_response,
+            operation="GetSuppressionRules",
+            error_message="Failed to get suppression rule details",
+            default_result=[],
+        )
+
+    def create_cspm_suppression_rule(
+        self,
+        name: str = Field(
+            description="Name for the suppression rule. Should be descriptive.",
+            examples=["Suppress S3 public access for dev accounts"],
+        ),
+        suppression_reason: str = Field(
+            description=(
+                "Reason for suppression. Required."
+                " Values: 'accept-risk', 'compensating-control', 'false-positive'."
+            ),
+            examples=["accept-risk", "compensating-control", "false-positive"],
+        ),
+        rule_ids: list[str] | None = Field(
+            default=None,
+            description=(
+                "Specific rule IDs to suppress."
+                " If not provided, use rule_severities or rule_names to scope."
+            ),
+        ),
+        rule_names: list[str] | None = Field(
+            default=None,
+            description="Rule names to suppress (supports wildcards).",
+        ),
+        rule_severities: list[str] | None = Field(
+            default=None,
+            description=(
+                "Rule severities to suppress."
+                " Values: 'critical', 'high', 'medium', 'low', 'informational'."
+            ),
+        ),
+        cloud_providers: list[str] | None = Field(
+            default=None,
+            description=(
+                "Limit suppression to specific cloud providers."
+                " Values: 'aws', 'azure', 'gcp'."
+            ),
+        ),
+        account_ids: list[str] | None = Field(
+            default=None,
+            description="Limit suppression to specific cloud account IDs.",
+        ),
+        regions: list[str] | None = Field(
+            default=None,
+            description=(
+                "Limit suppression to specific cloud regions."
+                " Ex: ['us-east-1', 'eu-west-1']."
+            ),
+        ),
+        resource_ids: list[str] | None = Field(
+            default=None,
+            description="Limit suppression to specific resource IDs.",
+        ),
+        resource_types: list[str] | None = Field(
+            default=None,
+            description=(
+                "Limit suppression to specific resource types."
+                " Ex: ['AWS::S3::Bucket']."
+            ),
+        ),
+        expiration_date: str | None = Field(
+            default=None,
+            description=(
+                "Optional expiration date in RFC 3339 format"
+                " (e.g., '2025-12-31T23:59:59Z')."
+                " WARNING: Omitting this creates a PERMANENT suppression."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Create a CSPM IOM suppression rule to suppress matching findings.
+
+        WARNING: This creates a suppression rule that will hide matching IOM findings
+        from compliance scores and active finding views. Suppressed findings are still
+        assessed but not surfaced. Use carefully and prefer narrow scope.
+
+        A suppression rule defines:
+        - WHICH rules to suppress (by ID, name, or severity)
+        - WHICH assets to suppress them for (by cloud provider, account, region, resource)
+        - WHY (accept-risk, compensating-control, false-positive)
+        - WHEN it expires (strongly recommended)
+
+        Requires the modern 'Cloud Security Posture Rules' mode (not legacy policies).
+
+        Returns the created suppression rule object on success, or an error dict
+        with details on failure.
+        """
+        valid_reasons = {"accept-risk", "compensating-control", "false-positive"}
+        if suppression_reason not in valid_reasons:
+            return {
+                "error": f"Invalid suppression_reason: '{suppression_reason}'",
+                "details": f"Must be one of: {', '.join(sorted(valid_reasons))}",
+            }
+
+        # Build rule selection filter
+        rule_filter: dict[str, Any] = {}
+        if rule_ids:
+            rule_filter["rule_ids"] = rule_ids
+        if rule_names:
+            rule_filter["rule_names"] = rule_names
+        if rule_severities:
+            rule_filter["rule_severities"] = rule_severities
+        if not rule_filter:
+            return {
+                "error": "At least one rule selection parameter is required",
+                "details": "Provide rule_ids, rule_names, or rule_severities to scope the suppression.",
+            }
+
+        # Build asset scope filter
+        asset_filter: dict[str, Any] = {}
+        if cloud_providers:
+            asset_filter["cloud_providers"] = cloud_providers
+        if account_ids:
+            asset_filter["account_ids"] = account_ids
+        if regions:
+            asset_filter["regions"] = regions
+        if resource_ids:
+            asset_filter["resource_ids"] = resource_ids
+        if resource_types:
+            asset_filter["resource_types"] = resource_types
+
+        # Build the flat suppression rule body
+        body: dict[str, Any] = {
+            "name": name,
+            "domain": "CSPM",
+            "subdomain": "IOM",
+            "suppression_reason": suppression_reason,
+            "rule_selection_type": "rule_selection_filter",
+            "rule_selection_filter": rule_filter,
+            "scope_type": "asset_filter" if asset_filter else "all_assets",
+        }
+
+        if asset_filter:
+            body["scope_asset_filter"] = asset_filter
+
+        if expiration_date:
+            body["suppression_expiration_date"] = expiration_date
+
+        response = self.client.command(
+            "CreateSuppressionRule",
+            override="POST,/cloud-policies/entities/suppression-rules/v1",
+            body=body,
+        )
+
+        return handle_api_response(
+            response,
+            operation="CreateSuppressionRule",
+            error_message="Failed to create suppression rule",
+            default_result=[],
+        )
+
+    def delete_cspm_suppression_rules(
+        self,
+        ids: list[str] = Field(
+            description=(
+                "List of suppression rule IDs to delete."
+                " Use falcon_search_cspm_suppression_rules to find rule IDs."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Delete CSPM IOM suppression rules by ID.
+
+        WARNING: Deleting a suppression rule will re-activate all findings that were
+        previously suppressed by that rule. They will appear as open findings again.
+
+        Use falcon_search_cspm_suppression_rules first to identify which rules to delete.
+
+        Returns a confirmation response on success, or an error dict on failure.
+        """
+        params = prepare_api_parameters({"ids": ids})
+        response = self.client.command(
+            "DeleteSuppressionRules",
+            override="DELETE,/cloud-policies/entities/suppression-rules/v1",
+            parameters=params,
+        )
+
+        return handle_api_response(
+            response,
+            operation="DeleteSuppressionRules",
+            error_message="Failed to delete suppression rules",
+            default_result=[],
+        )

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -71,12 +71,6 @@ class CloudModule(BaseModule):
 
         self._add_tool(
             server=server,
-            method=self.search_ioa_findings,
-            name="search_ioa_findings",
-        )
-
-        self._add_tool(
-            server=server,
             method=self.search_cspm_suppression_rules,
             name="search_cspm_suppression_rules",
         )
@@ -658,97 +652,6 @@ class CloudModule(BaseModule):
                 all_entities.extend(result)
 
         return all_entities
-
-    def search_ioa_findings(
-        self,
-        cloud_provider: str = Field(
-            description=(
-                "Cloud provider to search for IOA events. Required."
-                " Values: 'aws', 'azure', 'gcp'."
-            ),
-            examples=["aws", "azure", "gcp"],
-        ),
-        since: str = Field(
-            default="24h",
-            description=(
-                "Time window for IOA events as a duration string."
-                " Default: '24h'. Examples: '1h', '12h', '24h', '168h' (7 days)."
-            ),
-            examples=["1h", "12h", "24h", "168h"],
-        ),
-        severity: str | None = Field(
-            default=None,
-            description=(
-                "Filter by severity level."
-                " Values: 'Critical', 'High', 'Medium', 'Informational'."
-            ),
-            examples=["Critical", "High", "Medium"],
-        ),
-        state: str | None = Field(
-            default=None,
-            description="Filter by event state. Values: 'open', 'closed'.",
-            examples=["open", "closed"],
-        ),
-        service: str | None = Field(
-            default=None,
-            description=dedent(
-                """
-                Filter by cloud service. Examples: EC2, S3, IAM, Lambda, VPC,
-                KeyVault, Compute Engine, Cloud Storage, BigQuery.
-                See the full list of supported services in CrowdStrike documentation.
-            """
-            ).strip(),
-            examples=["EC2", "S3", "IAM", "Lambda"],
-        ),
-        account_id: str | None = Field(
-            default=None,
-            description=(
-                "Filter by cloud account ID"
-                " (AWS Account ID, Azure Subscription ID, GCP Project ID)."
-            ),
-        ),
-        limit: int = Field(
-            default=100,
-            ge=1,
-            le=500,
-            description="Maximum number of IOA events to return (default: 100; max: 500).",
-        ),
-    ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Search for CSPM Indicators of Attack (IOA) behavior detections.
-
-        Retrieves cloud security behavior detections that identify active attack
-        patterns in your cloud environment. IOAs detect runtime threats like
-        unauthorized API calls, suspicious credential usage, and lateral movement.
-
-        NOTE: This tool uses direct parameter filtering, NOT FQL. Pass parameters
-        directly rather than building a filter query string.
-
-        Returns a list of IOA event objects with cloud context including event type,
-        severity, cloud provider details, and associated resource information.
-        Returns an empty list if no events match the criteria.
-
-        Requires at least the cloud_provider parameter.
-        """
-        params = prepare_api_parameters(
-            {
-                "cloud_provider": cloud_provider,
-                "since": since,
-                "severity": severity,
-                "state": state,
-                "service": service,
-                "account_id": account_id,
-                "limit": limit,
-            }
-        )
-
-        response = self.client.command("GetBehaviorDetections", parameters=params)
-
-        return handle_api_response(
-            response,
-            operation="GetBehaviorDetections",
-            error_message="Failed to search IOA findings",
-            default_result=[],
-        )
 
     def search_cspm_suppression_rules(
         self,

--- a/falcon_mcp/resources/cloud.py
+++ b/falcon_mcp/resources/cloud.py
@@ -838,6 +838,311 @@ SEARCH_CSPM_ASSETS_FQL_FILTERS = [
     ),
 ]
 
+CSPM_IOM_FINDINGS_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Description"
+    ),
+    (
+        "account_id",
+        "String",
+        """
+        The cloud provider account ID.
+
+        Ex: account_id:'123456789012'
+        """
+    ),
+    (
+        "account_name",
+        "String",
+        """
+        The cloud provider account name.
+
+        Ex: account_name:'production-account'
+        """
+    ),
+    (
+        "cloud_provider",
+        "String",
+        """
+        The cloud provider. Values: aws, azure, gcp.
+
+        Ex: cloud_provider:'aws'
+        Ex: cloud_provider:['aws', 'azure']
+        """
+    ),
+    (
+        "severity",
+        "String",
+        """
+        The severity of the misconfiguration finding.
+        Values: critical, high, medium, low, informational.
+
+        Ex: severity:'critical'
+        Ex: severity:['critical', 'high']
+        """
+    ),
+    (
+        "status",
+        "String",
+        """
+        The status of the finding.
+        Values: open, suppressed, pass.
+
+        Ex: status:'open'
+        """
+    ),
+    (
+        "service",
+        "String",
+        """
+        The cloud service (e.g., EC2, S3, IAM, KeyVault, Compute Engine).
+
+        Ex: service:'S3'
+        Ex: service:'IAM'
+        """
+    ),
+    (
+        "service_category",
+        "String",
+        """
+        Broader service category.
+        Examples: Compute, Storage, Networking, Identity.
+
+        Ex: service_category:'Identity'
+        """
+    ),
+    (
+        "region",
+        "String",
+        """
+        The cloud region where the finding was detected.
+
+        Ex: region:'us-east-1'
+        Ex: region:['us-east-1', 'eu-west-1']
+        """
+    ),
+    (
+        "resource_id",
+        "String",
+        """
+        The unique identifier of the affected resource.
+
+        Ex: resource_id:'arn:aws:s3:::my-bucket'
+        """
+    ),
+    (
+        "resource_type",
+        "String",
+        """
+        The type of cloud resource affected.
+
+        Ex: resource_type:'AWS::S3::Bucket'
+        Ex: resource_type:*'*EC2*'
+        """
+    ),
+    (
+        "resource_type_name",
+        "String",
+        """
+        Human-readable resource type name.
+
+        Ex: resource_type_name:'S3 Bucket'
+        """
+    ),
+    (
+        "rule_name",
+        "String",
+        """
+        The name of the misconfiguration rule that triggered the finding.
+
+        Ex: rule_name:*'*encryption*'
+        Ex: rule_name:*'*public*'
+        """
+    ),
+    (
+        "rule_id",
+        "String",
+        """
+        The unique rule identifier.
+
+        Ex: rule_id:'CS-001'
+        """
+    ),
+    (
+        "policy_name",
+        "String",
+        """
+        The policy name containing the rule.
+
+        Ex: policy_name:*'*CIS*'
+        """
+    ),
+    (
+        "policy_id",
+        "String",
+        """
+        The policy identifier.
+
+        Ex: policy_id:'123'
+        """
+    ),
+    (
+        "benchmark_name",
+        "String",
+        """
+        Compliance benchmark name (e.g., CIS, NIST, SOC2).
+
+        Ex: benchmark_name:*'*CIS*'
+        """
+    ),
+    (
+        "framework",
+        "String",
+        """
+        Compliance framework the finding maps to.
+
+        Ex: framework:'CIS'
+        """
+    ),
+    (
+        "attack_type",
+        "String",
+        """
+        MITRE ATT&CK attack type classification.
+
+        Ex: attack_type:*'*credential*'
+        """
+    ),
+    (
+        "tactic_name",
+        "String",
+        """
+        MITRE ATT&CK tactic name.
+
+        Ex: tactic_name:'Credential Access'
+        """
+    ),
+    (
+        "technique_name",
+        "String",
+        """
+        MITRE ATT&CK technique name.
+
+        Ex: technique_name:*'*Brute Force*'
+        """
+    ),
+    (
+        "first_detected",
+        "Timestamp",
+        """
+        When the finding was first detected in UTC format.
+
+        Ex: first_detected:>'2025-01-01T00:00:00Z'
+        """
+    ),
+    (
+        "last_detected",
+        "Timestamp",
+        """
+        When the finding was last detected in UTC format.
+
+        Ex: last_detected:>'2025-04-01T00:00:00Z'
+        """
+    ),
+    (
+        "suppressed_by",
+        "String",
+        """
+        The user or rule that suppressed this finding.
+
+        Ex: suppressed_by:*'*admin*'
+        """
+    ),
+    (
+        "suppression_reason",
+        "String",
+        """
+        The reason the finding was suppressed.
+        Values: accept-risk, compensating-control, false-positive.
+
+        Ex: suppression_reason:'accept-risk'
+        """
+    ),
+    (
+        "tag_key",
+        "String",
+        """
+        Cloud resource tag key.
+
+        Ex: tag_key:'Environment'
+        """
+    ),
+    (
+        "tag_value",
+        "String",
+        """
+        Cloud resource tag value.
+
+        Ex: tag_value:'Production'
+        """
+    ),
+    (
+        "cloud_group",
+        "String",
+        """
+        Cloud group identifier for organizational grouping.
+
+        Ex: cloud_group:'prod-group'
+        """
+    ),
+]
+
+CSPM_IOM_FINDINGS_FQL_DOCUMENTATION = (
+    FQL_DOCUMENTATION
+    + """
+=== falcon_search_iom_findings FQL filter available fields ===
+
+""" + generate_md_table(CSPM_IOM_FINDINGS_FQL_FILTERS) + """
+
+=== falcon_search_iom_findings FQL filter examples ===
+
+# Find critical and high severity open findings
+severity:['critical', 'high']+status:'open'
+
+# Find open findings in AWS for a specific service
+cloud_provider:'aws'+service:'S3'+status:'open'
+
+# Find findings detected in the last 7 days
+first_detected:>'2025-05-05T00:00:00Z'+status:'open'
+
+# Find IAM-related misconfigurations across all clouds
+service_category:'Identity'+severity:['critical', 'high']
+
+# Find findings for a specific rule by name
+rule_name:*'*encryption*'+status:'open'
+
+# Find suppressed findings with a specific reason
+status:'suppressed'+suppression_reason:'accept-risk'
+
+# Find findings mapped to CIS benchmark
+benchmark_name:*'*CIS*'+severity:'critical'
+
+# Find findings for specific cloud accounts
+account_id:['123456789012', '987654321098']+status:'open'
+
+# Find findings by MITRE ATT&CK tactic
+tactic_name:'Credential Access'+severity:['critical', 'high']
+
+# Find findings in specific regions
+region:['us-east-1', 'eu-west-1']+cloud_provider:'aws'+status:'open'
+
+# Find findings by resource tag
+tag_key:'Environment'+tag_value:'Production'+severity:'critical'
+"""
+)
+
 SEARCH_CSPM_ASSETS_FQL_DOCUMENTATION = (
     FQL_DOCUMENTATION
     + """

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -68,6 +68,27 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     "falcon_search_cspm_assets": [
         "Find all AWS EC2 instances in my cloud inventory",
     ],
+    "falcon_search_iom_findings": [
+        "Show me critical open CSPM findings in AWS",
+        "Find misconfiguration findings for S3 buckets",
+        "What IOM findings are suppressed as accepted risk?",
+    ],
+    "falcon_search_ioa_findings": [
+        "Show me IOA events in AWS from the last 24 hours",
+        "Are there any critical IOA detections in Azure?",
+    ],
+    "falcon_search_cspm_suppression_rules": [
+        "Show me all CSPM suppression rules",
+        "What findings are being suppressed and why?",
+    ],
+    "falcon_create_cspm_suppression_rule": [
+        "Suppress that S3 encryption finding in the dev account as accepted risk",
+        "Create a suppression rule for the IAM password policy finding as false positive",
+    ],
+    "falcon_delete_cspm_suppression_rules": [
+        "Delete the suppression rule we just created",
+        "Remove suppression rule abc-123",
+    ],
     # Custom IOA
     "falcon_search_ioa_rule_groups": [
         "Find enabled Windows Custom IOA rule groups",

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -73,10 +73,6 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
         "Find IOM findings for S3 buckets with public access",
         "What CSPM IOM findings are suppressed as accepted risk?",
     ],
-    "falcon_search_ioa_findings": [
-        "Show me CSPM IOA behavior detections in AWS from the last 24 hours",
-        "Are there any critical cloud IOA detections in Azure?",
-    ],
     "falcon_search_cspm_suppression_rules": [
         "List all CSPM IOM suppression rules and their reasons",
         "Show me which CSPM findings are being suppressed and why",

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -69,25 +69,25 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
         "Find all AWS EC2 instances in my cloud inventory",
     ],
     "falcon_search_iom_findings": [
-        "Show me critical open CSPM findings in AWS",
-        "Find misconfiguration findings for S3 buckets",
-        "What IOM findings are suppressed as accepted risk?",
+        "Show me critical open CSPM misconfiguration findings in AWS",
+        "Find IOM findings for S3 buckets with public access",
+        "What CSPM IOM findings are suppressed as accepted risk?",
     ],
     "falcon_search_ioa_findings": [
-        "Show me IOA events in AWS from the last 24 hours",
-        "Are there any critical IOA detections in Azure?",
+        "Show me CSPM IOA behavior detections in AWS from the last 24 hours",
+        "Are there any critical cloud IOA detections in Azure?",
     ],
     "falcon_search_cspm_suppression_rules": [
-        "Show me all CSPM suppression rules",
-        "What findings are being suppressed and why?",
+        "List all CSPM IOM suppression rules and their reasons",
+        "Show me which CSPM findings are being suppressed and why",
     ],
     "falcon_create_cspm_suppression_rule": [
-        "Suppress that S3 encryption finding in the dev account as accepted risk",
-        "Create a suppression rule for the IAM password policy finding as false positive",
+        "Create a CSPM suppression rule for the S3 encryption finding in the dev account as accepted risk",
+        "Suppress the IAM password policy IOM finding as a false positive, expiring in 30 days",
     ],
     "falcon_delete_cspm_suppression_rules": [
-        "Delete the suppression rule we just created",
-        "Remove suppression rule abc-123",
+        "Delete CSPM suppression rule abc-123",
+        "Remove the CSPM IOM suppression rule for the S3 public access finding",
     ],
     # Custom IOA
     "falcon_search_ioa_rule_groups": [

--- a/tests/integration/test_cloud.py
+++ b/tests/integration/test_cloud.py
@@ -1,5 +1,7 @@
 """Integration tests for the Cloud module."""
 
+import time
+
 import pytest
 
 from falcon_mcp.modules.cloud import CloudModule
@@ -125,7 +127,21 @@ class TestCloudIntegration(BaseIntegrationTest):
 
         # Test cloud_security_assets_queries and cloud_security_assets_entities_get
         result = self.call_method(self.module.search_cspm_assets, limit=1)
-        self.assert_no_error(result, context="CSPM operation names")
+        self.assert_no_error(result, context="CSPM asset operation names")
+
+        # Test cspm_evaluations_iom_queries and cspm_evaluations_iom_entities
+        result = self.call_method(self.module.search_iom_findings, limit=1)
+        self.assert_no_error(result, context="IOM operation names")
+
+        # Test GetBehaviorDetections
+        result = self.call_method(
+            self.module.search_ioa_findings, cloud_provider="aws", limit=1
+        )
+        self.assert_no_error(result, context="GetBehaviorDetections operation name")
+
+        # Test suppression rules override endpoints
+        result = self.call_method(self.module.search_cspm_suppression_rules, limit=1)
+        self.assert_no_error(result, context="Suppression rules override operation names")
 
     def test_search_cspm_assets_returns_details(self):
         """Test that search_cspm_assets returns full asset details using two-step pattern.
@@ -210,4 +226,177 @@ class TestCloudIntegration(BaseIntegrationTest):
         # If we got >100 results, batching was tested successfully
         if len(result) > 100:
             print(f"✅ Batching tested successfully with {len(result)} assets")
+
+    # --- IOM Findings Integration Tests ---
+
+    def test_search_iom_findings_returns_details(self):
+        """Test that search_iom_findings returns full IOM entity details.
+
+        Validates:
+        - cspm_evaluations_iom_queries operation name is correct
+        - cspm_evaluations_iom_entities operation name is correct
+        - Two-step pattern returns full details, not just IDs
+        """
+        result = self.call_method(self.module.search_iom_findings, limit=5)
+
+        self.assert_no_error(result, context="search_iom_findings")
+        self.assert_valid_list_response(result, min_length=0, context="search_iom_findings")
+
+        if len(result) > 0:
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["id", "cid", "cloud", "evaluation", "resource"],
+                context="search_iom_findings full details",
+            )
+
+    def test_search_iom_findings_with_severity_filter(self):
+        """Test search_iom_findings with severity FQL filter."""
+        result = self.call_method(
+            self.module.search_iom_findings,
+            filter="severity:'critical'",
+            limit=3,
+        )
+
+        # May return list of results or FQL guide dict if no critical findings exist
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result, min_length=0, context="search_iom_findings with severity filter"
+            )
+        else:
+            # FQL guide response on empty results is valid
+            assert isinstance(result, dict), "Expected dict or list response"
+
+    def test_search_iom_findings_with_cloud_provider_filter(self):
+        """Test search_iom_findings filtering by cloud provider."""
+        result = self.call_method(
+            self.module.search_iom_findings,
+            filter="cloud_provider:'aws'",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="search_iom_findings with cloud_provider filter")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_iom_findings cloud_provider filter"
+        )
+
+    def test_search_iom_findings_with_sort(self):
+        """Test search_iom_findings with sort parameter."""
+        result = self.call_method(
+            self.module.search_iom_findings,
+            sort="severity|desc",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="search_iom_findings with sort")
+        self.assert_valid_list_response(result, min_length=0, context="search_iom_findings with sort")
+
+    def test_search_iom_findings_batching(self):
+        """Test search_iom_findings with larger limit to verify batching."""
+        result = self.call_method(self.module.search_iom_findings, limit=200)
+
+        self.assert_no_error(result, context="search_iom_findings batching")
+        self.assert_valid_list_response(result, min_length=0, context="search_iom_findings batching")
+
+        if len(result) > 100:
+            print(f"✅ IOM batching tested successfully with {len(result)} findings")
+
+    # --- IOA Findings Integration Tests ---
+
+    def test_search_ioa_findings_aws(self):
+        """Test search_ioa_findings for AWS cloud provider.
+
+        Validates GetBehaviorDetections operation name is correct.
+        IOA results may be empty if no recent events exist.
+        """
+        result = self.call_method(
+            self.module.search_ioa_findings,
+            cloud_provider="aws",
+            since="24h",
+            limit=5,
+        )
+
+        self.assert_no_error(result, context="search_ioa_findings aws")
+        # IOA results may be a list or may come as events dict
+        if isinstance(result, list):
+            self.assert_valid_list_response(result, min_length=0, context="search_ioa_findings aws")
+
+    def test_search_ioa_findings_with_severity(self):
+        """Test search_ioa_findings with severity filter."""
+        result = self.call_method(
+            self.module.search_ioa_findings,
+            cloud_provider="aws",
+            severity="High",
+            since="168h",
+            limit=5,
+        )
+
+        self.assert_no_error(result, context="search_ioa_findings with severity")
+
+    # --- Suppression Rules Integration Tests ---
+
+    def test_search_suppression_rules(self):
+        """Test search_cspm_suppression_rules returns rule details.
+
+        Validates the override endpoint pattern works correctly.
+        May return empty if no suppression rules exist in the environment.
+        """
+        result = self.call_method(self.module.search_cspm_suppression_rules, limit=5)
+
+        self.assert_no_error(result, context="search_cspm_suppression_rules")
+        self.assert_valid_list_response(result, min_length=0, context="search_cspm_suppression_rules")
+
+        if len(result) > 0:
+            first_rule = result[0]
+            assert isinstance(first_rule, dict), "Expected dict items for suppression rules"
+            print(f"✅ Found {len(result)} suppression rule(s). Fields: {list(first_rule.keys())}")
+
+    def test_create_and_delete_suppression_rule_roundtrip(self):
+        """Test creating and deleting a suppression rule (full roundtrip).
+
+        Creates a narrowly-scoped suppression rule with a short expiration,
+        verifies it was created, then deletes it to clean up.
+        """
+        # Create a narrowly-scoped test rule with unique name
+        rule_name = f"falcon-mcp-test-{int(time.time())}"
+        create_result = self.call_method(
+            self.module.create_cspm_suppression_rule,
+            name=rule_name,
+            suppression_reason="false-positive",
+            rule_names=["integration-test-nonexistent-rule"],
+            rule_ids=None,
+            rule_severities=None,
+            cloud_providers=["aws"],
+            account_ids=None,
+            regions=["us-east-1"],
+            resource_ids=None,
+            resource_types=None,
+            expiration_date="2027-01-01T00:00:00Z",
+        )
+
+        self.assert_no_error(create_result, context="create_cspm_suppression_rule")
+
+        # Extract the created rule ID for cleanup
+        # API returns IDs as strings in a list: ["uuid-here"]
+        rule_id = None
+        if isinstance(create_result, list) and len(create_result) > 0:
+            first = create_result[0]
+            if isinstance(first, str):
+                rule_id = first
+            elif isinstance(first, dict):
+                rule_id = first.get("id")
+            print(f"✅ Created suppression rule: {rule_id}")
+        elif isinstance(create_result, dict) and "id" in create_result:
+            rule_id = create_result["id"]
+            print(f"✅ Created suppression rule: {rule_id}")
+
+        # Clean up: delete the rule we just created
+        if rule_id:
+            delete_result = self.call_method(
+                self.module.delete_cspm_suppression_rules,
+                ids=[rule_id],
+            )
+            self.assert_no_error(delete_result, context="delete_cspm_suppression_rules")
+            print(f"✅ Deleted suppression rule: {rule_id}")
+        else:
+            print("⚠️  Could not extract rule ID from create response, skipping delete")
 

--- a/tests/integration/test_cloud.py
+++ b/tests/integration/test_cloud.py
@@ -133,12 +133,6 @@ class TestCloudIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_iom_findings, limit=1)
         self.assert_no_error(result, context="IOM operation names")
 
-        # Test GetBehaviorDetections
-        result = self.call_method(
-            self.module.search_ioa_findings, cloud_provider="aws", limit=1
-        )
-        self.assert_no_error(result, context="GetBehaviorDetections operation name")
-
         # Test suppression rules override endpoints
         result = self.call_method(self.module.search_cspm_suppression_rules, limit=1)
         self.assert_no_error(result, context="Suppression rules override operation names")
@@ -299,38 +293,6 @@ class TestCloudIntegration(BaseIntegrationTest):
 
         if len(result) > 100:
             print(f"✅ IOM batching tested successfully with {len(result)} findings")
-
-    # --- IOA Findings Integration Tests ---
-
-    def test_search_ioa_findings_aws(self):
-        """Test search_ioa_findings for AWS cloud provider.
-
-        Validates GetBehaviorDetections operation name is correct.
-        IOA results may be empty if no recent events exist.
-        """
-        result = self.call_method(
-            self.module.search_ioa_findings,
-            cloud_provider="aws",
-            since="24h",
-            limit=5,
-        )
-
-        self.assert_no_error(result, context="search_ioa_findings aws")
-        # IOA results may be a list or may come as events dict
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_ioa_findings aws")
-
-    def test_search_ioa_findings_with_severity(self):
-        """Test search_ioa_findings with severity filter."""
-        result = self.call_method(
-            self.module.search_ioa_findings,
-            cloud_provider="aws",
-            severity="High",
-            since="168h",
-            limit=5,
-        )
-
-        self.assert_no_error(result, context="search_ioa_findings with severity")
 
     # --- Suppression Rules Integration Tests ---
 

--- a/tests/modules/test_cloud.py
+++ b/tests/modules/test_cloud.py
@@ -327,6 +327,156 @@ class TestCloudModule(TestModules):
         self.assertIn("parameters", second_call[1])
         self.assertNotIn("body", second_call[1])
 
+    def test_search_cspm_assets_trims_bloated_fields(self):
+        """Test CSPM assets strips large fields to reduce response size."""
+        bloated_asset = {
+            "id": "cid|aws|123|us-east-1|AWS::EC2::Instance|i-abc",
+            "arn": "arn:aws:ec2:us-east-1:123:instance/i-abc",
+            "resource_id": "i-abc",
+            "resource_name": "my-instance",
+            "resource_type": "AWS::EC2::Instance",
+            "resource_type_name": "EC2 Instance",
+            "account_id": "123456789012",
+            "account_name": "production",
+            "region": "us-east-1",
+            "zone": "us-east-1a",
+            "cloud_provider": "aws",
+            "service": "EC2",
+            "service_category": "Compute",
+            "active": True,
+            "first_seen": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-03-01T00:00:00Z",
+            "creation_time": "2025-01-01T00:00:00Z",
+            "tags": {"Environment": "Production"},
+            "resource_url": "https://console.aws.amazon.com/ec2/...",
+            "relationships": [{"type": "vpc", "id": "vpc-123"}],
+            # Fields that should be REMOVED:
+            "gcrn": "cid|aws|123|us-east-1|AWS::EC2::Instance|i-abc",
+            "cid": "5ddb0407bef249c19c7a975f17979a1f",
+            "hash": "a8fc79d611a11b1a01a4e9a235c3834c",
+            "revision": 5,
+            "configuration": '{"instanceId":"i-abc","instanceType":"m5.large"}',
+            "supplementary_configuration": '{"vpcId":"vpc-123","subnetId":"subnet-456"}',
+            "cloud_context": {
+                "cspm_license": "cspm",
+                "publicly_exposed": True,
+                "managed_by": "Sensor",
+                "has_tags": True,
+                "instance_id": "i-abc",
+                "instance_state": "running",
+                "open_cloud_risks": 3,
+                "scan_type": "resource",
+                "data_classifications": {"scanned": True, "found": False},
+                "host": {
+                    "managed_by": "Sensor",
+                    "platform_name": "Linux",
+                    "platform_os_name": "Amazon Linux",
+                    "platform_os_version": "2023",
+                },
+                "detections": {
+                    "iom_counts": 5,
+                    "ioa_counts": 1,
+                    "severities": ["high", "medium"],
+                    "highest_severity": "high",
+                    "resource_url": "https://console.aws.amazon.com/ec2/...",
+                    "compliant": {
+                        "rules": ["rule-1", "rule-2"] * 50,
+                        "controls": [{"benchmark": "CIS", "version": "1.4"}] * 20,
+                        "benchmarkVersions": None,
+                        "legacy_policy_ids": ["pol-1", "pol-2"],
+                    },
+                    "non_compliant": {
+                        "rules": ["rule-x"] * 10,
+                        "controls": [{"benchmark": "NIST", "section": "5.1"}] * 15,
+                        "benchmarkVersions": None,
+                        "legacy_policy_ids": ["pol-3"],
+                    },
+                },
+                "insights": {
+                    "external": [
+                        {"id": "imdsv1Enabled", "ruleId": "r1", "booleanValue": True},
+                        {"id": "hasPublicIp", "ruleId": "r2", "booleanValue": False},
+                    ],
+                    "details": {"verbose": "data" * 100},
+                },
+                "asset_graph": {"id": "graph-123", "res_id": "ec2.Instance"},
+                "legacy_resource_id": "i-abc",
+                "legacy_uuid": "some-long-uuid-string",
+                "legacy_type_id": 1,
+                "account_name": "production",
+            },
+        }
+
+        query_response = {"status_code": 200, "body": {"resources": ["asset_1"]}}
+        get_response = {"status_code": 200, "body": {"resources": [bloated_asset]}}
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_cspm_assets(limit=1)
+
+        self.assertEqual(len(result), 1)
+        asset = result[0]
+
+        # Useful fields preserved
+        self.assertEqual(asset["id"], "cid|aws|123|us-east-1|AWS::EC2::Instance|i-abc")
+        self.assertEqual(asset["resource_type"], "AWS::EC2::Instance")
+        self.assertEqual(asset["account_id"], "123456789012")
+        self.assertEqual(asset["region"], "us-east-1")
+        self.assertEqual(asset["tags"], {"Environment": "Production"})
+        self.assertTrue(asset["active"])
+
+        # Bloated fields removed
+        self.assertNotIn("gcrn", asset)
+        self.assertNotIn("cid", asset)
+        self.assertNotIn("hash", asset)
+        self.assertNotIn("revision", asset)
+        self.assertNotIn("configuration", asset)
+        self.assertNotIn("supplementary_configuration", asset)
+
+        # cloud_context trimmed to security summary
+        cc = asset["cloud_context"]
+        self.assertTrue(cc["publicly_exposed"])
+        self.assertEqual(cc["managed_by"], "Sensor")
+        self.assertEqual(cc["instance_state"], "running")
+        self.assertEqual(cc["open_cloud_risks"], 3)
+        self.assertEqual(cc["host"]["platform_name"], "Linux")
+
+        # Detections: counts kept, rules/controls stripped
+        self.assertEqual(cc["detections"]["iom_counts"], 5)
+        self.assertEqual(cc["detections"]["ioa_counts"], 1)
+        self.assertEqual(cc["detections"]["highest_severity"], "high")
+        self.assertNotIn("compliant", cc["detections"])
+        self.assertNotIn("non_compliant", cc["detections"])
+
+        # Insights: external flags kept, verbose details stripped
+        self.assertEqual(len(cc["insights"]["external"]), 2)
+        self.assertNotIn("details", cc["insights"])
+
+        # Internal fields stripped from cloud_context
+        self.assertNotIn("asset_graph", cc)
+        self.assertNotIn("legacy_resource_id", cc)
+        self.assertNotIn("legacy_uuid", cc)
+
+    def test_search_cspm_assets_trims_handles_missing_cloud_context(self):
+        """Test trimming handles records without cloud_context gracefully."""
+        minimal_asset = {
+            "id": "asset_1",
+            "resource_type": "AWS::S3::Bucket",
+            "cloud_provider": "aws",
+            "region": "us-east-1",
+        }
+
+        query_response = {"status_code": 200, "body": {"resources": ["asset_1"]}}
+        get_response = {"status_code": 200, "body": {"resources": [minimal_asset]}}
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_cspm_assets(limit=1)
+
+        self.assertEqual(len(result), 1)
+        asset = result[0]
+        self.assertEqual(asset["id"], "asset_1")
+        self.assertEqual(asset["resource_type"], "AWS::S3::Bucket")
+        self.assertNotIn("cloud_context", asset)
+
     # --- IOM Findings Tests ---
 
     def test_search_iom_findings_success(self):

--- a/tests/modules/test_cloud.py
+++ b/tests/modules/test_cloud.py
@@ -25,7 +25,6 @@ class TestCloudModule(TestModules):
             "falcon_search_images_vulnerabilities",
             "falcon_search_cspm_assets",
             "falcon_search_iom_findings",
-            "falcon_search_ioa_findings",
             "falcon_search_cspm_suppression_rules",
             "falcon_create_cspm_suppression_rule",
             "falcon_delete_cspm_suppression_rules",
@@ -570,39 +569,6 @@ class TestCloudModule(TestModules):
         second_call = self.mock_client.command.call_args_list[1]
         self.assertIn("parameters", second_call[1])
         self.assertNotIn("body", second_call[1])
-
-    # --- IOA Findings Tests ---
-
-    def test_search_ioa_findings_success(self):
-        """Test searching for IOA behavior detections."""
-        mock_response = {
-            "status_code": 200,
-            "body": {"resources": [{"event_id": "ioa_1", "severity": "High"}]},
-        }
-        self.mock_client.command.return_value = mock_response
-
-        self.module.search_ioa_findings(
-            cloud_provider="aws", severity="High", limit=10
-        )
-
-        self.assertEqual(self.mock_client.command.call_count, 1)
-        call = self.mock_client.command.call_args_list[0]
-        self.assertEqual(call[0][0], "GetBehaviorDetections")
-        self.assertEqual(call[1]["parameters"]["cloud_provider"], "aws")
-        self.assertEqual(call[1]["parameters"]["severity"], "High")
-
-    def test_search_ioa_findings_error(self):
-        """Test IOA search error handling."""
-        mock_response = {
-            "status_code": 400,
-            "body": {"errors": [{"message": "cloud_provider is required"}]},
-        }
-        self.mock_client.command.return_value = mock_response
-
-        result = self.module.search_ioa_findings(cloud_provider="invalid")
-
-        self.assertIsInstance(result, dict)
-        self.assertIn("error", result)
 
     # --- Suppression Rules Tests ---
 

--- a/tests/modules/test_cloud.py
+++ b/tests/modules/test_cloud.py
@@ -4,6 +4,8 @@ Tests for the Cloud module.
 
 import unittest
 
+from mcp.types import ToolAnnotations
+
 from falcon_mcp.modules.cloud import CloudModule
 from tests.modules.utils.test_modules import TestModules
 
@@ -22,6 +24,11 @@ class TestCloudModule(TestModules):
             "falcon_count_kubernetes_containers",
             "falcon_search_images_vulnerabilities",
             "falcon_search_cspm_assets",
+            "falcon_search_iom_findings",
+            "falcon_search_ioa_findings",
+            "falcon_search_cspm_suppression_rules",
+            "falcon_create_cspm_suppression_rule",
+            "falcon_delete_cspm_suppression_rules",
         ]
         self.assert_tools_registered(expected_tools)
 
@@ -31,6 +38,7 @@ class TestCloudModule(TestModules):
             "falcon_kubernetes_containers_fql_filter_guide",
             "falcon_images_vulnerabilities_fql_filter_guide",
             "falcon_search_cspm_assets_fql_guide",
+            "falcon_search_iom_findings_fql_guide",
         ]
         self.assert_resources_registered(expected_resources)
 
@@ -318,6 +326,316 @@ class TestCloudModule(TestModules):
         second_call = self.mock_client.command.call_args_list[1]
         self.assertIn("parameters", second_call[1])
         self.assertNotIn("body", second_call[1])
+
+    # --- IOM Findings Tests ---
+
+    def test_search_iom_findings_success(self):
+        """Test searching for IOM findings with two-step pattern."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["iom_1", "iom_2"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "iom_1", "severity": "critical", "status": "open"},
+                    {"id": "iom_2", "severity": "high", "status": "open"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_iom_findings(
+            filter="severity:'critical'+status:'open'", limit=10
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+
+        # Verify query call
+        first_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(first_call[0][0], "cspm_evaluations_iom_queries")
+        self.assertEqual(first_call[1]["parameters"]["filter"], "severity:'critical'+status:'open'")
+
+        # Verify get call
+        second_call = self.mock_client.command.call_args_list[1]
+        self.assertEqual(second_call[0][0], "cspm_evaluations_iom_entities")
+        self.assertEqual(second_call[1]["parameters"]["ids"], ["iom_1", "iom_2"])
+
+        # Verify full details returned
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertIn("severity", result[0])
+
+    def test_search_iom_findings_error_returns_fql_guide(self):
+        """Test IOM search returns FQL guide on error."""
+        mock_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid FQL syntax"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        result = self.module.search_iom_findings(filter="invalid::syntax")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("fql_guide", result)
+        self.assertIn("hint", result)
+        self.assertIn("severity", result["fql_guide"])
+
+    def test_search_iom_findings_empty_returns_fql_guide(self):
+        """Test IOM search returns FQL guide on empty results."""
+        query_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = query_response
+
+        result = self.module.search_iom_findings(filter="severity:'nonexistent'")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("fql_guide", result)
+        self.assertIn("results", result)
+        self.assertEqual(result["results"], [])
+
+    def test_search_iom_findings_batching(self):
+        """Test IOM search handles >100 IDs with batching."""
+        iom_ids = [f"iom_{i}" for i in range(150)]
+        query_response = {"status_code": 200, "body": {"resources": iom_ids}}
+
+        batch1 = {"status_code": 200, "body": {"resources": [{"id": f"iom_{i}"} for i in range(100)]}}
+        batch2 = {"status_code": 200, "body": {"resources": [{"id": f"iom_{i}"} for i in range(100, 150)]}}
+
+        self.mock_client.command.side_effect = [query_response, batch1, batch2]
+
+        result = self.module.search_iom_findings(limit=200)
+
+        self.assertEqual(self.mock_client.command.call_count, 3)
+        self.assertEqual(len(result), 150)
+
+    def test_search_iom_findings_uses_params_true(self):
+        """Test IOM entity fetch uses GET with query params."""
+        query_response = {"status_code": 200, "body": {"resources": ["iom_1"]}}
+        get_response = {"status_code": 200, "body": {"resources": [{"id": "iom_1"}]}}
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        self.module.search_iom_findings(limit=1)
+
+        second_call = self.mock_client.command.call_args_list[1]
+        self.assertIn("parameters", second_call[1])
+        self.assertNotIn("body", second_call[1])
+
+    # --- IOA Findings Tests ---
+
+    def test_search_ioa_findings_success(self):
+        """Test searching for IOA behavior detections."""
+        mock_response = {
+            "status_code": 200,
+            "body": {"resources": [{"event_id": "ioa_1", "severity": "High"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        self.module.search_ioa_findings(
+            cloud_provider="aws", severity="High", limit=10
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(call[0][0], "GetBehaviorDetections")
+        self.assertEqual(call[1]["parameters"]["cloud_provider"], "aws")
+        self.assertEqual(call[1]["parameters"]["severity"], "High")
+
+    def test_search_ioa_findings_error(self):
+        """Test IOA search error handling."""
+        mock_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "cloud_provider is required"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        result = self.module.search_ioa_findings(cloud_provider="invalid")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    # --- Suppression Rules Tests ---
+
+    def test_search_suppression_rules_success(self):
+        """Test searching for suppression rules with two-step pattern."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["rule_1", "rule_2"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "rule_1", "suppression_reason": "accept-risk"},
+                    {"id": "rule_2", "suppression_reason": "false-positive"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_cspm_suppression_rules(limit=10)
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+
+        # Verify override used for query
+        first_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(first_call[1]["override"], "GET,/cloud-policies/queries/suppression-rules/v1")
+
+        # Verify override used for get
+        second_call = self.mock_client.command.call_args_list[1]
+        self.assertEqual(second_call[1]["override"], "GET,/cloud-policies/entities/suppression-rules/v1")
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    def test_search_suppression_rules_empty(self):
+        """Test suppression rules search with no results."""
+        query_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = query_response
+
+        result = self.module.search_cspm_suppression_rules()
+
+        self.assertEqual(result, [])
+
+    def test_create_suppression_rule_success(self):
+        """Test creating a suppression rule."""
+        mock_response = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "new_rule_1"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        self.module.create_cspm_suppression_rule(
+            name="Test suppression rule",
+            suppression_reason="accept-risk",
+            rule_ids=["rule_123"],
+            rule_names=None,
+            rule_severities=None,
+            cloud_providers=["aws"],
+            account_ids=["123456789012"],
+            regions=None,
+            resource_ids=None,
+            resource_types=None,
+            expiration_date="2025-12-31T23:59:59Z",
+        )
+
+        call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(call[1]["override"], "POST,/cloud-policies/entities/suppression-rules/v1")
+
+        body = call[1]["body"]
+        self.assertEqual(body["name"], "Test suppression rule")
+        self.assertEqual(body["suppression_reason"], "accept-risk")
+        self.assertEqual(body["domain"], "CSPM")
+        self.assertEqual(body["subdomain"], "IOM")
+        self.assertEqual(body["suppression_expiration_date"], "2025-12-31T23:59:59Z")
+        self.assertEqual(body["rule_selection_filter"]["rule_ids"], ["rule_123"])
+        self.assertEqual(body["scope_asset_filter"]["cloud_providers"], ["aws"])
+
+    def test_create_suppression_rule_invalid_reason(self):
+        """Test create suppression rule rejects invalid reason."""
+        result = self.module.create_cspm_suppression_rule(
+            name="Test rule",
+            suppression_reason="invalid-reason",
+            rule_ids=["rule_123"],
+            rule_names=None,
+            rule_severities=None,
+            cloud_providers=None,
+            account_ids=None,
+            regions=None,
+            resource_ids=None,
+            resource_types=None,
+            expiration_date=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+        self.assertIn("Invalid suppression_reason", result["error"])
+
+    def test_create_suppression_rule_requires_rule_selection(self):
+        """Test create suppression rule requires at least one rule selector."""
+        result = self.module.create_cspm_suppression_rule(
+            suppression_reason="accept-risk",
+            rule_ids=None,
+            rule_names=None,
+            rule_severities=None,
+            cloud_providers=None,
+            account_ids=None,
+            regions=None,
+            resource_ids=None,
+            resource_types=None,
+            expiration_date=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+        self.assertIn("rule selection parameter is required", result["error"])
+
+    def test_create_suppression_rule_all_assets_scope(self):
+        """Test create suppression rule with no asset filter uses all_assets scope."""
+        mock_response = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "new_rule_1"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        self.module.create_cspm_suppression_rule(
+            name="Test all assets rule",
+            suppression_reason="false-positive",
+            rule_ids=["rule_123"],
+            rule_names=None,
+            rule_severities=None,
+            cloud_providers=None,
+            account_ids=None,
+            regions=None,
+            resource_ids=None,
+            resource_types=None,
+            expiration_date=None,
+        )
+
+        call = self.mock_client.command.call_args_list[0]
+        body = call[1]["body"]
+        self.assertEqual(body["scope_type"], "all_assets")
+        self.assertNotIn("scope_asset_filter", body)
+
+    def test_delete_suppression_rules_success(self):
+        """Test deleting suppression rules."""
+        mock_response = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "rule_1"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        self.module.delete_cspm_suppression_rules(ids=["rule_1", "rule_2"])
+
+        call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(call[1]["override"], "DELETE,/cloud-policies/entities/suppression-rules/v1")
+        self.assertEqual(call[1]["parameters"]["ids"], ["rule_1", "rule_2"])
+
+    def test_mutating_tools_have_correct_annotations(self):
+        """Test that mutating tools have destructiveHint=True."""
+        self.module.register_tools(self.mock_server)
+
+        # Check create tool
+        self.assert_tool_annotations(
+            "falcon_create_cspm_suppression_rule",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+        # Check delete tool
+        self.assert_tool_annotations(
+            "falcon_delete_cspm_suppression_rules",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -51,6 +51,9 @@ MUTATING_TOOL_ALLOWLIST: set[str] = {
     "falcon_dismiss_shield_check",
     # scheduled_reports module
     "falcon_launch_scheduled_report",
+    # cloud module (cspm suppression rules)
+    "falcon_create_cspm_suppression_rule",
+    "falcon_delete_cspm_suppression_rules",
 }
 
 RESOURCE_URI_PATTERN = re.compile(r"^falcon://[a-z0-9-]+(/[a-z0-9-]+)+/[a-z]+-guide$")


### PR DESCRIPTION
Extends the Cloud module with CSPM findings query and suppression rule management, covering [#270](https://github.com/CrowdStrike/falcon-mcp/issues/270).

Four new tools: `falcon_search_iom_findings` queries misconfiguration findings through the CloudSecurityDetections endpoints with FQL and batched entity fetching. `falcon_search_cspm_suppression_rules`, `falcon_create_cspm_suppression_rule`, and `falcon_delete_cspm_suppression_rules` handle the full suppression rule lifecycle. The create and delete tools are annotated as destructive since suppression rules affect compliance visibility.

Suppression rules hit `/cloud-policies/entities/suppression-rules/v1` which FalconPy hasn't wrapped yet, so these use the uber class override pattern. Worth noting the API body format is flat rather than the usual `resources[]` wrapper — we only caught that through live API testing.

The original plan included an IOA query tool using `GetBehaviorDetections`, but that endpoint was deprecated on 2026-04-30 when CrowdStrike moved cloud IOAs into the unified Alerts API. The existing Detections module already covers this with `falcon_search_detections` and filter `product:'fcs'+type:'cloud-ioa'`, so no separate tool is needed.

Also adds an FQL resource with 28 filter fields for IOM findings, the corresponding API scope entries, and docs. 29 unit tests and 20 integration tests, all run against the live API.

Closes #270