### PR TITLE
refactor(modules): standardize tool descriptions across all modules

### DIFF
--- a/docs-site/src/content/docs/development/module-development.md
+++ b/docs-site/src/content/docs/development/module-development.md
@@ -60,11 +60,16 @@ class YourModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter string.",
+            description="FQL filter expression. See `falcon://your-module/entities/fql-guide` for syntax.",
         ),
         limit: int = Field(default=100, ge=1, le=500),
     ) -> list[dict[str, Any]]:
-        """Search for entities. Tool descriptions come from docstrings."""
+        """Search for entities in your CrowdStrike environment.
+
+        Use this to find entities by name, status, or other attributes. Consult
+        falcon://your-module/entities/fql-guide before constructing filter expressions.
+        Returns full entity details.
+        """
         ids = self._base_search("QueryOperation", filter=filter, limit=limit)
         if self._is_error(ids):
             return [ids]

--- a/docs-site/src/content/docs/development/resource-development.md
+++ b/docs-site/src/content/docs/development/resource-development.md
@@ -85,13 +85,14 @@ def search_entities(
     self,
     filter: str | None = Field(
         default=None,
-        description="FQL filter. IMPORTANT: use the falcon://your-module/entities/fql-guide resource when building this parameter.",
+        description="FQL filter expression. See `falcon://your-module/entities/fql-guide` for syntax.",
     ),
 ) -> list[dict[str, Any]]:
-    """Search for entities.
+    """Search for entities in your CrowdStrike environment.
 
-    IMPORTANT: Call the FQL guide resource first:
-    falcon://your-module/entities/fql-guide
+    Use this to find entities by name, status, or other attributes. Consult
+    falcon://your-module/entities/fql-guide before constructing filter expressions.
+    Returns full entity details.
     """
 ```
 

--- a/docs/development/module_development.md
+++ b/docs/development/module_development.md
@@ -79,10 +79,11 @@ class YourModule(BaseModule):
             description="Description of param2. Include constraints if applicable.",
         ),
     ) -> dict[str, Any]:
-        """Description of what your tool does.
+        """Search for entities in your CrowdStrike environment.
 
-        Provide context on when to use this tool and any important notes.
-        Tool descriptions are derived from this docstring.
+        Use this to find entities by name, status, or other attributes. Consult
+        falcon://your-module/entities/fql-guide before constructing filter expressions.
+        Returns full entity details including id, name, and status.
         """
         # Use base class methods for common patterns
         results = self._base_search_api_call(
@@ -346,9 +347,9 @@ The `_add_tool()` helper applies `READ_ONLY_ANNOTATIONS` by default. **Override 
 
 ### Documentation
 
-1. **Docstrings**: Include detailed docstrings for all classes and methods. Tool descriptions are derived from method docstrings, so make sure they are comprehensive and well-written.
-2. **Parameter Descriptions**: Document all parameters and return values
-3. **Examples**: Include examples in docstrings where helpful
+1. **Tool Docstrings**: Tool descriptions are sent verbatim to LLM clients. Write 2-4 sentences covering: what the tool does, when to use it, the FQL resource pointer (for search tools), and what it returns. Avoid `IMPORTANT:` shouting — use natural prose. Keep return descriptions high-level and accurate (don't enumerate every field).
+2. **Parameter Descriptions**: Use concise Field descriptions. For FQL filters: `"FQL filter expression. See \`falcon://path/fql-guide\` for syntax."`
+3. **Examples**: Include examples in Field `examples` parameter where helpful
 
 ### Type Hints
 
@@ -454,7 +455,7 @@ class HostsModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL Syntax formatted string used to limit the results.",
+            description="FQL filter expression. See `falcon://hosts/search/fql-guide` for syntax.",
             examples={"platform_name:'Windows'", "hostname:'PC*'"},
         ),
         limit: int = Field(
@@ -490,6 +491,11 @@ class HostsModule(BaseModule):
         ),
     ) -> list[dict[str, Any]]:
         """Search for hosts in your CrowdStrike environment.
+
+        Use this to find devices by hostname, platform, IP, sensor version, or other
+        attributes. Consult falcon://hosts/search/fql-guide before constructing filter
+        expressions. Returns full host details including device info, OS, and network
+        context.
         """
         device_ids = self._base_search_api_call(
             operation="QueryDevicesByFilter",
@@ -530,11 +536,11 @@ class HostsModule(BaseModule):
             description="Host device IDs to retrieve details for. You can get device IDs from the search_hosts operation, the Falcon console, or the Streaming API. Maximum: 5000 IDs per request."
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Retrieve detailed information for specified host device IDs.
+        """Retrieve detailed information for one or more host device IDs.
 
-        This tool returns comprehensive host details for one or more device IDs.
-        Use this when you already have specific device IDs and need their full details.
-        For searching/discovering hosts, use the `falcon_search_hosts` tool instead.
+        Use when you already have specific device IDs from search results, the Falcon
+        console, or the Streaming API. For discovering hosts by criteria, use
+        falcon_search_hosts instead. Returns comprehensive host details.
         """
         logger.debug("Getting host details for IDs: %s", ids)
 

--- a/docs/development/resource_development.md
+++ b/docs/development/resource_development.md
@@ -201,16 +201,15 @@ def query_actor_entities(
     self,
     filter: str | None = Field(
         default=None,
-        description="FQL query expression that should be used to limit the results. IMPORTANT: use the 'falcon://query_actor_entities_fql_documentation' resource when building this parameter.",
+        description="FQL filter expression. See `falcon://intel/actors/fql-guide` for syntax.",
     ),
     # Other parameters...
 ) -> list[dict[str, Any]]:
-    """Get info about actors that match provided FQL filters.
+    """Research threat actors and adversary groups tracked by CrowdStrike intelligence.
 
-    IMPORTANT: You must call the FQL Guide for Intel Query Actor Entities (falcon://intel/query_actor_entities/fql-guide) resource first
-
-    Returns:
-        Information about actors that match the provided filters.
+    Use this to search actors by name, target countries/industries, or activity dates.
+    Consult falcon://intel/actors/fql-guide before constructing filter expressions.
+    Returns full actor profiles including aliases, motivations, and targeting details.
     """
     # Method implementation...
 ```

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -154,7 +154,7 @@ class CloudModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://cloud/kubernetes-containers/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://cloud/kubernetes-containers/fql-guide` for syntax.",
             examples={"cloud:'AWS'", "cluster_name:'prod'"},
         ),
         limit: int = Field(
@@ -193,10 +193,11 @@ class CloudModule(BaseModule):
             examples={"container_name.desc", "last_seen.desc"},
         ),
     ) -> list[dict[str, Any]]:
-        """Search for kubernetes containers in your CrowdStrike Kubernetes & Containers Inventory
+        """Search for Kubernetes containers in your CrowdStrike container inventory.
 
-        IMPORTANT: You must use the `falcon://cloud/kubernetes-containers/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for `falcon_search_kubernetes_containers` tool.
+        Use this to find containers by cluster, namespace, image, or cloud provider.
+        Consult falcon://cloud/kubernetes-containers/fql-guide before constructing filter
+        expressions. Returns full container details including image, status, and vulnerabilities.
         """
 
         return self._base_search_api_call(
@@ -214,14 +215,15 @@ class CloudModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://cloud/kubernetes-containers/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://cloud/kubernetes-containers/fql-guide` for syntax.",
             examples={"cloud:'Azure'", "container_name:'service'"},
         ),
     ) -> int:
-        """Count kubernetes containers in your CrowdStrike Kubernetes & Containers Inventory
+        """Count Kubernetes containers matching filter criteria.
 
-        IMPORTANT: You must use the `falcon://cloud/kubernetes-containers/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for `falcon_count_kubernetes_containers` tool.
+        Use this for aggregate counts without returning full container details. Consult
+        falcon://cloud/kubernetes-containers/fql-guide before constructing filter
+        expressions. Returns the count as a single-element list.
         """
 
         # Prepare parameters
@@ -249,7 +251,7 @@ class CloudModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://cloud/images-vulnerabilities/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://cloud/images-vulnerabilities/fql-guide` for syntax.",
             examples={"cve_id:*'*2025*'", "cvss_score:>5"},
         ),
         limit: int = Field(
@@ -282,10 +284,12 @@ class CloudModule(BaseModule):
             examples={"cvss_score.desc", "cps_current_rating.asc"},
         ),
     ) -> list[dict[str, Any]]:
-        """Search for images vulnerabilities in your CrowdStrike Image Assessments
+        """Search for container image vulnerabilities in CrowdStrike Image Assessments.
 
-        IMPORTANT: You must use the `falcon://cloud/images-vulnerabilities/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for `falcon_search_images_vulnerabilities` tool.
+        Use this to find CVEs affecting container images by severity, CVSS score, or
+        CVE ID. Consult falcon://cloud/images-vulnerabilities/fql-guide before constructing
+        filter expressions. Returns vulnerability details including CVE IDs, scores, and
+        impacted image counts.
         """
 
         # Prepare parameters
@@ -316,7 +320,7 @@ class CloudModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://cloud/cspm-assets/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://cloud/cspm-assets/fql-guide` for syntax.",
             examples=["cloud_provider:'AWS'", "tag_key:'Environment'+tag_value:'Production'"],
         ),
         limit: int = Field(
@@ -356,20 +360,12 @@ class CloudModule(BaseModule):
             examples=["updated_at.desc", "resource_type.asc"],
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Search for cloud assets in your CrowdStrike CSPM Asset Inventory.
+        """Search for cloud assets in your CrowdStrike CSPM inventory.
 
-        This tool queries cloud resources (EC2 instances, VPCs, subnets, load balancers, etc.)
-        managed by CrowdStrike CSPM. Supports comprehensive FQL filtering including:
-        - Cloud provider and resource type filtering
-        - Tag-based filtering (AWS/Azure/GCP tags)
-        - Security posture (publicly exposed, severity, IOM/IOA counts)
-        - Compliance status and benchmarks
-        - Temporal filtering (creation time, last updated)
-
-        IMPORTANT: You must use the `falcon://cloud/cspm-assets/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for `falcon_search_cspm_assets` tool.
-
-        Returns FQL syntax guide on error or empty results to help refine queries.
+        Use this to find cloud resources (EC2, VPCs, S3, etc.) by provider, region,
+        resource type, or tags. Consult falcon://cloud/cspm-assets/fql-guide before
+        constructing filter expressions. Returns slimmed asset details with security
+        posture context (IOM/IOA counts, exposure, severity).
         """
         # Step 1: Query for asset IDs
         asset_ids = self._base_search_api_call(
@@ -533,9 +529,8 @@ class CloudModule(BaseModule):
         filter: str | None = Field(
             default=None,
             description=(
-                "FQL Syntax formatted string used to limit the results."
-                " IMPORTANT: use the `falcon://cloud/cspm-iom-findings/fql-guide`"
-                " resource when building this filter parameter."
+                "FQL filter expression."
+                " See `falcon://cloud/cspm-iom-findings/fql-guide` for syntax."
             ),
             examples=["severity:'critical'+status:'open'", "cloud_provider:'aws'+service:'S3'"],
         ),
@@ -574,23 +569,10 @@ class CloudModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for CSPM Indicators of Misconfiguration (IOM) findings.
 
-        Retrieves cloud security posture findings that identify misconfigurations
-        in your cloud environment (AWS, Azure, GCP). Findings map to compliance
-        frameworks (CIS, NIST, SOC2) and MITRE ATT&CK techniques.
-
-        Supports filtering by suppression state to view which findings have been
-        accepted as risk, marked as false positives, or have compensating controls.
-
-        IMPORTANT: You must use the `falcon://cloud/cspm-iom-findings/fql-guide` resource
-        when you need to use the `filter` parameter.
-
-        Returns a list of IOM finding entities with nested structure:
-        - id: Unique finding identifier
-        - cloud: {account_id, account_name, provider, region}
-        - evaluation: {severity, status, attack_types, rule, created, url}
-        - resource: {resource_id, resource_type, service, service_category}
-
-        Returns FQL syntax guide on error or empty results to help refine queries.
+        Use this to find cloud misconfigurations by severity, provider, service, or
+        suppression state. Consult falcon://cloud/cspm-iom-findings/fql-guide before
+        constructing filter expressions. Returns IOM entities with cloud context,
+        evaluation details, and resource information.
         """
         # Step 1: Query for IOM IDs
         iom_ids = self._base_search_api_call(
@@ -667,15 +649,9 @@ class CloudModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for CSPM IOM suppression rules.
 
-        Lists suppression rules that control which IOM findings are suppressed.
-        Suppression rules define which rules and assets are excluded from generating
-        active findings, along with the reason and optional expiration date.
-
-        Use this to review existing suppressions before creating new ones.
-
-        Returns a list of suppression rule objects containing: id, name, domain,
-        subdomain, disabled, rule_selection_type, scope_type, suppression_reason,
-        created_at, created_by. Returns an empty list if no rules exist.
+        Use this to review existing suppressions before creating new ones. Returns
+        suppression rule objects including scope, reason, and expiration details.
+        Returns an empty list if no rules exist.
         """
         # Step 1: Query suppression rule IDs
         params = prepare_api_parameters({"limit": limit, "offset": offset})
@@ -747,8 +723,7 @@ class CloudModule(BaseModule):
         cloud_providers: list[str] | None = Field(
             default=None,
             description=(
-                "Limit suppression to specific cloud providers."
-                " Values: 'aws', 'azure', 'gcp'."
+                "Limit suppression to specific cloud providers. Values: 'aws', 'azure', 'gcp'."
             ),
         ),
         account_ids: list[str] | None = Field(
@@ -758,8 +733,7 @@ class CloudModule(BaseModule):
         regions: list[str] | None = Field(
             default=None,
             description=(
-                "Limit suppression to specific cloud regions."
-                " Ex: ['us-east-1', 'eu-west-1']."
+                "Limit suppression to specific cloud regions. Ex: ['us-east-1', 'eu-west-1']."
             ),
         ),
         resource_ids: list[str] | None = Field(
@@ -768,10 +742,7 @@ class CloudModule(BaseModule):
         ),
         resource_types: list[str] | None = Field(
             default=None,
-            description=(
-                "Limit suppression to specific resource types."
-                " Ex: ['AWS::S3::Bucket']."
-            ),
+            description=("Limit suppression to specific resource types. Ex: ['AWS::S3::Bucket']."),
         ),
         expiration_date: str | None = Field(
             default=None,
@@ -782,22 +753,12 @@ class CloudModule(BaseModule):
             ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Create a CSPM IOM suppression rule to suppress matching findings.
+        """Create a CSPM IOM suppression rule to hide matching findings.
 
-        WARNING: This creates a suppression rule that will hide matching IOM findings
-        from compliance scores and active finding views. Suppressed findings are still
-        assessed but not surfaced. Use carefully and prefer narrow scope.
-
-        A suppression rule defines:
-        - WHICH rules to suppress (by ID, name, or severity)
-        - WHICH assets to suppress them for (by cloud provider, account, region, resource)
-        - WHY (accept-risk, compensating-control, false-positive)
-        - WHEN it expires (strongly recommended)
-
-        Requires the modern 'Cloud Security Posture Rules' mode (not legacy policies).
-
-        Returns the created suppression rule object on success, or an error dict
-        with details on failure.
+        Suppressed findings are still assessed but not surfaced in compliance scores.
+        Requires at least one rule selection (rule_ids, rule_names, or rule_severities)
+        and a suppression reason. Setting an expiration_date is strongly recommended to
+        avoid permanent suppressions. Returns the created suppression rule object.
         """
         valid_reasons = {"accept-risk", "compensating-control", "false-positive"}
         if suppression_reason not in valid_reasons:
@@ -895,12 +856,9 @@ class CloudModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Delete CSPM IOM suppression rules by ID.
 
-        WARNING: Deleting a suppression rule will re-activate all findings that were
-        previously suppressed by that rule. They will appear as open findings again.
-
-        Use falcon_search_cspm_suppression_rules first to identify which rules to delete.
-
-        Returns a confirmation response on success, or an error dict on failure.
+        Deleting a suppression rule re-activates all findings that were previously
+        suppressed by it. Use falcon_search_cspm_suppression_rules to find rule IDs
+        first. Returns a confirmation response.
         """
         params = prepare_api_parameters({"ids": ids})
         response = self.client.command(

--- a/falcon_mcp/modules/custom_ioa.py
+++ b/falcon_mcp/modules/custom_ioa.py
@@ -142,7 +142,7 @@ class CustomIOAModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter to limit rule group search results. IMPORTANT: use the `falcon://custom-ioa/rule-groups/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://custom-ioa/rule-groups/fql-guide` for syntax.",
             examples={"platform:'windows'+enabled:true", "rules.pattern_severity:'high'"},
         ),
         limit: int = Field(
@@ -165,13 +165,11 @@ class CustomIOAModule(BaseModule):
             description="Free-text match query that searches across all filter string fields.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Search Custom IOA rule groups and return full rule group details including their rules.
+        """Search Custom IOA rule groups and return full details including their rules.
 
-        IMPORTANT: You must use the `falcon://custom-ioa/rule-groups/fql-guide` resource
-        when you need to use the `filter` parameter.
-
-        Rule groups are containers that hold behavioral detection rules. Each group is
-        associated with a specific platform (windows, mac, or linux).
+        Use this to find rule groups by platform, name, or enabled state. Consult
+        falcon://custom-ioa/rule-groups/fql-guide before constructing filter expressions.
+        Returns rule group objects with their contained behavioral detection rules.
         """
         result = self._base_search_api_call(
             operation="query_rule_groups_full",
@@ -200,8 +198,8 @@ class CustomIOAModule(BaseModule):
     def get_ioa_platforms(self) -> list[dict[str, Any]] | dict[str, Any]:
         """Get all available platforms for Custom IOA rule groups.
 
-        Returns details about each available platform (e.g., windows, mac, linux).
-        Use this to discover valid platform values before creating a rule group.
+        Use this to discover valid platform values (windows, mac, linux) before
+        creating a rule group. Returns platform details.
         """
         platform_ids = self._base_search_api_call(
             operation="query_platformsMixin0",
@@ -241,12 +239,9 @@ class CustomIOAModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Get all available Custom IOA rule types.
 
-        Returns details about each rule type including its name, platform, fields,
-        and supported disposition IDs. Use this to discover valid rule type IDs and
-        required field values before creating a behavioral rule.
-
-        Rule types define the category of behavioral detection (e.g., Process Creation,
-        Network Connection, File Creation).
+        Use this to discover valid rule type IDs, required fields, and disposition IDs
+        before creating a behavioral detection rule. Returns rule type details including
+        platform, fields, and supported actions.
         """
         rule_type_ids = self._base_search_api_call(
             operation="query_rule_types",
@@ -295,11 +290,9 @@ class CustomIOAModule(BaseModule):
     ) -> list[dict[str, Any]]:
         """Create a new Custom IOA rule group.
 
-        Rule groups are containers that hold behavioral detection rules for a specific
-        platform. After creating a group, use `falcon_create_ioa_rule` to add detection
-        rules to it.
-
-        Use `falcon_get_ioa_platforms` to see available platform values.
+        Rule groups are containers for behavioral detection rules scoped to a platform.
+        Use falcon_get_ioa_platforms to see valid platform values. After creating a
+        group, use falcon_create_ioa_rule to add detection rules to it.
         """
         body: dict[str, Any] = {
             "name": name,
@@ -349,11 +342,8 @@ class CustomIOAModule(BaseModule):
     ) -> list[dict[str, Any]]:
         """Update an existing Custom IOA rule group.
 
-        You can modify the name, description, and enabled state of a rule group.
-        The `rulegroup_version` is required for optimistic locking to prevent
-        concurrent modification conflicts.
-
-        Use `falcon_search_ioa_rule_groups` to retrieve the current version number.
+        Modify name, description, or enabled state. Requires rulegroup_version for
+        optimistic locking — get it from falcon_search_ioa_rule_groups.
         """
         body: dict[str, Any] = {
             "id": id,
@@ -392,8 +382,8 @@ class CustomIOAModule(BaseModule):
     ) -> list[dict[str, Any]]:
         """Delete Custom IOA rule groups by ID.
 
-        This permanently removes the rule groups and all rules within them.
-        Use `falcon_search_ioa_rule_groups` to find rule group IDs.
+        Permanently removes the rule groups and all rules within them. Use
+        falcon_search_ioa_rule_groups to find rule group IDs.
         """
         if not ids:
             return [
@@ -459,13 +449,9 @@ class CustomIOAModule(BaseModule):
     ) -> list[dict[str, Any]]:
         """Create a new Custom IOA behavioral detection rule within a rule group.
 
-        Before creating a rule:
-        1. Use `falcon_get_ioa_rule_types` to discover available rule types, their IDs,
-           required fields, and valid disposition IDs.
-        2. Use `falcon_search_ioa_rule_groups` to find the target rule group ID.
-
-        The `field_values` parameter defines the behavioral criteria the rule will match
-        against (e.g., process names, file paths, command line patterns using regex).
+        Use falcon_get_ioa_rule_types first to discover rule type IDs, required fields,
+        and valid disposition IDs. The field_values parameter defines the behavioral
+        criteria the rule matches against (process names, file paths, command line regex).
         """
         body: dict[str, Any] = {
             "rulegroup_id": rulegroup_id,
@@ -534,9 +520,8 @@ class CustomIOAModule(BaseModule):
     ) -> list[dict[str, Any]]:
         """Update an existing Custom IOA behavioral detection rule.
 
-        The `rulegroup_version` is required for optimistic locking to prevent
-        concurrent modification conflicts. Use `falcon_search_ioa_rule_groups` to
-        retrieve the current version and instance ID.
+        Requires rulegroup_version for optimistic locking. Get the current version
+        and instance_id from falcon_search_ioa_rule_groups.
         """
         rule_update: dict[str, Any] = {
             "instance_id": instance_id,
@@ -590,8 +575,8 @@ class CustomIOAModule(BaseModule):
     ) -> list[dict[str, Any]]:
         """Delete Custom IOA behavioral detection rules from a rule group.
 
-        Use `falcon_search_ioa_rule_groups` to find the rule group ID and
-        the individual rule IDs (instance IDs) to delete.
+        Use falcon_search_ioa_rule_groups to find the rule group ID and individual
+        rule instance IDs to delete.
         """
         if not ids:
             return [

--- a/falcon_mcp/modules/detections.py
+++ b/falcon_mcp/modules/detections.py
@@ -14,7 +14,6 @@ from pydantic import AnyUrl, Field
 from falcon_mcp.common.logging import get_logger
 from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.resources.detections import (
-    EMBEDDED_FQL_SYNTAX,
     SEARCH_DETECTIONS_FQL_DOCUMENTATION,
 )
 
@@ -64,7 +63,7 @@ class DetectionsModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description=EMBEDDED_FQL_SYNTAX,
+            description="FQL filter expression. See `falcon://detections/search/fql-guide` for syntax.",
             examples=["status:'new'+severity_name:'High'", "device.hostname:'DC*'"],
         ),
         limit: int = Field(
@@ -107,11 +106,10 @@ class DetectionsModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Find detections by criteria and return their complete details.
 
-        Use this tool to discover detections - filter by severity, status, hostname,
-        time range, etc. Returns full detection information including behaviors,
-        device context, and threat details.
-
-        Returns FQL syntax guide on error or empty results to help refine queries.
+        Use this to discover detections by severity, status, hostname, time range, or
+        other attributes. Consult falcon://detections/search/fql-guide before constructing
+        filter expressions. Returns full alert records including process context, device
+        info, tactic/technique details, and threat classification.
         """
         detection_ids = self._base_search_api_call(
             operation="GetQueriesAlertsV2",
@@ -160,8 +158,9 @@ class DetectionsModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Retrieve details for detection IDs you already have.
 
-        Use ONLY when you have specific composite detection ID(s). To find detections
-        by criteria (severity, status, hostname, etc.), use `falcon_search_detections`.
+        Use when you have specific composite detection ID(s). For discovering detections
+        by criteria (severity, status, hostname, etc.), use falcon_search_detections
+        instead. Returns full detection records.
         """
         logger.debug("Getting detection details for ID(s): %s", ids)
 

--- a/falcon_mcp/modules/discover.py
+++ b/falcon_mcp/modules/discover.py
@@ -78,7 +78,7 @@ class DiscoverModule(BaseModule):
     def search_applications(
         self,
         filter: str = Field(
-            description="FQL filter expression used to limit the results. IMPORTANT: use the `falcon://discover/applications/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression (required). See `falcon://discover/applications/fql-guide` for syntax.",
             examples={"name:'Chrome'", "vendor:'Microsoft Corporation'"},
         ),
         facet: str | None = Field(
@@ -107,10 +107,11 @@ class DiscoverModule(BaseModule):
             examples={"name.asc", "vendor.desc", "last_updated_timestamp.desc"},
         ),
     ) -> list[dict[str, Any]]:
-        """Search for applications in your CrowdStrike environment.
+        """Search for applications discovered in your CrowdStrike environment.
 
-        IMPORTANT: You must use the `falcon://discover/applications/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_applications` tool.
+        Use this to find applications by name, vendor, or installation details. Consult
+        falcon://discover/applications/fql-guide before constructing filter expressions.
+        Returns application entities with optional host info and usage data (based on facet).
         """
         # Prepare parameters for combined_applications
         params = prepare_api_parameters(
@@ -149,7 +150,7 @@ class DiscoverModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression used to limit the results. IMPORTANT: use the `falcon://discover/hosts/fql-guide` resource when building this filter parameter. Note: entity_type:'unmanaged' is automatically applied.",
+            description="FQL filter expression. See `falcon://discover/hosts/fql-guide` for syntax. Note: entity_type:'unmanaged' is automatically applied.",
             examples={"platform_name:'Windows'", "criticality:'Critical'"},
         ),
         limit: int = Field(
@@ -184,16 +185,12 @@ class DiscoverModule(BaseModule):
             examples={"hostname.asc", "last_seen_timestamp.desc", "criticality.desc"},
         ),
     ) -> list[dict[str, Any]]:
-        """Search for unmanaged assets (hosts) in your CrowdStrike environment.
+        """Search for unmanaged assets (hosts without Falcon sensor) in your environment.
 
-        These are systems that do not have the Falcon sensor installed but have been
-        discovered by systems that do have a Falcon sensor installed.
-
-        IMPORTANT: You must use the `falcon://discover/hosts/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_unmanaged_assets` tool.
-
-        The tool automatically filters for unmanaged assets only by adding entity_type:'unmanaged' to all queries.
-        You do not need to (and cannot) specify entity_type in your filter - it is always set to 'unmanaged'.
+        Finds systems discovered by Falcon-managed hosts that lack a sensor themselves.
+        Consult falcon://discover/hosts/fql-guide before constructing filter expressions.
+        The tool automatically adds entity_type:'unmanaged' to all queries. Returns full
+        asset details including platform, network, and criticality information.
         """
         # Always enforce entity_type:'unmanaged' filter
         base_filter = "entity_type:'unmanaged'"

--- a/falcon_mcp/modules/firewall.py
+++ b/falcon_mcp/modules/firewall.py
@@ -87,7 +87,7 @@ class FirewallModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter for firewall rule search. IMPORTANT: use the `falcon://firewall/rules/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://firewall/rules/fql-guide` for syntax.",
             examples=["enabled:true", "platform:'windows'+name:'Block*'"],
         ),
         limit: int = Field(
@@ -118,7 +118,12 @@ class FirewallModule(BaseModule):
             description="Pagination token from a previous query response.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Search firewall rules and return full rule details."""
+        """Search firewall rules and return full rule details.
+
+        Use this to find firewall rules by name, platform, or enabled state. Consult
+        falcon://firewall/rules/fql-guide before constructing filter expressions.
+        Returns complete rule objects including conditions and actions.
+        """
         rule_ids = self._base_search_api_call(
             operation="query_rules",
             search_params={
@@ -159,7 +164,7 @@ class FirewallModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter for firewall rule group search. IMPORTANT: use the `falcon://firewall/rules/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://firewall/rules/fql-guide` for syntax.",
             examples=["enabled:true", "platform:'windows'+name:'Default*'"],
         ),
         limit: int = Field(
@@ -185,7 +190,12 @@ class FirewallModule(BaseModule):
             description="Pagination token from a previous query response.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Search firewall rule groups and return full rule group details."""
+        """Search firewall rule groups and return full rule group details.
+
+        Use this to find rule groups by name, platform, or enabled state. Consult
+        falcon://firewall/rules/fql-guide before constructing filter expressions.
+        Returns rule group objects including their contained rules.
+        """
         rule_group_ids = self._base_search_api_call(
             operation="query_rule_groups",
             search_params={
@@ -229,7 +239,7 @@ class FirewallModule(BaseModule):
         ),
         filter: str | None = Field(
             default=None,
-            description="FQL filter for policy rule search. IMPORTANT: use the `falcon://firewall/rules/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://firewall/rules/fql-guide` for syntax.",
         ),
         limit: int = Field(
             default=10,
@@ -250,7 +260,12 @@ class FirewallModule(BaseModule):
             description="Free-text query string across policy rule fields.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Search firewall rules in a specific policy container and return full rule details."""
+        """Search firewall rules within a specific policy container.
+
+        Use this when you need rules scoped to a particular policy. Consult
+        falcon://firewall/rules/fql-guide before constructing filter expressions.
+        Returns full rule details for the specified policy.
+        """
         policy_rule_ids = self._base_search_api_call(
             operation="query_policy_rules",
             search_params={
@@ -326,7 +341,11 @@ class FirewallModule(BaseModule):
             description="Full request body override. If provided, convenience fields are ignored.",
         ),
     ) -> list[dict[str, Any]]:
-        """Create a firewall rule group."""
+        """Create a firewall rule group.
+
+        Provide a name, platform, and either rules or a clone_id. Returns a list
+        containing the created rule group object.
+        """
         request_body = body
         if request_body is None:
             if not name or not platform:
@@ -382,7 +401,11 @@ class FirewallModule(BaseModule):
             description="Audit log comment for this action.",
         ),
     ) -> list[dict[str, Any]]:
-        """Delete firewall rule groups by ID."""
+        """Delete firewall rule groups by ID.
+
+        Permanently removes the specified rule groups and all rules within them.
+        Returns an empty list on success.
+        """
         if not ids:
             return [
                 _format_error_response(

--- a/falcon_mcp/modules/hosts.py
+++ b/falcon_mcp/modules/hosts.py
@@ -62,7 +62,7 @@ class HostsModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://hosts/search/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://hosts/search/fql-guide` for syntax.",
             examples={"platform_name:'Windows'", "hostname:'PC*'"},
         ),
         limit: int = Field(
@@ -99,8 +99,10 @@ class HostsModule(BaseModule):
     ) -> list[dict[str, Any]]:
         """Search for hosts in your CrowdStrike environment.
 
-        IMPORTANT: You must use the `falcon://hosts/search/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_hosts` tool.
+        Use this to find devices by hostname, platform, IP, sensor version, or other
+        attributes. Consult falcon://hosts/search/fql-guide before constructing filter
+        expressions. Returns full host details including device info, OS, and network
+        context.
         """
         device_ids = self._base_search_api_call(
             operation="QueryDevicesByFilter",
@@ -141,11 +143,11 @@ class HostsModule(BaseModule):
             description="Host device IDs to retrieve details for. You can get device IDs from the search_hosts operation, the Falcon console, or the Streaming API. Maximum: 5000 IDs per request."
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Retrieve detailed information for specified host device IDs.
+        """Retrieve detailed information for one or more host device IDs.
 
-        This tool returns comprehensive host details for one or more device IDs.
-        Use this when you already have specific device IDs and need their full details.
-        For searching/discovering hosts, use the `falcon_search_hosts` tool instead.
+        Use when you already have specific device IDs from search results, the Falcon
+        console, or the Streaming API. For discovering hosts by criteria, use
+        falcon_search_hosts instead. Returns comprehensive host details.
         """
         logger.debug("Getting host details for IDs: %s", ids)
 

--- a/falcon_mcp/modules/idp.py
+++ b/falcon_mcp/modules/idp.py
@@ -108,13 +108,13 @@ class IdpModule(BaseModule):
             description="Include open security incidents in results",
         ),
     ) -> dict[str, Any]:
-        """Comprehensive entity investigation tool.
+        """Investigate one or more Identity Protection entities by ID, name, email, IP, or domain.
 
-        This tool provides complete entity investigation capabilities including:
-        - Entity search and details lookup
-        - Activity timeline analysis
-        - Relationship and association mapping
-        - Risk assessment
+        Use this to look up entity details, activity timelines, relationship graphs, and risk
+        assessments; at least one identifier must be supplied, and multiple identifiers are
+        combined with AND logic (email and IP cannot be combined — email takes precedence).
+        Returns a structured response with an investigation_summary, resolved entity IDs,
+        and results keyed by each requested investigation type.
         """
         logger.debug("Starting comprehensive entity investigation")
 

--- a/falcon_mcp/modules/intel.py
+++ b/falcon_mcp/modules/intel.py
@@ -99,7 +99,7 @@ class IntelModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL query expression that should be used to limit the results. IMPORTANT: use the `falcon://intel/actors/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://intel/actors/fql-guide` for syntax.",
         ),
         limit: int = Field(
             default=10,
@@ -126,8 +126,9 @@ class IntelModule(BaseModule):
     ) -> list[dict[str, Any]]:
         """Research threat actors and adversary groups tracked by CrowdStrike intelligence.
 
-        IMPORTANT: You must use the `falcon://intel/actors/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_actors` tool.
+        Use this to search actors by name, target countries/industries, or activity dates.
+        Consult falcon://intel/actors/fql-guide before constructing filter expressions.
+        Returns full actor profiles including aliases, motivations, and targeting details.
         """
         api_response = self._base_search_api_call(
             operation="QueryIntelActorEntities",
@@ -150,7 +151,7 @@ class IntelModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL query expression that should be used to limit the results. IMPORTANT: use the `falcon://intel/indicators/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://intel/indicators/fql-guide` for syntax.",
         ),
         limit: int = Field(
             default=10,
@@ -180,10 +181,11 @@ class IntelModule(BaseModule):
             description="Flag indicating if related indicators should be returned.",
         ),
     ) -> list[dict[str, Any]]:
-        """Search for threat indicators and indicators of compromise (IOCs) from CrowdStrike intelligence.
+        """Search for threat indicators and IOCs from CrowdStrike intelligence.
 
-        IMPORTANT: You must use the `falcon://intel/indicators/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_indicators` tool.
+        Use this to find indicators by type, publish date, malware family, or threat actor
+        association. Consult falcon://intel/indicators/fql-guide before constructing filter
+        expressions. Returns full indicator details including labels, relations, and kill chain stage.
         """
         api_response = self._base_search_api_call(
             operation="QueryIntelIndicatorEntities",
@@ -208,7 +210,7 @@ class IntelModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL query expression that should be used to limit the results. IMPORTANT: use the `falcon://intel/reports/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://intel/reports/fql-guide` for syntax.",
         ),
         limit: int = Field(
             default=10,
@@ -230,14 +232,11 @@ class IntelModule(BaseModule):
             description="Free text search across all indexed fields.",
         ),
     ) -> list[dict[str, Any]]:
-        """Access CrowdStrike intelligence publications and threat reports.
+        """Search CrowdStrike intelligence publications and threat reports.
 
-        This tool returns comprehensive intelligence report details based on your search criteria.
-        Use this when you need to find CrowdStrike intelligence publications matching specific conditions.
-        For guidance on building FQL filters, use the `falcon://intel/reports/fql-guide` resource.
-
-        IMPORTANT: You must use the `falcon://intel/reports/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_reports` tool.
+        Use this to find reports by name, target industry, threat type, or publication date.
+        Consult falcon://intel/reports/fql-guide before constructing filter expressions.
+        Returns full report metadata including title, description, and target details.
         """
         api_response = self._base_search_api_call(
             operation="QueryIntelReportEntities",
@@ -271,14 +270,11 @@ class IntelModule(BaseModule):
             examples={"json", "csv"},
         ),
     ) -> list[dict[str, Any]] | str:
-        """Generate MITRE ATT&CK report for a given threat actor.
+        """Generate a MITRE ATT&CK report for a given threat actor.
 
-        Provides detailed MITRE ATT&CK tactics, techniques, and procedures (TTPs)
-        report associated with a specific threat actor tracked.
-
-        Args:
-            actor: Pass the actor name (string) or numeric actor ID (string).
-            format: Report format. Accepted options: 'csv' or 'json'. Defaults to 'json'.
+        Accepts an actor name (e.g., 'WARP PANDA') or numeric ID. Returns MITRE ATT&CK
+        tactics, techniques, and procedures (TTPs) for the actor. JSON format returns a
+        decoded string; CSV format returns CSV text.
         """
 
         # Check if the actor parameter looks like an ID (numeric) or a name

--- a/falcon_mcp/modules/ioc.py
+++ b/falcon_mcp/modules/ioc.py
@@ -82,7 +82,7 @@ class IOCModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter to limit IOC search results. IMPORTANT: use the `falcon://ioc/search/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://ioc/search/fql-guide` for syntax.",
             examples={"type:'domain'+expired:false", "source:'mcp'"},
         ),
         limit: int = Field(
@@ -120,8 +120,9 @@ class IOCModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search custom IOCs and return full IOC details.
 
-        IMPORTANT: You must use the `falcon://ioc/search/fql-guide` resource
-        when you need to use the `filter` parameter.
+        Use this to find IOCs by type, value, action, severity, or expiration status.
+        Consult falcon://ioc/search/fql-guide before constructing filter expressions.
+        Returns full indicator records including metadata, platforms, and host groups.
         """
         indicator_ids = self._base_search_api_call(
             operation="indicator_search_v1",
@@ -230,7 +231,11 @@ class IOCModule(BaseModule):
             description="Whether to submit IOCs to retrodetect processing.",
         ),
     ) -> list[dict[str, Any]]:
-        """Create one or more custom IOCs."""
+        """Create one or more custom IOCs.
+
+        Provide type/value/action for a single IOC, or pass a bulk indicators array.
+        Returns the created indicator records on success.
+        """
         payload_or_error = self._build_add_ioc_payload(
             type=type,
             value=value,
@@ -288,7 +293,11 @@ class IOCModule(BaseModule):
             description="Limit action to IOCs originating from the MSSP parent.",
         ),
     ) -> list[dict[str, Any]]:
-        """Remove custom IOCs by IDs or FQL filter."""
+        """Remove custom IOCs by IDs or FQL filter.
+
+        Provide either specific IDs or an FQL filter for bulk removal. If both are
+        given, filter takes precedence. Returns an empty list on success.
+        """
         if not ids and not filter:
             return [
                 _format_error_response(

--- a/falcon_mcp/modules/ngsiem.py
+++ b/falcon_mcp/modules/ngsiem.py
@@ -92,21 +92,10 @@ class NGSIEMModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Execute a CQL query against CrowdStrike Next-Gen SIEM.
 
-        This tool executes pre-written CQL queries provided by the user. It does NOT
-        assist with query construction - users must supply complete, valid CQL syntax.
-
-        The tool starts an asynchronous search job, polls for completion (up to the
-        configured timeout), and returns matching events.
-
-        Note: Search times out after FALCON_MCP_NGSIEM_TIMEOUT seconds (default: 300).
-        Polling interval is controlled by FALCON_MCP_NGSIEM_POLL_INTERVAL (default: 5).
-
-        Args:
-            query_string (required): The CQL query to execute. Example: '#event_simpleName=ProcessRollup2'
-            start (required): ISO 8601 timestamp for search start. Example: '2025-01-01T00:00:00Z'
-            repository (optional): Repository to search. Default: 'search-all'.
-                Options: search-all, investigate_view, third-party, falcon_for_it_view, forensics_view
-            end (optional): ISO 8601 timestamp for search end. Defaults to current time.
+        Use this to search security events, logs, and telemetry; callers must supply
+        a complete, valid CQL query — this tool does not assist with query construction.
+        Returns matching event records, or an error dict if the job fails or times out.
+        Search times out after FALCON_MCP_NGSIEM_TIMEOUT seconds (default: 300).
         """
         # Step 1: Start the search job
         # Note: FalconPy uber class passes body unchanged; API expects camelCase keys

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -16,7 +16,6 @@ from pydantic import AnyUrl, Field
 from falcon_mcp.common.logging import get_logger
 from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.resources.rtr import (
-    EMBEDDED_FQL_SYNTAX,
     SEARCH_RTR_SESSIONS_FQL_DOCUMENTATION,
 )
 
@@ -126,7 +125,7 @@ class RTRModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description=EMBEDDED_FQL_SYNTAX,
+            description="FQL filter expression. See `falcon://rtr/sessions/search/fql-guide` for syntax.",
             examples=["hostname:'BRR-WB-LIB-22'", "aid:'2c5c4e7738...'"],
         ),
         limit: int = Field(
@@ -150,10 +149,9 @@ class RTRModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search RTR sessions and return full session details.
 
-        IMPORTANT: You must use the `falcon://rtr/sessions/search/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_rtr_sessions` tool.
-
-        Returns FQL syntax guide on error or empty results to help refine queries.
+        Use this to find sessions by hostname, agent ID, user, or creation time. Consult
+        falcon://rtr/sessions/search/fql-guide before constructing filter expressions.
+        Returns session metadata including host info, commands executed, and status.
         """
         session_ids = self._base_search_api_call(
             operation="RTR_ListAllSessions",
@@ -194,7 +192,12 @@ class RTRModule(BaseModule):
             description="RTR session IDs to retrieve details for.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Retrieve detailed metadata for one or more RTR sessions."""
+        """Retrieve detailed metadata for one or more RTR sessions.
+
+        Use when you already have session IDs from search results. For discovering
+        sessions by criteria, use falcon_search_rtr_sessions instead. Returns full
+        session records.
+        """
         logger.debug("Getting RTR session details for IDs: %s", ids)
 
         if not ids:
@@ -231,7 +234,12 @@ class RTRModule(BaseModule):
             description="Alternate duration syntax such as `30s`, `2m`, or `1h`.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Initialize or reuse an RTR session for a single host."""
+        """Initialize or reuse an RTR session for a single host.
+
+        Opens a live connection to the specified device for executing RTR commands.
+        Use queue_offline=True if the host may be offline. Returns session records
+        containing the session_id needed for subsequent commands.
+        """
         return self._base_query_api_call(
             operation="RTR_InitSession",
             query_params={
@@ -260,7 +268,11 @@ class RTRModule(BaseModule):
             description="Queue the pulse if the host is currently offline.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Refresh an RTR session timeout for a single host."""
+        """Refresh an RTR session timeout for a single host.
+
+        Keeps an existing session alive by resetting its inactivity timer. Use this
+        to prevent session expiration during long investigations.
+        """
         return self._base_query_api_call(
             operation="RTR_PulseSession",
             body_params={
@@ -291,9 +303,9 @@ class RTRModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Execute a read-only RTR command on a single host.
 
-        This tool is intentionally limited to the read-only RTR endpoint for
-        hunt and triage workflows. It does not expose admin or remediation
-        command APIs.
+        Limited to read-only commands (ls, ps, cat, filehash, reg) for hunt and triage
+        workflows. Does not expose admin or remediation commands. Returns command records
+        containing a cloud_request_id for polling output via falcon_check_rtr_command_status.
         """
         return self._base_query_api_call(
             operation="RTR_ExecuteCommand",
@@ -317,7 +329,11 @@ class RTRModule(BaseModule):
             description="Sequence chunk to retrieve for command output. Starts at 0.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Get the status and output chunk for an RTR command."""
+        """Get the status and output for an RTR command execution.
+
+        Poll this after falcon_execute_rtr_read_only_command to retrieve command
+        output. Use sequence_id to paginate through large output chunks.
+        """
         return self._base_query_api_call(
             operation="RTR_CheckCommandStatus",
             query_params={
@@ -333,7 +349,11 @@ class RTRModule(BaseModule):
             description="RTR session ID to retrieve extracted session files for.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """List files currently associated with an RTR session."""
+        """List files extracted during an RTR session.
+
+        Returns file metadata for artifacts captured during the session, such as
+        files pulled with the `get` command.
+        """
         return self._base_query_api_call(
             operation="RTR_ListFilesV2",
             query_params={"session_id": session_id},
@@ -346,7 +366,10 @@ class RTRModule(BaseModule):
             description="RTR session ID to close.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Delete an RTR session."""
+        """Close an RTR session and release the host connection.
+
+        Use this when investigation is complete to free up session resources.
+        """
         return self._base_query_api_call(
             operation="RTR_DeleteSession",
             query_params={"session_id": session_id},

--- a/falcon_mcp/modules/scheduled_reports.py
+++ b/falcon_mcp/modules/scheduled_reports.py
@@ -95,7 +95,7 @@ class ScheduledReportsModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter to limit results. Use id:'<id>' to get specific reports. IMPORTANT: use the `falcon://scheduled-reports/search/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://scheduled-reports/search/fql-guide` for syntax.",
         ),
         limit: int = Field(
             default=10,
@@ -118,23 +118,9 @@ class ScheduledReportsModule(BaseModule):
     ) -> list[dict[str, Any]]:
         """Search for scheduled reports and searches in your CrowdStrike environment.
 
-        Returns full details for matching scheduled report/search entities. Use the filter
-        parameter to narrow results or retrieve specific entities by ID.
-
-        IMPORTANT: You must use the `falcon://scheduled-reports/search/fql-guide` resource
-        when you need to use the `filter` parameter.
-
-        Common use cases:
-        - Get specific report by ID: filter=id:'<report-id>'
-        - Get multiple reports by ID: filter=id:['id1','id2']
-        - Find active reports: filter=status:'ACTIVE'
-        - Find scheduled searches: filter=type:'event_search'
-        - Find by creator: filter=user_id:'user@email.com'
-
-        Examples:
-        - filter=status:'ACTIVE'+type:'event_search' - Active scheduled searches
-        - filter=created_on:>'2023-01-01' - Created after date
-        - filter=id:'45c59557ded4413cafb8ff81e7640456' - Specific report by ID
+        Use this to find reports by status, type, creator, or creation date. Consult
+        falcon://scheduled-reports/search/fql-guide before constructing filter expressions.
+        Returns full report/search entity details including schedule configuration.
         """
         report_ids = self._base_search_api_call(
             operation="scheduled_reports_query",
@@ -171,16 +157,12 @@ class ScheduledReportsModule(BaseModule):
         self,
         id: str = Field(description="Scheduled report/search entity ID to execute."),
     ) -> list[dict[str, Any]]:
-        """Launch a scheduled report on demand.
+        """Launch a scheduled report or search on demand.
 
-        Execute a scheduled report or search immediately, outside of its recurring schedule.
-        This creates a new execution instance that can be tracked and downloaded.
-
-        Returns the execution details including the execution ID which can be used with:
-        - falcon_search_report_executions to check status (filter=id:'<execution-id>')
-        - falcon_download_report_execution to download results when ready
-
-        Note: The report will run with the same parameters as defined in the entity configuration.
+        Executes the report immediately outside its recurring schedule. Returns
+        execution records containing an execution ID that can be tracked with
+        falcon_search_report_executions and downloaded with
+        falcon_download_report_execution when complete.
         """
         result = self._base_query_api_call(
             operation="scheduled_reports_launch",
@@ -198,7 +180,7 @@ class ScheduledReportsModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter to limit results. Use id:'<id>' to get specific executions. IMPORTANT: use the `falcon://scheduled-reports/executions/search/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://scheduled-reports/executions/search/fql-guide` for syntax.",
         ),
         limit: int = Field(
             default=10,
@@ -215,24 +197,11 @@ class ScheduledReportsModule(BaseModule):
             description="Property to sort by. Ex: created_on.asc, last_updated_on.desc",
         ),
     ) -> list[dict[str, Any]]:
-        """Search for scheduled report/search executions in your CrowdStrike environment.
+        """Search for report/search execution history.
 
-        Returns full details for matching executions. Use the filter parameter to narrow
-        results or retrieve specific executions by ID.
-
-        IMPORTANT: You must use the `falcon://scheduled-reports/executions/search/fql-guide`
-        resource when you need to use the `filter` parameter.
-
-        Common use cases:
-        - Get specific execution by ID: filter=id:'<execution-id>'
-        - Get all executions for a report: filter=scheduled_report_id:'<report-id>'
-        - Find completed executions: filter=status:'DONE'
-        - Find failed executions: filter=status:'FAILED'
-
-        Examples:
-        - filter=status:'DONE'+created_on:>'2023-01-01' - Successful runs after date
-        - filter=scheduled_report_id:'abc123' - All executions for report abc123
-        - filter=id:'f1984ff006a94980b352f18ee79aed77' - Specific execution by ID
+        Use this to find executions by status, report ID, or completion date. Consult
+        falcon://scheduled-reports/executions/search/fql-guide before constructing filter
+        expressions. Returns full execution details including status and timestamps.
         """
         execution_ids = self._base_search_api_call(
             operation="report_executions_query",
@@ -268,19 +237,11 @@ class ScheduledReportsModule(BaseModule):
         self,
         id: str = Field(description="Report execution ID to download."),
     ) -> str | list[dict[str, Any]] | dict[str, Any]:
-        """Download generated report results.
+        """Download the results of a completed report execution.
 
-        Download the report results for a completed execution. Only works for executions
-        with status='DONE'.
-
-        The return format depends on how the scheduled report was configured:
-        - CSV format reports: Returns string containing CSV data
-        - JSON format reports: Returns list of result records
-        - PDF format reports: Not supported (returns error - use CSV/JSON instead)
-
-        Note: Check execution status first using falcon_search_report_executions with
-        filter=id:'<execution-id>' to ensure the execution is complete (status='DONE')
-        before attempting to download.
+        Only works for executions with status='DONE'. Check status first using
+        falcon_search_report_executions. Returns CSV string or JSON records depending
+        on the report's configured format. PDF format is not supported.
         """
         prepared_params = prepare_api_parameters({"ids": id})
         response = self.client.command(

--- a/falcon_mcp/modules/sensor_usage.py
+++ b/falcon_mcp/modules/sensor_usage.py
@@ -57,14 +57,15 @@ class SensorUsageModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://sensor-usage/weekly/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://sensor-usage/weekly/fql-guide` for syntax.",
             examples={"event_date:'2024-06-11'", "period:'30'"},
         ),
     ) -> list[dict[str, Any]]:
-        """Search for sensor usage data in your CrowdStrike environment.
+        """Search for weekly sensor usage data in your CrowdStrike environment.
 
-        IMPORTANT: You must use the `falcon://sensor-usage/weekly/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_sensor_usage` tool.
+        Use this to retrieve sensor billing and usage metrics by date or period. Consult
+        falcon://sensor-usage/weekly/fql-guide before constructing filter expressions.
+        Returns weekly usage records.
         """
         # Prepare parameters for GetSensorUsageWeekly
         params = prepare_api_parameters(

--- a/falcon_mcp/modules/serverless.py
+++ b/falcon_mcp/modules/serverless.py
@@ -57,7 +57,7 @@ class ServerlessModule(BaseModule):
     def search_serverless_vulnerabilities(
         self,
         filter: str = Field(
-            description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://serverless/vulnerabilities/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression (required). See `falcon://serverless/vulnerabilities/fql-guide` for syntax.",
             examples={"cloud_provider:'aws'", "severity:'HIGH'"},
         ),
         limit: int | None = Field(
@@ -105,16 +105,12 @@ class ServerlessModule(BaseModule):
             },
         ),
     ) -> list[dict[str, Any]]:
-        """Search for vulnerabilities in your serverless functions across all cloud service providers.
+        """Search for vulnerabilities in serverless functions across all cloud providers.
 
-        This endpoint provides security information in SARIF format, including:
-        - CVE IDs for identified vulnerabilities
-        - Severity levels
-        - Vulnerability descriptions
-        - Additional relevant details
-
-        IMPORTANT: You must use the `falcon://serverless/vulnerabilities/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_serverless_vulnerabilities` tool.
+        Use this to find CVEs in Lambda/Cloud Functions/Azure Functions by severity,
+        provider, or runtime. Consult falcon://serverless/vulnerabilities/fql-guide before
+        constructing filter expressions. Returns vulnerability data in SARIF format
+        including CVE IDs, severity levels, and descriptions.
         """
         # Prepare parameters for GetCombinedVulnerabilitiesSARIF
         params = prepare_api_parameters(

--- a/falcon_mcp/modules/shield.py
+++ b/falcon_mcp/modules/shield.py
@@ -215,18 +215,9 @@ class ShieldModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search individual Falcon Shield (SaaS Security) posture checks with filtering.
 
-        Use the check id from results to call `get_shield_check_affected_entities` for
-        violating entities, `get_shield_check_compliance` for compliance mappings, or
-        `dismiss_shield_check` to dismiss.
-
-        For an aggregated posture summary (total score, status breakdown), use
-        `get_shield_posture_metrics` instead.
-
-        IMPORTANT: Consult the falcon://shield/search/query-guide resource for valid
-        filter parameter values.
-
-        Returns check records containing id, name, status, impact level, affected entity
-        count, and remediation plan."""
+        Use this to find specific failing checks by status, impact, integration, or type; consult
+        falcon://shield/search/query-guide for valid filter values. Returns check records containing
+        id, name, status, impact level, affected entity count, and remediation plan."""
         return self._search_with_docs(
             operation="GetSecurityChecksV3",
             search_params={
@@ -261,13 +252,10 @@ class ShieldModule(BaseModule):
             ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Retrieve the specific entities (users, apps, or devices) that are violating
-        a given Falcon Shield (SaaS Security) posture check.
+        """Retrieve the specific entities (users, apps, or devices) that are violating a given Falcon Shield posture check.
 
-        Use this after `search_shield_checks` to drill into which entities are failing
-        a specific check.
-
-        Returns entity objects with entity name, type, and relevant security details."""
+        Use this after `search_shield_checks` to drill into which entities are failing a specific check. Returns entity
+        objects with entity name, type, and relevant security details."""
         return self._search_with_docs(
             operation="GetSecurityCheckAffectedV3",
             search_params={"id": id, "limit": limit, "offset": offset},
@@ -315,14 +303,11 @@ class ShieldModule(BaseModule):
             ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Get aggregated Falcon Shield (SaaS Security) posture metrics.
+        """Get aggregated Falcon Shield (SaaS Security) posture metrics for a dashboard or summary view.
 
-        Use this for a summary/dashboard view of your security posture. To retrieve
-        individual check records with remediation details, use `search_shield_checks`
-        instead.
-
-        Returns total check counts, overall score percentage, and breakdown of checks
-        by status (Passed, Failed, Dismissed, etc.) across connected SaaS applications."""
+        Use this for a high-level overview of your SaaS security posture; for individual check records
+        with remediation details, use `search_shield_checks` instead. Returns total check counts, overall
+        score percentage, and a breakdown of checks by status across connected SaaS applications."""
         return self._search_with_docs(
             operation="GetMetricsV3",
             search_params={
@@ -343,13 +328,11 @@ class ShieldModule(BaseModule):
             description="Security check ID. Obtain from the id field in results returned by `search_shield_checks`.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Retrieve the compliance framework mappings for a specific Falcon Shield
-        (SaaS Security) posture check.
+        """Retrieve the compliance framework mappings for a specific Falcon Shield posture check.
 
-        Use this to understand the regulatory impact of a failing check.
-
-        Returns compliance objects identifying the framework (e.g., SOC 2, CIS, NIST,
-        PCI DSS), control ID, and control description that the check satisfies."""
+        Use this after `search_shield_checks` to understand the regulatory impact of a failing check.
+        Returns compliance objects identifying the framework (e.g., SOC 2, CIS, NIST, PCI DSS),
+        control ID, and control description that the check satisfies."""
         return self._search_with_docs(
             operation="GetSecurityCheckComplianceV3",
             search_params={"id": id},
@@ -404,15 +387,9 @@ class ShieldModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search Falcon Shield (SaaS Security) alerts for monitored SaaS applications.
 
-        Alert types: configuration_drift (a previously passing check now fails),
-        check_degraded (check status worsened), integration_failure (connectivity issue
-        with a SaaS platform), threat (active threat indicator).
-
-        Pagination: use last_id from the last result for cursor-based pagination, or
-        use offset for offset-based pagination.
-
-        Returns alert objects containing id, type, integration details, timestamp,
-        and severity."""
+        Use this to find configuration drift, degraded checks, integration failures, or active threats;
+        use last_id from the last result for cursor-based pagination or offset for offset-based pagination.
+        Returns alert objects containing id, type, integration details, timestamp, and severity."""
         return self._search_with_docs(
             operation="GetAlertsV3",
             search_params={
@@ -480,20 +457,12 @@ class ShieldModule(BaseModule):
             ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Get events from the Falcon Shield (SaaS Security) activity monitor.
-        Data retained for 180 days.
+        """Get events from the Falcon Shield (SaaS Security) activity monitor; data is retained for 180 days.
 
-        Note: When using integration_id, category, or actor filters, the date range
-        (from_date to to_date) must be within 24 hours.
-
-        Pagination: Use meta.pagination.next as to_date and meta.pagination.offset as
-        skip for subsequent pages.
-
-        IMPORTANT: Consult the falcon://shield/search/query-guide resource for valid
-        category, actor, and projection values.
-
-        Returns activity event objects including timestamp, event name, actor identity,
-        integration, category, and location details."""
+        Use this to investigate user activity, threats, or IoC events across connected SaaS platforms;
+        when filtering by integration_id, category, or actor, the date range must be within 24 hours.
+        Returns activity event objects including timestamp, event name, actor identity, integration,
+        category, and location details."""
         return self._search_with_docs(
             operation="GetActivityMonitorV3",
             search_params={
@@ -539,17 +508,12 @@ class ShieldModule(BaseModule):
             ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """List end-users discovered across Falcon Shield (SaaS Security) connected
-        SaaS applications.
+        """List end-users discovered across Falcon Shield (SaaS Security) connected SaaS applications.
 
-        Use this to audit user access across your SaaS estate or to identify
-        over-privileged or stale accounts.
-
-        To list Shield platform administrators instead of SaaS app end-users, use
-        `get_shield_system_users`.
-
-        Returns user objects containing email, display name, connected application
-        details, privilege status, and exposure metrics."""
+        Use this to audit user access across your SaaS estate or identify over-privileged or stale accounts;
+        for Shield platform administrators instead of SaaS app end-users, use `get_shield_system_users`.
+        Returns user objects containing email, display name, connected application details, privilege status,
+        and exposure metrics."""
         return self._search_with_docs(
             operation="GetUserInventoryV3",
             search_params={
@@ -596,15 +560,11 @@ class ShieldModule(BaseModule):
             ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """List devices registered to users in Falcon Shield (SaaS Security) connected
-        SaaS applications.
+        """List devices registered to users in Falcon Shield (SaaS Security) connected SaaS applications.
 
-        Note: This returns devices from SaaS provider records, not from the Falcon
-        sensor inventory. To search Falcon-sensor-enrolled hosts, use `search_hosts`
-        instead.
-
-        Returns device objects containing device name, owner email, compliance posture,
-        and management status."""
+        Use this to identify unmanaged or unassociated devices in your SaaS estate; note that this returns
+        devices from SaaS provider records, not Falcon sensor inventory — use `search_hosts` for that.
+        Returns device objects containing device name, owner email, compliance posture, and management status."""
         return self._search_with_docs(
             operation="GetDeviceInventoryV3",
             search_params={
@@ -675,15 +635,12 @@ class ShieldModule(BaseModule):
             ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """List third-party applications (OAuth apps, API tokens, browser extensions,
-        service principals) with access to Falcon Shield (SaaS Security) monitored
-        platforms.
+        """List third-party applications (OAuth apps, API tokens, browser extensions, service principals)
+        with access to Falcon Shield (SaaS Security) monitored platforms.
 
-        Use the item_id from results with `get_shield_app_users` to retrieve the users
-        of a specific app.
-
-        Returns app objects containing item_id, name, type, status, access_level,
-        granted scopes, and user count."""
+        Use this to audit app access across your SaaS estate; use the item_id from results with
+        `get_shield_app_users` to see who authorized a specific app. Returns app objects containing
+        item_id, name, type, status, access_level, granted scopes, and user count."""
         return self._search_with_docs(
             operation="GetAppInventory",
             search_params={
@@ -710,12 +667,9 @@ class ShieldModule(BaseModule):
             ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Retrieve the users who have authorized or are associated with a specific
-        third-party app in Falcon Shield (SaaS Security).
+        """Retrieve the users who have authorized or are associated with a specific third-party app in Falcon Shield.
 
-        Use this after `search_shield_apps` to drill into a specific app's user
-        population.
-
+        Use this after `search_shield_apps` to drill into a specific app's user population.
         Returns user objects including email, display name, and granted permissions."""
         return self._search_with_docs(
             operation="GetAppInventoryUsers",
@@ -798,14 +752,11 @@ class ShieldModule(BaseModule):
             ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """List files and resources shared externally across Falcon Shield (SaaS
-        Security) monitored SaaS applications.
+        """List files and resources shared externally across Falcon Shield (SaaS Security) monitored applications.
 
-        Use this to identify overshared or externally exposed files (e.g., Google
-        Drive documents shared outside the organization).
-
-        Returns resource objects containing resource name, type, owner, sharing access
-        level, password protection status, and last access/modification timestamps."""
+        Use this to identify overshared or externally exposed files such as Google Drive documents shared
+        outside the organization. Returns resource objects containing resource name, type, owner, sharing
+        access level, password protection status, and last access/modification timestamps."""
         return self._search_with_docs(
             operation="GetAssetInventoryV3",
             search_params={
@@ -832,15 +783,11 @@ class ShieldModule(BaseModule):
             description="Comma-separated SaaS platform IDs to filter by.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """List all SaaS integrations connected to Falcon Shield (SaaS Security) and
-        their current connection status.
+        """List all SaaS integrations connected to Falcon Shield and their current connection status.
 
-        The integration_id values returned here are used as input to most other Shield
-        tools. Call this tool first when starting a Shield investigation to discover
-        available integrations.
-
-        Returns integration objects containing integration_id, SaaS platform name,
-        connection health, and last sync time."""
+        Call this first when starting a Shield investigation to discover available integration IDs,
+        which are required as input to most other Shield tools. Returns integration objects containing
+        integration_id, SaaS platform name, connection health, and last sync time."""
         return self._search_with_docs(
             operation="GetIntegrationsV3",
             search_params={"saas_id": saas_id},
@@ -850,10 +797,9 @@ class ShieldModule(BaseModule):
     def get_shield_system_users(self) -> list[dict[str, Any]] | dict[str, Any]:
         """List Falcon Shield (SaaS Security) platform administrators.
 
-        These are Shield console administrators, not end-users of connected SaaS
-        applications. For SaaS app end-users, use `search_shield_users`.
-
-        Returns system-level user objects including email, role, and MFA status."""
+        Use this to audit console-level admin accounts; for end-users of connected SaaS applications,
+        use `search_shield_users` instead. Returns system-level user objects including email, role,
+        and MFA status."""
         return self._search_with_docs(
             operation="GetSystemUsersV3",
             search_params={},
@@ -861,11 +807,9 @@ class ShieldModule(BaseModule):
         )
 
     def get_shield_supported_saas(self) -> list[dict[str, Any]] | dict[str, Any]:
-        """List SaaS platforms supported by Falcon Shield (SaaS Security) for integration.
+        """List SaaS platforms supported by Falcon Shield for integration.
 
-        Use this to discover which SaaS applications can be connected to Shield
-        before setting up new integrations.
-
+        Use this to discover which SaaS applications can be connected before setting up new integrations.
         Returns supported SaaS platform objects including platform name and ID."""
         return self._search_with_docs(
             operation="GetSupportedSaasV3",
@@ -900,15 +844,10 @@ class ShieldModule(BaseModule):
             description="If true, include total count of matching logs in the response metadata.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Retrieve Falcon Shield (SaaS Security) system audit logs. Data retained
-        for 90 days.
+        """Retrieve Falcon Shield (SaaS Security) system audit logs; data is retained for 90 days.
 
-        Logs include integration creates/updates, check dismissals, and data syncs.
-
-        Use date range filters to narrow results. Without filters, returns the most
-        recent logs up to the limit.
-
-        Returns log objects containing timestamp, event type, actor, and details."""
+        Use date range filters to narrow results, covering events such as integration creates, check
+        dismissals, and data syncs. Returns log objects containing timestamp, event type, actor, and details."""
         return self._search_with_docs(
             operation="GetSystemLogsV3",
             search_params={
@@ -943,15 +882,12 @@ class ShieldModule(BaseModule):
             ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Dismiss a Falcon Shield (SaaS Security) posture check to suppress it from
-        the failed checks list.
+        """Dismiss a Falcon Shield (SaaS Security) posture check to suppress it from the failed checks list.
 
-        WARNING: This action is permanent and cannot be undone from the API. The
-        dismissal reason is recorded in audit logs.
-
-        When entities is omitted, the entire check is dismissed for all entities.
-        When entities is provided, only the specified entities are dismissed and the
-        check remains active for others."""
+        Use this only when a check is intentionally accepted as a known risk; omit entities to dismiss
+        the entire check for all entities, or provide specific entity names to dismiss only those.
+        This action is permanent and cannot be undone from the API — the dismissal reason is recorded
+        in audit logs."""
         if isinstance(entities, str):
             operation = "DismissAffectedEntityV3"
             body = {

--- a/falcon_mcp/modules/spotlight.py
+++ b/falcon_mcp/modules/spotlight.py
@@ -56,7 +56,7 @@ class SpotlightModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL Syntax formatted string used to limit the results. IMPORTANT: use the `falcon://spotlight/vulnerabilities/fql-guide` resource when building this filter parameter.",
+            description="FQL filter expression. See `falcon://spotlight/vulnerabilities/fql-guide` for syntax.",
             examples={"status:'open'", "cve.severity:'HIGH'"},
         ),
         limit: int = Field(
@@ -117,8 +117,10 @@ class SpotlightModule(BaseModule):
     ) -> list[dict[str, Any]]:
         """Search for vulnerabilities in your CrowdStrike environment.
 
-        IMPORTANT: You must use the `falcon://spotlight/vulnerabilities/fql-guide` resource when you need to use the `filter` parameter.
-        This resource contains the guide on how to build the FQL `filter` parameter for the `falcon_search_vulnerabilities` tool.
+        Use this to find vulnerabilities by CVE severity, status, host, or remediation
+        state. Consult falcon://spotlight/vulnerabilities/fql-guide before constructing
+        filter expressions. Returns vulnerability details including CVE info, host context,
+        and remediation guidance (based on facet selection).
         """
         vulnerabilities = self._base_search_api_call(
             operation="combinedQueryVulnerabilities",

--- a/falcon_mcp/resources/detections.py
+++ b/falcon_mcp/resources/detections.py
@@ -4,35 +4,6 @@ Contains Detections resources.
 
 from falcon_mcp.common.utils import generate_md_table
 
-# Concise FQL syntax for embedding in tool parameter descriptions
-EMBEDDED_FQL_SYNTAX = """FQL filter string for querying detections.
-
-SYNTAX:
-- Equals: field:'value'
-- Not equals: field:!'value'
-- Comparison: field:>50, field:>=50, field:<50, field:<=50
-- Contains (case-insensitive): field:~'partial'
-- Wildcard: field:'prefix*', field:'*suffix'
-
-COMBINING:
-- AND (all must match): field1:'value1'+field2:'value2'
-- OR (any can match): field:'value1',field:'value2'
-- Grouping: (status:'new',status:'in_progress')+severity_name:'High'
-
-COMMON FIELDS:
-- status: 'new', 'in_progress', 'closed', 'reopened'
-- severity_name: 'Informational', 'Low', 'Medium', 'High', 'Critical'
-- product: 'epp', 'idp', 'xdr', 'overwatch'
-- device.hostname: Hostname contains string
-- created_timestamp: ISO 8601 format (e.g., '2025-01-14T00:00:00Z')
-
-EXAMPLES:
-- New high/critical alerts: status:'new'+(severity_name:'High',severity_name:'Critical')
-- Last 24h endpoint detections: created_timestamp:>'2025-01-14T00:00:00Z'+product:'epp'
-- Hostname pattern: device.hostname:'DC*'+status:'new'
-- Unassigned critical: assigned_to_name:!'*'+severity_name:'Critical'
-"""
-
 # List of tuples containing filter options data: (name, type, description)
 SEARCH_DETECTIONS_FQL_FILTERS = [
     (

--- a/falcon_mcp/resources/rtr.py
+++ b/falcon_mcp/resources/rtr.py
@@ -4,39 +4,6 @@ Contains RTR (Real Time Response) resources.
 
 from falcon_mcp.common.utils import generate_md_table
 
-# Concise FQL syntax for embedding in tool parameter descriptions
-EMBEDDED_FQL_SYNTAX = """FQL filter string for querying RTR sessions.
-
-SYNTAX:
-- Equals: field:'value'
-- Not equals: field:!'value'
-- Comparison: field:>50, field:>=50, field:<50, field:<=50
-- Contains (case-insensitive): field:~'partial'
-- Wildcard: field:'prefix*', field:'*suffix'
-
-COMBINING:
-- AND (all must match): field1:'value1'+field2:'value2'
-- OR (any can match): field:'value1',field:'value2'
-- Grouping: (field1:'v1',field1:'v2')+field2:'v3'
-
-COMMON FIELDS:
-- aid: Host agent ID
-- hostname: Host name
-- user_id: API user who created the session ('@me' for current user)
-- origin: Session origin label (e.g., 'falcon-mcp')
-- created_at: Session creation timestamp (ISO 8601)
-- updated_at: Last update timestamp (ISO 8601)
-- base_command: RTR command name (e.g., 'ls', 'ps', 'cat')
-- command_string: Full command line executed
-- offline_queued: Whether session was queued offline (true/false)
-
-EXAMPLES:
-- Sessions for a host: hostname:'BRR-WB-LIB-22'
-- Sessions by agent ID: aid:'2c5c4e7738004deaa9dfcdb86f633f3e'
-- Current user sessions: user_id:'@me'
-- Offline-queued sessions: offline_queued:true+hostname:'DC*'
-"""
-
 # List of tuples containing filter options data: (name, type, description)
 SEARCH_RTR_SESSIONS_FQL_FILTERS = [
     (


### PR DESCRIPTION
Tool descriptions were all over the place — some had multi-paragraph FQL boilerplate repeated in both the docstring and parameter description, others were bare one-liners that gave the model nothing to work with.

We researched what actually matters: Anthropic's tool use docs say 3-4 sentences minimum and call description quality "by far the most important factor in tool performance." Real-world MCP servers all landed on 2-4 sentence prose. The MCP spec is silent on format and the Python SDK passes docstrings through verbatim.

Every tool across all 16 modules now follows a consistent pattern — what it does, when to use it, an FQL resource pointer for search tools, and what gets returned. Return claims were validated against live API responses, which caught a few wrong ones (filed separately as #382, #383, #384).

Also removed the dead EMBEDDED_FQL_SYNTAX constants from the detections and rtr resource files, and updated the developer docs (both docs/ and docs-site/) to reflect the new standard.

Closes #380