### PR TITLE
fix(server): surface diagnostic details on auth failure at startup

### DIFF
--- a/falcon_mcp/client.py
+++ b/falcon_mcp/client.py
@@ -78,6 +78,50 @@ class FalconClient:
         if self.member_cid:
             logger.debug("Flight Control member_cid: %s", self.member_cid)
 
+    @property
+    def token_status(self) -> int | None:
+        """HTTP status code from the last authentication attempt."""
+        result: int | None = self.client.token_status
+        return result
+
+    @property
+    def token_fail_reason(self) -> str | None:
+        """Error message from the API when authentication failed."""
+        result: str | None = self.client.token_fail_reason
+        return result
+
+    def auth_failure_message(self) -> str:
+        """Build a diagnostic message after a failed authentication attempt."""
+        parts = ["Failed to authenticate with the Falcon API"]
+        if self.token_status:
+            parts[0] += f" (HTTP {self.token_status})"
+        if self.token_fail_reason:
+            parts.append(self.token_fail_reason)
+
+        if self.token_status == 401:
+            parts.append(
+                "Hint: Verify FALCON_CLIENT_ID and FALCON_CLIENT_SECRET are correct"
+                " and the API key has not been revoked."
+            )
+        elif self.token_status == 403 and self.member_cid:
+            parts.append(
+                f"Hint: A member_cid is configured ({self.member_cid})."
+                " Verify this is a valid child CID managed by your parent tenant,"
+                " not the parent CID itself."
+            )
+        elif self.token_status == 403:
+            parts.append(
+                "Hint: Verify the API client has the required scopes"
+                " and has not been disabled."
+            )
+        else:
+            parts.append(
+                f"Hint: Check network connectivity to {self.base_url}"
+                " and verify FALCON_BASE_URL is correct for your CrowdStrike region."
+            )
+
+        return ". ".join(parts)
+
     def authenticate(self) -> bool:
         """Authenticate with the Falcon API.
 

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -90,8 +90,9 @@ class FalconMCPServer:
 
         # Authenticate with the Falcon API
         if not self.falcon_client.authenticate():
-            logger.error("Failed to authenticate with the Falcon API")
-            raise RuntimeError("Failed to authenticate with the Falcon API")
+            msg = self.falcon_client.auth_failure_message()
+            logger.error(msg)
+            raise RuntimeError(msg)
 
         # Initialize the MCP server
         self.server = FastMCP(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -398,5 +398,83 @@ class TestFalconClient(unittest.TestCase):
         self.assertNotIn("member_cid", call_args)
 
 
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_auth_failure_message_401(self, mock_apiharness, mock_environ_get):
+        """Test auth failure message for invalid credentials (HTTP 401)."""
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+        }.get(key, default)
+
+        mock_instance = MagicMock()
+        mock_instance.token_status = 401
+        mock_instance.token_fail_reason = "invalid credentials"
+        mock_apiharness.return_value = mock_instance
+
+        client = FalconClient()
+        msg = client.auth_failure_message()
+        self.assertIn("HTTP 401", msg)
+        self.assertIn("invalid credentials", msg)
+        self.assertIn("FALCON_CLIENT_ID", msg)
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_auth_failure_message_403_with_member_cid(self, mock_apiharness, mock_environ_get):
+        """Test auth failure with member_cid hints about child CID misconfiguration."""
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+        }.get(key, default)
+
+        mock_instance = MagicMock()
+        mock_instance.token_status = 403
+        mock_instance.token_fail_reason = "access denied"
+        mock_apiharness.return_value = mock_instance
+
+        client = FalconClient(member_cid="parent-cid-used-by-mistake")
+        msg = client.auth_failure_message()
+        self.assertIn("HTTP 403", msg)
+        self.assertIn("member_cid", msg)
+        self.assertIn("parent-cid-used-by-mistake", msg)
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_auth_failure_message_403_without_member_cid(self, mock_apiharness, mock_environ_get):
+        """Test auth failure without member_cid hints about scopes."""
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+        }.get(key, default)
+
+        mock_instance = MagicMock()
+        mock_instance.token_status = 403
+        mock_instance.token_fail_reason = "access denied"
+        mock_apiharness.return_value = mock_instance
+
+        client = FalconClient()
+        msg = client.auth_failure_message()
+        self.assertIn("HTTP 403", msg)
+        self.assertIn("required scopes", msg)
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_auth_failure_message_no_status(self, mock_apiharness, mock_environ_get):
+        """Test auth failure with no status suggests network/URL check."""
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+        }.get(key, default)
+
+        mock_instance = MagicMock()
+        mock_instance.token_status = None
+        mock_instance.token_fail_reason = None
+        mock_apiharness.return_value = mock_instance
+
+        client = FalconClient(base_url="https://api.crowdstrike.com")
+        msg = client.auth_failure_message()
+        self.assertIn("FALCON_BASE_URL", msg)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -85,15 +85,19 @@ class TestFalconMCPServer(unittest.TestCase):
 
     @patch("falcon_mcp.server.FalconClient")
     def test_authentication_failure(self, mock_client):
-        """Test server initialization with authentication failure."""
-        # Setup mock
+        """Test server initialization with authentication failure includes diagnostics."""
         mock_client_instance = MagicMock()
         mock_client_instance.authenticate.return_value = False
+        mock_client_instance.auth_failure_message.return_value = (
+            "Failed to authenticate with the Falcon API (HTTP 401). invalid credentials"
+        )
         mock_client.return_value = mock_client_instance
 
-        # Verify authentication failure raises RuntimeError
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as ctx:
             FalconMCPServer()
+
+        self.assertIn("HTTP 401", str(ctx.exception))
+        mock_client_instance.auth_failure_message.assert_called_once()
 
     @patch("falcon_mcp.server.FalconClient")
     def test_falcon_check_connectivity_success(self, mock_client):


### PR DESCRIPTION
When authentication fails at startup, we log "Failed to authenticate with the Falcon API" and exit. No HTTP status, no error from the API, nothing to actually debug with. Both reporters in #351 hit this — one was passing a parent CID as `--member-cid`, the other had internal TLS certificate issues — and neither could tell from the error what was going wrong.

FalconPy already stores the HTTP status code and error message after a failed `login()`, we just weren't reading them. Now we do. The error includes the status code, the API's error message, and a hint tailored to the failure type: 401 points at credentials, 403 with a member_cid warns you probably passed your parent CID instead of a child, 403 without one suggests scopes or a disabled key, and anything else (network failures, TLS errors) tells you to check connectivity and your base URL.

Added `token_status` and `token_fail_reason` properties to `FalconClient` that delegate to the underlying FalconPy client.

Closes #351