### PR TITLE
feat(modules/cases): add Case Management module

### DIFF
--- a/docs-site/src/content/docs/modules/cases.md
+++ b/docs-site/src/content/docs/modules/cases.md
@@ -1,0 +1,156 @@
+---
+title: Case Management
+description: Managing CrowdStrike cases, including searching, creating, updating, and managing evidence and tags
+sidebar:
+  order: 10
+---
+
+Managing CrowdStrike cases, including searching, creating, updating, and managing evidence and tags
+
+## API Scopes
+
+- `Case Templates:read`
+- `Cases:read`
+- `Cases:write`
+
+## Tools
+
+### `falcon_add_case_alert_evidence`
+
+:::note
+This tool modifies data.
+:::
+
+**Required scopes:** `Cases:write`
+
+Attach alert evidence to an existing case.
+
+Provide alert composite_id values from the Alerts v2 API (e.g. from
+falcon_search_detections). Each case supports a maximum of 100 combined
+evidence items. Returns the updated case record.
+
+**Example prompts:**
+
+- "Attach these detection alerts to the open case"
+
+### `falcon_add_case_event_evidence`
+
+:::note
+This tool modifies data.
+:::
+
+**Required scopes:** `Cases:write`
+
+Attach LogScale event evidence to an existing case.
+
+Provide event IDs obtained from falcon_search_ngsiem or the Falcon
+console. Each case supports a maximum of 100 combined evidence items.
+Returns the updated case record.
+
+**Example prompts:**
+
+- "Add these NGSIEM event IDs to the case as evidence"
+
+### `falcon_create_case`
+
+:::note
+This tool modifies data.
+:::
+
+**Required scopes:** `Cases:write`
+
+Create a new case in CrowdStrike.
+
+Provide a name and severity at minimum. Optionally attach alert or event
+evidence, assign a user, apply a template, and set tags. Returns the
+created case record.
+
+**Example prompts:**
+
+- "Create a high-severity case for the suspicious lateral movement investigation"
+- "Open a new case and attach these alert IDs as evidence"
+
+### `falcon_get_cases`
+
+**Required scopes:** `Cases:read`
+
+Retrieve details for case IDs you already have.
+
+Use when you have specific case IDs from search results or external
+references. For discovering cases by criteria, use falcon_search_cases
+instead. Returns full case records.
+
+**Example prompts:**
+
+- "Get details for this case ID"
+
+### `falcon_list_case_templates`
+
+**Required scopes:** `Case Templates:read`
+
+List available case templates.
+
+Use to discover templates that can be applied when creating or updating
+cases. Returns template details including name, custom fields, and SLA
+configuration.
+
+**Example prompts:**
+
+- "Show me the available case templates"
+
+### `falcon_manage_case_tags`
+
+:::note
+This tool modifies data.
+:::
+
+**Required scopes:** `Cases:write`
+
+Add or remove tags on a case.
+
+Set action to 'add' to attach new tags, or 'remove' to delete existing
+tags. Returns the updated case record.
+
+**Example prompts:**
+
+- "Tag this case with 'ransomware' and 'priority'"
+- "Remove the 'false-positive' tag from this case"
+
+### `falcon_search_cases`
+
+**Required scopes:** `Cases:read`
+
+Find cases by criteria and return their complete details.
+
+Use this to discover cases by status, severity, assignee, time range, or
+evidence attributes. Consult falcon://cases/search/fql-guide before
+constructing filter expressions. Returns full case records including
+status, severity, evidence, assigned user, and analysis results.
+
+**Example prompts:**
+
+- "Show me all open high-severity cases"
+- "Find cases assigned to me that are in progress"
+
+### `falcon_update_case`
+
+:::note
+This tool modifies data.
+:::
+
+**Required scopes:** `Cases:write`
+
+Update an existing case's fields.
+
+Provide the case ID and any fields to change. Use expected_version for
+optimistic concurrency control to prevent conflicting updates. Returns the
+updated case record with incremented version.
+
+**Example prompts:**
+
+- "Close case ABC-1234"
+- "Assign this case to the SOC analyst and set severity to critical"
+
+## Resources
+
+- **`falcon://cases/search/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_cases` tool.

--- a/docs-site/src/content/docs/modules/cases.md
+++ b/docs-site/src/content/docs/modules/cases.md
@@ -31,7 +31,7 @@ evidence items. Returns the updated case record.
 
 **Example prompts:**
 
-- "Attach these detection alerts to the open case"
+- "Attach these detection alerts to the case"
 
 ### `falcon_add_case_event_evidence`
 
@@ -67,8 +67,8 @@ created case record.
 
 **Example prompts:**
 
-- "Create a high-severity case for the suspicious lateral movement investigation"
-- "Open a new case and attach these alert IDs as evidence"
+- "Create a critical case called 'Suspicious lateral movement from WORKSTATION-42'"
+- "Open a high-severity case for the credential theft alerts and attach them as evidence"
 
 ### `falcon_get_cases`
 
@@ -82,7 +82,7 @@ instead. Returns full case records.
 
 **Example prompts:**
 
-- "Get details for this case ID"
+- "Pull up the full details on that case"
 
 ### `falcon_list_case_templates`
 
@@ -96,7 +96,7 @@ configuration.
 
 **Example prompts:**
 
-- "Show me the available case templates"
+- "What case templates are available?"
 
 ### `falcon_manage_case_tags`
 
@@ -113,8 +113,8 @@ tags. Returns the updated case record.
 
 **Example prompts:**
 
-- "Tag this case with 'ransomware' and 'priority'"
-- "Remove the 'false-positive' tag from this case"
+- "Tag that case with 'ransomware' and 'escalated'"
+- "Remove the 'escalated' tag from that case"
 
 ### `falcon_search_cases`
 
@@ -129,8 +129,8 @@ status, severity, evidence, assigned user, and analysis results.
 
 **Example prompts:**
 
-- "Show me all open high-severity cases"
-- "Find cases assigned to me that are in progress"
+- "Show me any open cases with high severity or above"
+- "What cases have been created in the last 24 hours?"
 
 ### `falcon_update_case`
 
@@ -148,8 +148,8 @@ updated case record with incremented version.
 
 **Example prompts:**
 
-- "Close case ABC-1234"
-- "Assign this case to the SOC analyst and set severity to critical"
+- "Set that case to in_progress and assign it to the analyst"
+- "Close the case — investigation is complete"
 
 ## Resources
 

--- a/docs-site/src/content/docs/modules/cloud.md
+++ b/docs-site/src/content/docs/modules/cloud.md
@@ -21,7 +21,11 @@ Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Con
 
 **Required scopes:** `Falcon Container Image:read`
 
-Count kubernetes containers in your CrowdStrike Kubernetes & Containers Inventory
+Count Kubernetes containers matching filter criteria.
+
+Use this for aggregate counts without returning full container details. Consult
+falcon://cloud/kubernetes-containers/fql-guide before constructing filter
+expressions. Returns the count as a single-element list.
 
 **Example prompts:**
 
@@ -33,24 +37,14 @@ Count kubernetes containers in your CrowdStrike Kubernetes & Containers Inventor
 This tool performs destructive operations.
 :::
 
-**Required scopes:** `Cloud Security Policies:write`
+**Required scopes:** `Cloud Security Policies:read`, `Cloud Security Policies:write`
 
-Create a CSPM IOM suppression rule to suppress matching findings.
+Create a CSPM IOM suppression rule to hide matching findings.
 
-WARNING: This creates a suppression rule that will hide matching IOM findings
-from compliance scores and active finding views. Suppressed findings are still
-assessed but not surfaced. Use carefully and prefer narrow scope.
-
-A suppression rule defines:
-- WHICH rules to suppress (by ID, name, or severity)
-- WHICH assets to suppress them for (by cloud provider, account, region, resource)
-- WHY (accept-risk, compensating-control, false-positive)
-- WHEN it expires (strongly recommended)
-
-Requires the modern 'Cloud Security Posture Rules' mode (not legacy policies).
-
-Returns the created suppression rule object on success, or an error dict
-with details on failure.
+Suppressed findings are still assessed but not surfaced in compliance scores.
+Requires at least one rule selection (rule_ids, rule_names, or rule_severities)
+and a suppression reason. Setting an expiration_date is strongly recommended to
+avoid permanent suppressions. Returns the created suppression rule object.
 
 **Example prompts:**
 
@@ -67,12 +61,9 @@ This tool performs destructive operations.
 
 Delete CSPM IOM suppression rules by ID.
 
-WARNING: Deleting a suppression rule will re-activate all findings that were
-previously suppressed by that rule. They will appear as open findings again.
-
-Use falcon_search_cspm_suppression_rules first to identify which rules to delete.
-
-Returns a confirmation response on success, or an error dict on failure.
+Deleting a suppression rule re-activates all findings that were previously
+suppressed by it. Use falcon_search_cspm_suppression_rules to find rule IDs
+first. Returns a confirmation response.
 
 **Example prompts:**
 
@@ -83,15 +74,12 @@ Returns a confirmation response on success, or an error dict on failure.
 
 **Required scopes:** `Cloud Security API Assets:read`
 
-Search for cloud assets in your CrowdStrike CSPM Asset Inventory.
+Search for cloud assets in your CrowdStrike CSPM inventory.
 
-This tool queries cloud resources (EC2 instances, VPCs, subnets, load balancers, etc.)
-managed by CrowdStrike CSPM. Supports comprehensive FQL filtering including:
-- Cloud provider and resource type filtering
-- Tag-based filtering (AWS/Azure/GCP tags)
-- Security posture (publicly exposed, severity, IOM/IOA counts)
-- Compliance status and benchmarks
-- Temporal filtering (creation time, last updated)
+Use this to find cloud resources (EC2, VPCs, S3, etc.) by provider, region,
+resource type, or tags. Consult falcon://cloud/cspm-assets/fql-guide before
+constructing filter expressions. Returns slimmed asset details with security
+posture context (IOM/IOA counts, exposure, severity).
 
 **Example prompts:**
 
@@ -103,15 +91,9 @@ managed by CrowdStrike CSPM. Supports comprehensive FQL filtering including:
 
 Search for CSPM IOM suppression rules.
 
-Lists suppression rules that control which IOM findings are suppressed.
-Suppression rules define which rules and assets are excluded from generating
-active findings, along with the reason and optional expiration date.
-
-Use this to review existing suppressions before creating new ones.
-
-Returns a list of suppression rule objects containing: id, name, domain,
-subdomain, disabled, rule_selection_type, scope_type, suppression_reason,
-created_at, created_by. Returns an empty list if no rules exist.
+Use this to review existing suppressions before creating new ones. Returns
+suppression rule objects including scope, reason, and expiration details.
+Returns an empty list if no rules exist.
 
 **Example prompts:**
 
@@ -122,7 +104,12 @@ created_at, created_by. Returns an empty list if no rules exist.
 
 **Required scopes:** `Falcon Container Image:read`
 
-Search for images vulnerabilities in your CrowdStrike Image Assessments
+Search for container image vulnerabilities in CrowdStrike Image Assessments.
+
+Use this to find CVEs affecting container images by severity, CVSS score, or
+CVE ID. Consult falcon://cloud/images-vulnerabilities/fql-guide before constructing
+filter expressions. Returns vulnerability details including CVE IDs, scores, and
+impacted image counts.
 
 **Example prompts:**
 
@@ -134,18 +121,10 @@ Search for images vulnerabilities in your CrowdStrike Image Assessments
 
 Search for CSPM Indicators of Misconfiguration (IOM) findings.
 
-Retrieves cloud security posture findings that identify misconfigurations
-in your cloud environment (AWS, Azure, GCP). Findings map to compliance
-frameworks (CIS, NIST, SOC2) and MITRE ATT&CK techniques.
-
-Supports filtering by suppression state to view which findings have been
-accepted as risk, marked as false positives, or have compensating controls.
-
-Returns a list of IOM finding entities with nested structure:
-- id: Unique finding identifier
-- cloud: {account_id, account_name, provider, region}
-- evaluation: {severity, status, attack_types, rule, created, url}
-- resource: {resource_id, resource_type, service, service_category}
+Use this to find cloud misconfigurations by severity, provider, service, or
+suppression state. Consult falcon://cloud/cspm-iom-findings/fql-guide before
+constructing filter expressions. Returns IOM entities with cloud context,
+evaluation details, and resource information.
 
 **Example prompts:**
 
@@ -157,7 +136,11 @@ Returns a list of IOM finding entities with nested structure:
 
 **Required scopes:** `Falcon Container Image:read`
 
-Search for kubernetes containers in your CrowdStrike Kubernetes & Containers Inventory
+Search for Kubernetes containers in your CrowdStrike container inventory.
+
+Use this to find containers by cluster, namespace, image, or cloud provider.
+Consult falcon://cloud/kubernetes-containers/fql-guide before constructing filter
+expressions. Returns full container details including image, status, and vulnerabilities.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/custom-ioa.md
+++ b/docs-site/src/content/docs/modules/custom-ioa.md
@@ -24,13 +24,9 @@ This tool modifies data.
 
 Create a new Custom IOA behavioral detection rule within a rule group.
 
-Before creating a rule:
-1. Use `falcon_get_ioa_rule_types` to discover available rule types, their IDs,
-   required fields, and valid disposition IDs.
-2. Use `falcon_search_ioa_rule_groups` to find the target rule group ID.
-
-The `field_values` parameter defines the behavioral criteria the rule will match
-against (e.g., process names, file paths, command line patterns using regex).
+Use falcon_get_ioa_rule_types first to discover rule type IDs, required fields,
+and valid disposition IDs. The field_values parameter defines the behavioral
+criteria the rule matches against (process names, file paths, command line regex).
 
 **Example prompts:**
 
@@ -46,11 +42,9 @@ This tool modifies data.
 
 Create a new Custom IOA rule group.
 
-Rule groups are containers that hold behavioral detection rules for a specific
-platform. After creating a group, use `falcon_create_ioa_rule` to add detection
-rules to it.
-
-Use `falcon_get_ioa_platforms` to see available platform values.
+Rule groups are containers for behavioral detection rules scoped to a platform.
+Use falcon_get_ioa_platforms to see valid platform values. After creating a
+group, use falcon_create_ioa_rule to add detection rules to it.
 
 **Example prompts:**
 
@@ -66,8 +60,8 @@ This tool performs destructive operations.
 
 Delete Custom IOA rule groups by ID.
 
-This permanently removes the rule groups and all rules within them.
-Use `falcon_search_ioa_rule_groups` to find rule group IDs.
+Permanently removes the rule groups and all rules within them. Use
+falcon_search_ioa_rule_groups to find rule group IDs.
 
 **Example prompts:**
 
@@ -83,8 +77,8 @@ This tool performs destructive operations.
 
 Delete Custom IOA behavioral detection rules from a rule group.
 
-Use `falcon_search_ioa_rule_groups` to find the rule group ID and
-the individual rule IDs (instance IDs) to delete.
+Use falcon_search_ioa_rule_groups to find the rule group ID and individual
+rule instance IDs to delete.
 
 **Example prompts:**
 
@@ -96,8 +90,8 @@ the individual rule IDs (instance IDs) to delete.
 
 Get all available platforms for Custom IOA rule groups.
 
-Returns details about each available platform (e.g., windows, mac, linux).
-Use this to discover valid platform values before creating a rule group.
+Use this to discover valid platform values (windows, mac, linux) before
+creating a rule group. Returns platform details.
 
 **Example prompts:**
 
@@ -109,12 +103,9 @@ Use this to discover valid platform values before creating a rule group.
 
 Get all available Custom IOA rule types.
 
-Returns details about each rule type including its name, platform, fields,
-and supported disposition IDs. Use this to discover valid rule type IDs and
-required field values before creating a behavioral rule.
-
-Rule types define the category of behavioral detection (e.g., Process Creation,
-Network Connection, File Creation).
+Use this to discover valid rule type IDs, required fields, and disposition IDs
+before creating a behavioral detection rule. Returns rule type details including
+platform, fields, and supported actions.
 
 **Example prompts:**
 
@@ -124,10 +115,11 @@ Network Connection, File Creation).
 
 **Required scopes:** `Custom IOA Rules:read`
 
-Search Custom IOA rule groups and return full rule group details including their rules.
+Search Custom IOA rule groups and return full details including their rules.
 
-Rule groups are containers that hold behavioral detection rules. Each group is
-associated with a specific platform (windows, mac, or linux).
+Use this to find rule groups by platform, name, or enabled state. Consult
+falcon://custom-ioa/rule-groups/fql-guide before constructing filter expressions.
+Returns rule group objects with their contained behavioral detection rules.
 
 **Example prompts:**
 
@@ -143,9 +135,8 @@ This tool modifies data.
 
 Update an existing Custom IOA behavioral detection rule.
 
-The `rulegroup_version` is required for optimistic locking to prevent
-concurrent modification conflicts. Use `falcon_search_ioa_rule_groups` to
-retrieve the current version and instance ID.
+Requires rulegroup_version for optimistic locking. Get the current version
+and instance_id from falcon_search_ioa_rule_groups.
 
 **Example prompts:**
 
@@ -161,11 +152,8 @@ This tool modifies data.
 
 Update an existing Custom IOA rule group.
 
-You can modify the name, description, and enabled state of a rule group.
-The `rulegroup_version` is required for optimistic locking to prevent
-concurrent modification conflicts.
-
-Use `falcon_search_ioa_rule_groups` to retrieve the current version number.
+Modify name, description, or enabled state. Requires rulegroup_version for
+optimistic locking — get it from falcon_search_ioa_rule_groups.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/detections.md
+++ b/docs-site/src/content/docs/modules/detections.md
@@ -19,8 +19,9 @@ Accessing and analyzing CrowdStrike Falcon detections
 
 Retrieve details for detection IDs you already have.
 
-Use ONLY when you have specific composite detection ID(s). To find detections
-by criteria (severity, status, hostname, etc.), use `falcon_search_detections`.
+Use when you have specific composite detection ID(s). For discovering detections
+by criteria (severity, status, hostname, etc.), use falcon_search_detections
+instead. Returns full detection records.
 
 **Example prompts:**
 
@@ -32,9 +33,10 @@ by criteria (severity, status, hostname, etc.), use `falcon_search_detections`.
 
 Find detections by criteria and return their complete details.
 
-Use this tool to discover detections - filter by severity, status, hostname,
-time range, etc. Returns full detection information including behaviors,
-device context, and threat details.
+Use this to discover detections by severity, status, hostname, time range, or
+other attributes. Consult falcon://detections/search/fql-guide before constructing
+filter expressions. Returns full alert records including process context, device
+info, tactic/technique details, and threat classification.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/discover.md
+++ b/docs-site/src/content/docs/modules/discover.md
@@ -17,7 +17,11 @@ Accessing and managing CrowdStrike Falcon Discover applications and unmanaged as
 
 **Required scopes:** `Assets:read`
 
-Search for applications in your CrowdStrike environment.
+Search for applications discovered in your CrowdStrike environment.
+
+Use this to find applications by name, vendor, or installation details. Consult
+falcon://discover/applications/fql-guide before constructing filter expressions.
+Returns application entities with optional host info and usage data (based on facet).
 
 **Example prompts:**
 
@@ -27,13 +31,12 @@ Search for applications in your CrowdStrike environment.
 
 **Required scopes:** `Assets:read`
 
-Search for unmanaged assets (hosts) in your CrowdStrike environment.
+Search for unmanaged assets (hosts without Falcon sensor) in your environment.
 
-These are systems that do not have the Falcon sensor installed but have been
-discovered by systems that do have a Falcon sensor installed.
-
-The tool automatically filters for unmanaged assets only by adding entity_type:'unmanaged' to all queries.
-You do not need to (and cannot) specify entity_type in your filter - it is always set to 'unmanaged'.
+Finds systems discovered by Falcon-managed hosts that lack a sensor themselves.
+Consult falcon://discover/hosts/fql-guide before constructing filter expressions.
+The tool automatically adds entity_type:'unmanaged' to all queries. Returns full
+asset details including platform, network, and criticality information.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/firewall.md
+++ b/docs-site/src/content/docs/modules/firewall.md
@@ -24,6 +24,9 @@ This tool modifies data.
 
 Create a firewall rule group.
 
+Provide a name, platform, and either rules or a clone_id. Returns a list
+containing the created rule group object.
+
 **Example prompts:**
 
 - "Create a Windows firewall rule group named 'Prod Outbound'"
@@ -38,6 +41,9 @@ This tool performs destructive operations.
 
 Delete firewall rule groups by ID.
 
+Permanently removes the specified rule groups and all rules within them.
+Returns an empty list on success.
+
 **Example prompts:**
 
 - "Delete firewall rule group abc123"
@@ -46,7 +52,11 @@ Delete firewall rule groups by ID.
 
 **Required scopes:** `Firewall Management:read`
 
-Search firewall rules in a specific policy container and return full rule details.
+Search firewall rules within a specific policy container.
+
+Use this when you need rules scoped to a particular policy. Consult
+falcon://firewall/rules/fql-guide before constructing filter expressions.
+Returns full rule details for the specified policy.
 
 **Example prompts:**
 
@@ -58,6 +68,10 @@ Search firewall rules in a specific policy container and return full rule detail
 
 Search firewall rule groups and return full rule group details.
 
+Use this to find rule groups by name, platform, or enabled state. Consult
+falcon://firewall/rules/fql-guide before constructing filter expressions.
+Returns rule group objects including their contained rules.
+
 **Example prompts:**
 
 - "Find all enabled firewall rule groups for Windows"
@@ -67,6 +81,10 @@ Search firewall rule groups and return full rule group details.
 **Required scopes:** `Firewall Management:read`
 
 Search firewall rules and return full rule details.
+
+Use this to find firewall rules by name, platform, or enabled state. Consult
+falcon://firewall/rules/fql-guide before constructing filter expressions.
+Returns complete rule objects including conditions and actions.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/hosts.md
+++ b/docs-site/src/content/docs/modules/hosts.md
@@ -17,11 +17,11 @@ Accessing and managing CrowdStrike Falcon hosts/devices
 
 **Required scopes:** `Hosts:read`
 
-Retrieve detailed information for specified host device IDs.
+Retrieve detailed information for one or more host device IDs.
 
-This tool returns comprehensive host details for one or more device IDs.
-Use this when you already have specific device IDs and need their full details.
-For searching/discovering hosts, use the `falcon_search_hosts` tool instead.
+Use when you already have specific device IDs from search results, the Falcon
+console, or the Streaming API. For discovering hosts by criteria, use
+falcon_search_hosts instead. Returns comprehensive host details.
 
 **Example prompts:**
 
@@ -32,6 +32,11 @@ For searching/discovering hosts, use the `falcon_search_hosts` tool instead.
 **Required scopes:** `Hosts:read`
 
 Search for hosts in your CrowdStrike environment.
+
+Use this to find devices by hostname, platform, IP, sensor version, or other
+attributes. Consult falcon://hosts/search/fql-guide before constructing filter
+expressions. Returns full host details including device info, OS, and network
+context.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/idp.md
+++ b/docs-site/src/content/docs/modules/idp.md
@@ -21,10 +21,10 @@ Accessing and managing CrowdStrike Falcon Identity Protection capabilities
 
 **Required scopes:** `Identity Protection Assessment:read`, `Identity Protection Detections:read`, `Identity Protection Entities:read`, `Identity Protection Timeline:read`, `Identity Protection GraphQL:write`
 
-Comprehensive entity investigation tool.
+Investigate one or more Identity Protection entities by ID, name, email, IP, or domain.
 
-This tool provides complete entity investigation capabilities including:
-- Entity search and details lookup
-- Activity timeline analysis
-- Relationship and association mapping
-- Risk assessment
+Use this to look up entity details, activity timelines, relationship graphs, and risk
+assessments; at least one identifier must be supplied, and multiple identifiers are
+combined with AND logic (email and IP cannot be combined — email takes precedence).
+Returns a structured response with an investigation_summary, resolved entity IDs,
+and results keyed by each requested investigation type.

--- a/docs-site/src/content/docs/modules/intel.md
+++ b/docs-site/src/content/docs/modules/intel.md
@@ -19,14 +19,11 @@ Accessing and analyzing CrowdStrike Falcon intelligence data
 
 **Required scopes:** `Actors (Falcon Intelligence):read`
 
-Generate MITRE ATT&CK report for a given threat actor.
+Generate a MITRE ATT&CK report for a given threat actor.
 
-Provides detailed MITRE ATT&CK tactics, techniques, and procedures (TTPs)
-report associated with a specific threat actor tracked.
-
-Args:
-    actor: Pass the actor name (string) or numeric actor ID (string).
-    format: Report format. Accepted options: 'csv' or 'json'. Defaults to 'json'.
+Accepts an actor name (e.g., 'WARP PANDA') or numeric ID. Returns MITRE ATT&CK
+tactics, techniques, and procedures (TTPs) for the actor. JSON format returns a
+decoded string; CSV format returns CSV text.
 
 **Example prompts:**
 
@@ -38,21 +35,29 @@ Args:
 
 Research threat actors and adversary groups tracked by CrowdStrike intelligence.
 
+Use this to search actors by name, target countries/industries, or activity dates.
+Consult falcon://intel/actors/fql-guide before constructing filter expressions.
+Returns full actor profiles including aliases, motivations, and targeting details.
+
 ### `falcon_query_indicator_entities`
 
 **Required scopes:** `Indicators (Falcon Intelligence):read`
 
-Search for threat indicators and indicators of compromise (IOCs) from CrowdStrike intelligence.
+Search for threat indicators and IOCs from CrowdStrike intelligence.
+
+Use this to find indicators by type, publish date, malware family, or threat actor
+association. Consult falcon://intel/indicators/fql-guide before constructing filter
+expressions. Returns full indicator details including labels, relations, and kill chain stage.
 
 ### `falcon_query_report_entities`
 
 **Required scopes:** `Reports (Falcon Intelligence):read`
 
-Access CrowdStrike intelligence publications and threat reports.
+Search CrowdStrike intelligence publications and threat reports.
 
-This tool returns comprehensive intelligence report details based on your search criteria.
-Use this when you need to find CrowdStrike intelligence publications matching specific conditions.
-For guidance on building FQL filters, use the `falcon://intel/reports/fql-guide` resource.
+Use this to find reports by name, target industry, threat type, or publication date.
+Consult falcon://intel/reports/fql-guide before constructing filter expressions.
+Returns full report metadata including title, description, and target details.
 
 ## Resources
 

--- a/docs-site/src/content/docs/modules/ioc.md
+++ b/docs-site/src/content/docs/modules/ioc.md
@@ -24,6 +24,9 @@ This tool modifies data.
 
 Create one or more custom IOCs.
 
+Provide type/value/action for a single IOC, or pass a bulk indicators array.
+Returns the created indicator records on success.
+
 **Example prompts:**
 
 - "Block the domain evil.example.com"
@@ -39,6 +42,9 @@ This tool performs destructive operations.
 
 Remove custom IOCs by IDs or FQL filter.
 
+Provide either specific IDs or an FQL filter for bulk removal. If both are
+given, filter takes precedence. Returns an empty list on success.
+
 **Example prompts:**
 
 - "Delete IOC with ID abc123"
@@ -49,6 +55,10 @@ Remove custom IOCs by IDs or FQL filter.
 **Required scopes:** `IOC Management:read`
 
 Search custom IOCs and return full IOC details.
+
+Use this to find IOCs by type, value, action, severity, or expiration status.
+Consult falcon://ioc/search/fql-guide before constructing filter expressions.
+Returns full indicator records including metadata, platforms, and host groups.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/ngsiem.md
+++ b/docs-site/src/content/docs/modules/ngsiem.md
@@ -20,21 +20,10 @@ Running search queries against CrowdStrike's Next-Gen SIEM via the asynchronous 
 
 Execute a CQL query against CrowdStrike Next-Gen SIEM.
 
-This tool executes pre-written CQL queries provided by the user. It does NOT
-assist with query construction - users must supply complete, valid CQL syntax.
-
-The tool starts an asynchronous search job, polls for completion (up to the
-configured timeout), and returns matching events.
-
-Note: Search times out after FALCON_MCP_NGSIEM_TIMEOUT seconds (default: 300).
-Polling interval is controlled by FALCON_MCP_NGSIEM_POLL_INTERVAL (default: 5).
-
-Args:
-    query_string (required): The CQL query to execute. Example: '#event_simpleName=ProcessRollup2'
-    start (required): ISO 8601 timestamp for search start. Example: '2025-01-01T00:00:00Z'
-    repository (optional): Repository to search. Default: 'search-all'.
-        Options: search-all, investigate_view, third-party, falcon_for_it_view, forensics_view
-    end (optional): ISO 8601 timestamp for search end. Defaults to current time.
+Use this to search security events, logs, and telemetry; callers must supply
+a complete, valid CQL query — this tool does not assist with query construction.
+Returns matching event records, or an error dict if the job fails or times out.
+Search times out after FALCON_MCP_NGSIEM_TIMEOUT seconds (default: 300).
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/overview.md
+++ b/docs-site/src/content/docs/modules/overview.md
@@ -9,6 +9,7 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 
 | Module | API Scopes | Description |
 |--------|-------------------|-------------|
+| [Case Management](/falcon-mcp/modules/cases/) | `Case Templates:read`, `Cases:read`, `Cases:write` | Managing CrowdStrike cases, including searching, creating, updating, and managing evidence and tags |
 | [Cloud Security](/falcon-mcp/modules/cloud/) | `Cloud Security API Assets:read`, `Cloud Security API Detections:read`, `Cloud Security Policies:read`, `Falcon Container Image:read`, `Cloud Security Policies:write` | Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets |
 | [Custom IOA](/falcon-mcp/modules/custom-ioa/) | `Custom IOA Rules:read`, `Custom IOA Rules:write` | Searching, creating, updating, and deleting Custom IOA (Indicators of Attack) behavioral rules and rule groups using Falcon Custom IOA Service Collection endpoints |
 | [Detections](/falcon-mcp/modules/detections/) | `Alerts:read` | Accessing and analyzing CrowdStrike Falcon detections |

--- a/docs-site/src/content/docs/modules/rtr.md
+++ b/docs-site/src/content/docs/modules/rtr.md
@@ -18,13 +18,18 @@ Initiating and inspecting RTR sessions and for executing read-only RTR commands 
 
 **Required scopes:** `Real time response:read`
 
-Get the status and output chunk for an RTR command.
+Get the status and output for an RTR command execution.
+
+Poll this after falcon_execute_rtr_read_only_command to retrieve command
+output. Use sequence_id to paginate through large output chunks.
 
 ### `falcon_delete_session`
 
 **Required scopes:** `Real time response:read`
 
-Delete an RTR session.
+Close an RTR session and release the host connection.
+
+Use this when investigation is complete to free up session resources.
 
 ### `falcon_execute_read_only_command`
 
@@ -32,9 +37,9 @@ Delete an RTR session.
 
 Execute a read-only RTR command on a single host.
 
-This tool is intentionally limited to the read-only RTR endpoint for
-hunt and triage workflows. It does not expose admin or remediation
-command APIs.
+Limited to read-only commands (ls, ps, cat, filehash, reg) for hunt and triage
+workflows. Does not expose admin or remediation commands. Returns command records
+containing a cloud_request_id for polling output via falcon_check_rtr_command_status.
 
 ### `falcon_get_session_details`
 
@@ -42,17 +47,28 @@ command APIs.
 
 Retrieve detailed metadata for one or more RTR sessions.
 
+Use when you already have session IDs from search results. For discovering
+sessions by criteria, use falcon_search_rtr_sessions instead. Returns full
+session records.
+
 ### `falcon_init_session`
 
 **Required scopes:** `Real time response:read`
 
 Initialize or reuse an RTR session for a single host.
 
+Opens a live connection to the specified device for executing RTR commands.
+Use queue_offline=True if the host may be offline. Returns session records
+containing the session_id needed for subsequent commands.
+
 ### `falcon_list_session_files`
 
 **Required scopes:** `Real time response:write`
 
-List files currently associated with an RTR session.
+List files extracted during an RTR session.
+
+Returns file metadata for artifacts captured during the session, such as
+files pulled with the `get` command.
 
 ### `falcon_pulse_session`
 
@@ -60,11 +76,18 @@ List files currently associated with an RTR session.
 
 Refresh an RTR session timeout for a single host.
 
+Keeps an existing session alive by resetting its inactivity timer. Use this
+to prevent session expiration during long investigations.
+
 ### `falcon_search_sessions`
 
 **Required scopes:** `Real time response:read`
 
 Search RTR sessions and return full session details.
+
+Use this to find sessions by hostname, agent ID, user, or creation time. Consult
+falcon://rtr/sessions/search/fql-guide before constructing filter expressions.
+Returns session metadata including host info, commands executed, and status.
 
 ## Resources
 

--- a/docs-site/src/content/docs/modules/scheduled-reports.md
+++ b/docs-site/src/content/docs/modules/scheduled-reports.md
@@ -17,19 +17,11 @@ Accessing and managing CrowdStrike Falcon scheduled reports and scheduled search
 
 **Required scopes:** `Scheduled Reports:read`
 
-Download generated report results.
+Download the results of a completed report execution.
 
-Download the report results for a completed execution. Only works for executions
-with status='DONE'.
-
-The return format depends on how the scheduled report was configured:
-- CSV format reports: Returns string containing CSV data
-- JSON format reports: Returns list of result records
-- PDF format reports: Not supported (returns error - use CSV/JSON instead)
-
-Note: Check execution status first using falcon_search_report_executions with
-filter=id:'<execution-id>' to ensure the execution is complete (status='DONE')
-before attempting to download.
+Only works for executions with status='DONE'. Check status first using
+falcon_search_report_executions. Returns CSV string or JSON records depending
+on the report's configured format. PDF format is not supported.
 
 **Example prompts:**
 
@@ -43,16 +35,12 @@ This tool modifies data.
 
 **Required scopes:** `Scheduled Reports:read`
 
-Launch a scheduled report on demand.
+Launch a scheduled report or search on demand.
 
-Execute a scheduled report or search immediately, outside of its recurring schedule.
-This creates a new execution instance that can be tracked and downloaded.
-
-Returns the execution details including the execution ID which can be used with:
-- falcon_search_report_executions to check status (filter=id:'<execution-id>')
-- falcon_download_report_execution to download results when ready
-
-Note: The report will run with the same parameters as defined in the entity configuration.
+Executes the report immediately outside its recurring schedule. Returns
+execution records containing an execution ID that can be tracked with
+falcon_search_report_executions and downloaded with
+falcon_download_report_execution when complete.
 
 **Example prompts:**
 
@@ -62,23 +50,11 @@ Note: The report will run with the same parameters as defined in the entity conf
 
 **Required scopes:** `Scheduled Reports:read`
 
-Search for scheduled report/search executions in your CrowdStrike environment.
+Search for report/search execution history.
 
-Returns full details for matching executions. Use the filter parameter to narrow
-results or retrieve specific executions by ID.
-
-resource when you need to use the `filter` parameter.
-
-Common use cases:
-- Get specific execution by ID: filter=id:'<execution-id>'
-- Get all executions for a report: filter=scheduled_report_id:'<report-id>'
-- Find completed executions: filter=status:'DONE'
-- Find failed executions: filter=status:'FAILED'
-
-Examples:
-- filter=status:'DONE'+created_on:>'2023-01-01' - Successful runs after date
-- filter=scheduled_report_id:'abc123' - All executions for report abc123
-- filter=id:'f1984ff006a94980b352f18ee79aed77' - Specific execution by ID
+Use this to find executions by status, report ID, or completion date. Consult
+falcon://scheduled-reports/executions/search/fql-guide before constructing filter
+expressions. Returns full execution details including status and timestamps.
 
 **Example prompts:**
 
@@ -90,20 +66,9 @@ Examples:
 
 Search for scheduled reports and searches in your CrowdStrike environment.
 
-Returns full details for matching scheduled report/search entities. Use the filter
-parameter to narrow results or retrieve specific entities by ID.
-
-Common use cases:
-- Get specific report by ID: filter=id:'<report-id>'
-- Get multiple reports by ID: filter=id:['id1','id2']
-- Find active reports: filter=status:'ACTIVE'
-- Find scheduled searches: filter=type:'event_search'
-- Find by creator: filter=user_id:'user@email.com'
-
-Examples:
-- filter=status:'ACTIVE'+type:'event_search' - Active scheduled searches
-- filter=created_on:>'2023-01-01' - Created after date
-- filter=id:'45c59557ded4413cafb8ff81e7640456' - Specific report by ID
+Use this to find reports by status, type, creator, or creation date. Consult
+falcon://scheduled-reports/search/fql-guide before constructing filter expressions.
+Returns full report/search entity details including schedule configuration.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/sensor-usage.md
+++ b/docs-site/src/content/docs/modules/sensor-usage.md
@@ -17,7 +17,11 @@ Accessing CrowdStrike Falcon sensor usage data
 
 **Required scopes:** `Sensor Usage:read`
 
-Search for sensor usage data in your CrowdStrike environment.
+Search for weekly sensor usage data in your CrowdStrike environment.
+
+Use this to retrieve sensor billing and usage metrics by date or period. Consult
+falcon://sensor-usage/weekly/fql-guide before constructing filter expressions.
+Returns weekly usage records.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/serverless.md
+++ b/docs-site/src/content/docs/modules/serverless.md
@@ -17,13 +17,12 @@ Accessing and managing CrowdStrike Falcon Serverless Vulnerabilities
 
 **Required scopes:** `Falcon Container Image:read`
 
-Search for vulnerabilities in your serverless functions across all cloud service providers.
+Search for vulnerabilities in serverless functions across all cloud providers.
 
-This endpoint provides security information in SARIF format, including:
-- CVE IDs for identified vulnerabilities
-- Severity levels
-- Vulnerability descriptions
-- Additional relevant details
+Use this to find CVEs in Lambda/Cloud Functions/Azure Functions by severity,
+provider, or runtime. Consult falcon://serverless/vulnerabilities/fql-guide before
+constructing filter expressions. Returns vulnerability data in SARIF format
+including CVE IDs, severity levels, and descriptions.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/shield.md
+++ b/docs-site/src/content/docs/modules/shield.md
@@ -22,15 +22,12 @@ This tool performs destructive operations.
 
 **Required scopes:** `SaaS Security:write`
 
-Dismiss a Falcon Shield (SaaS Security) posture check to suppress it from
-the failed checks list.
+Dismiss a Falcon Shield (SaaS Security) posture check to suppress it from the failed checks list.
 
-WARNING: This action is permanent and cannot be undone from the API. The
-dismissal reason is recorded in audit logs.
-
-When entities is omitted, the entire check is dismissed for all entities.
-When entities is provided, only the specified entities are dismissed and the
-check remains active for others.
+Use this only when a check is intentionally accepted as a known risk; omit entities to dismiss
+the entire check for all entities, or provide specific entity names to dismiss only those.
+This action is permanent and cannot be undone from the API — the dismissal reason is recorded
+in audit logs.
 
 **Example prompts:**
 
@@ -40,20 +37,12 @@ check remains active for others.
 
 **Required scopes:** `SaaS Security:read`
 
-Get events from the Falcon Shield (SaaS Security) activity monitor.
-Data retained for 180 days.
+Get events from the Falcon Shield (SaaS Security) activity monitor; data is retained for 180 days.
 
-Note: When using integration_id, category, or actor filters, the date range
-(from_date to to_date) must be within 24 hours.
-
-Pagination: Use meta.pagination.next as to_date and meta.pagination.offset as
-skip for subsequent pages.
-
-IMPORTANT: Consult the falcon://shield/search/query-guide resource for valid
-category, actor, and projection values.
-
-Returns activity event objects including timestamp, event name, actor identity,
-integration, category, and location details.
+Use this to investigate user activity, threats, or IoC events across connected SaaS platforms;
+when filtering by integration_id, category, or actor, the date range must be within 24 hours.
+Returns activity event objects including timestamp, event name, actor identity, integration,
+category, and location details.
 
 **Example prompts:**
 
@@ -63,12 +52,9 @@ integration, category, and location details.
 
 **Required scopes:** `SaaS Security:read`
 
-Retrieve the users who have authorized or are associated with a specific
-third-party app in Falcon Shield (SaaS Security).
+Retrieve the users who have authorized or are associated with a specific third-party app in Falcon Shield.
 
-Use this after `search_shield_apps` to drill into a specific app's user
-population.
-
+Use this after `search_shield_apps` to drill into a specific app's user population.
 Returns user objects including email, display name, and granted permissions.
 
 **Example prompts:**
@@ -79,13 +65,10 @@ Returns user objects including email, display name, and granted permissions.
 
 **Required scopes:** `SaaS Security:read`
 
-Retrieve the specific entities (users, apps, or devices) that are violating
-a given Falcon Shield (SaaS Security) posture check.
+Retrieve the specific entities (users, apps, or devices) that are violating a given Falcon Shield posture check.
 
-Use this after `search_shield_checks` to drill into which entities are failing
-a specific check.
-
-Returns entity objects with entity name, type, and relevant security details.
+Use this after `search_shield_checks` to drill into which entities are failing a specific check. Returns entity
+objects with entity name, type, and relevant security details.
 
 **Example prompts:**
 
@@ -95,13 +78,11 @@ Returns entity objects with entity name, type, and relevant security details.
 
 **Required scopes:** `SaaS Security:read`
 
-Retrieve the compliance framework mappings for a specific Falcon Shield
-(SaaS Security) posture check.
+Retrieve the compliance framework mappings for a specific Falcon Shield posture check.
 
-Use this to understand the regulatory impact of a failing check.
-
-Returns compliance objects identifying the framework (e.g., SOC 2, CIS, NIST,
-PCI DSS), control ID, and control description that the check satisfies.
+Use this after `search_shield_checks` to understand the regulatory impact of a failing check.
+Returns compliance objects identifying the framework (e.g., SOC 2, CIS, NIST, PCI DSS),
+control ID, and control description that the check satisfies.
 
 **Example prompts:**
 
@@ -111,15 +92,11 @@ PCI DSS), control ID, and control description that the check satisfies.
 
 **Required scopes:** `SaaS Security:read`
 
-List all SaaS integrations connected to Falcon Shield (SaaS Security) and
-their current connection status.
+List all SaaS integrations connected to Falcon Shield and their current connection status.
 
-The integration_id values returned here are used as input to most other Shield
-tools. Call this tool first when starting a Shield investigation to discover
-available integrations.
-
-Returns integration objects containing integration_id, SaaS platform name,
-connection health, and last sync time.
+Call this first when starting a Shield investigation to discover available integration IDs,
+which are required as input to most other Shield tools. Returns integration objects containing
+integration_id, SaaS platform name, connection health, and last sync time.
 
 **Example prompts:**
 
@@ -129,14 +106,11 @@ connection health, and last sync time.
 
 **Required scopes:** `SaaS Security:read`
 
-Get aggregated Falcon Shield (SaaS Security) posture metrics.
+Get aggregated Falcon Shield (SaaS Security) posture metrics for a dashboard or summary view.
 
-Use this for a summary/dashboard view of your security posture. To retrieve
-individual check records with remediation details, use `search_shield_checks`
-instead.
-
-Returns total check counts, overall score percentage, and breakdown of checks
-by status (Passed, Failed, Dismissed, etc.) across connected SaaS applications.
+Use this for a high-level overview of your SaaS security posture; for individual check records
+with remediation details, use `search_shield_checks` instead. Returns total check counts, overall
+score percentage, and a breakdown of checks by status across connected SaaS applications.
 
 **Example prompts:**
 
@@ -146,11 +120,9 @@ by status (Passed, Failed, Dismissed, etc.) across connected SaaS applications.
 
 **Required scopes:** `SaaS Security:read`
 
-List SaaS platforms supported by Falcon Shield (SaaS Security) for integration.
+List SaaS platforms supported by Falcon Shield for integration.
 
-Use this to discover which SaaS applications can be connected to Shield
-before setting up new integrations.
-
+Use this to discover which SaaS applications can be connected before setting up new integrations.
 Returns supported SaaS platform objects including platform name and ID.
 
 **Example prompts:**
@@ -161,15 +133,10 @@ Returns supported SaaS platform objects including platform name and ID.
 
 **Required scopes:** `SaaS Security:read`
 
-Retrieve Falcon Shield (SaaS Security) system audit logs. Data retained
-for 90 days.
+Retrieve Falcon Shield (SaaS Security) system audit logs; data is retained for 90 days.
 
-Logs include integration creates/updates, check dismissals, and data syncs.
-
-Use date range filters to narrow results. Without filters, returns the most
-recent logs up to the limit.
-
-Returns log objects containing timestamp, event type, actor, and details.
+Use date range filters to narrow results, covering events such as integration creates, check
+dismissals, and data syncs. Returns log objects containing timestamp, event type, actor, and details.
 
 **Example prompts:**
 
@@ -181,10 +148,9 @@ Returns log objects containing timestamp, event type, actor, and details.
 
 List Falcon Shield (SaaS Security) platform administrators.
 
-These are Shield console administrators, not end-users of connected SaaS
-applications. For SaaS app end-users, use `search_shield_users`.
-
-Returns system-level user objects including email, role, and MFA status.
+Use this to audit console-level admin accounts; for end-users of connected SaaS applications,
+use `search_shield_users` instead. Returns system-level user objects including email, role,
+and MFA status.
 
 **Example prompts:**
 
@@ -196,15 +162,9 @@ Returns system-level user objects including email, role, and MFA status.
 
 Search Falcon Shield (SaaS Security) alerts for monitored SaaS applications.
 
-Alert types: configuration_drift (a previously passing check now fails),
-check_degraded (check status worsened), integration_failure (connectivity issue
-with a SaaS platform), threat (active threat indicator).
-
-Pagination: use last_id from the last result for cursor-based pagination, or
-use offset for offset-based pagination.
-
-Returns alert objects containing id, type, integration details, timestamp,
-and severity.
+Use this to find configuration drift, degraded checks, integration failures, or active threats;
+use last_id from the last result for cursor-based pagination or offset for offset-based pagination.
+Returns alert objects containing id, type, integration details, timestamp, and severity.
 
 **Example prompts:**
 
@@ -215,15 +175,12 @@ and severity.
 
 **Required scopes:** `SaaS Security:read`
 
-List third-party applications (OAuth apps, API tokens, browser extensions,
-service principals) with access to Falcon Shield (SaaS Security) monitored
-platforms.
+List third-party applications (OAuth apps, API tokens, browser extensions, service principals)
+with access to Falcon Shield (SaaS Security) monitored platforms.
 
-Use the item_id from results with `get_shield_app_users` to retrieve the users
-of a specific app.
-
-Returns app objects containing item_id, name, type, status, access_level,
-granted scopes, and user count.
+Use this to audit app access across your SaaS estate; use the item_id from results with
+`get_shield_app_users` to see who authorized a specific app. Returns app objects containing
+item_id, name, type, status, access_level, granted scopes, and user count.
 
 **Example prompts:**
 
@@ -236,18 +193,9 @@ granted scopes, and user count.
 
 Search individual Falcon Shield (SaaS Security) posture checks with filtering.
 
-Use the check id from results to call `get_shield_check_affected_entities` for
-violating entities, `get_shield_check_compliance` for compliance mappings, or
-`dismiss_shield_check` to dismiss.
-
-For an aggregated posture summary (total score, status breakdown), use
-`get_shield_posture_metrics` instead.
-
-IMPORTANT: Consult the falcon://shield/search/query-guide resource for valid
-filter parameter values.
-
-Returns check records containing id, name, status, impact level, affected entity
-count, and remediation plan.
+Use this to find specific failing checks by status, impact, integration, or type; consult
+falcon://shield/search/query-guide for valid filter values. Returns check records containing
+id, name, status, impact level, affected entity count, and remediation plan.
 
 **Example prompts:**
 
@@ -258,14 +206,11 @@ count, and remediation plan.
 
 **Required scopes:** `SaaS Security:read`
 
-List files and resources shared externally across Falcon Shield (SaaS
-Security) monitored SaaS applications.
+List files and resources shared externally across Falcon Shield (SaaS Security) monitored applications.
 
-Use this to identify overshared or externally exposed files (e.g., Google
-Drive documents shared outside the organization).
-
-Returns resource objects containing resource name, type, owner, sharing access
-level, password protection status, and last access/modification timestamps.
+Use this to identify overshared or externally exposed files such as Google Drive documents shared
+outside the organization. Returns resource objects containing resource name, type, owner, sharing
+access level, password protection status, and last access/modification timestamps.
 
 **Example prompts:**
 
@@ -275,15 +220,11 @@ level, password protection status, and last access/modification timestamps.
 
 **Required scopes:** `SaaS Security:read`
 
-List devices registered to users in Falcon Shield (SaaS Security) connected
-SaaS applications.
+List devices registered to users in Falcon Shield (SaaS Security) connected SaaS applications.
 
-Note: This returns devices from SaaS provider records, not from the Falcon
-sensor inventory. To search Falcon-sensor-enrolled hosts, use `search_hosts`
-instead.
-
-Returns device objects containing device name, owner email, compliance posture,
-and management status.
+Use this to identify unmanaged or unassociated devices in your SaaS estate; note that this returns
+devices from SaaS provider records, not Falcon sensor inventory — use `search_hosts` for that.
+Returns device objects containing device name, owner email, compliance posture, and management status.
 
 **Example prompts:**
 
@@ -293,17 +234,12 @@ and management status.
 
 **Required scopes:** `SaaS Security:read`
 
-List end-users discovered across Falcon Shield (SaaS Security) connected
-SaaS applications.
+List end-users discovered across Falcon Shield (SaaS Security) connected SaaS applications.
 
-Use this to audit user access across your SaaS estate or to identify
-over-privileged or stale accounts.
-
-To list Shield platform administrators instead of SaaS app end-users, use
-`get_shield_system_users`.
-
-Returns user objects containing email, display name, connected application
-details, privilege status, and exposure metrics.
+Use this to audit user access across your SaaS estate or identify over-privileged or stale accounts;
+for Shield platform administrators instead of SaaS app end-users, use `get_shield_system_users`.
+Returns user objects containing email, display name, connected application details, privilege status,
+and exposure metrics.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/spotlight.md
+++ b/docs-site/src/content/docs/modules/spotlight.md
@@ -19,6 +19,11 @@ Accessing and managing CrowdStrike Falcon Spotlight vulnerabilities
 
 Search for vulnerabilities in your CrowdStrike environment.
 
+Use this to find vulnerabilities by CVE severity, status, host, or remediation
+state. Consult falcon://spotlight/vulnerabilities/fql-guide before constructing
+filter expressions. Returns vulnerability details including CVE info, host context,
+and remediation guidance (based on facet selection).
+
 **Example prompts:**
 
 - "Show me open HIGH severity vulnerabilities"

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -118,6 +118,18 @@ API_SCOPE_REQUIREMENTS = {
     "GetSystemLogsV3": ["SaaS Security:read"],
     "DismissSecurityCheckV3": ["SaaS Security:write"],
     "DismissAffectedEntityV3": ["SaaS Security:write"],
+    # Case Management operations
+    "queries_cases_get_v1": ["Cases:read"],
+    "entities_cases_post_v2": ["Cases:read"],
+    "entities_cases_put_v2": ["Cases:write"],
+    "entities_cases_patch_v2": ["Cases:write"],
+    "entities_alert_evidence_post_v1": ["Cases:write"],
+    "entities_event_evidence_post_v1": ["Cases:write"],
+    "entities_case_tags_post_v1": ["Cases:write"],
+    "entities_case_tags_delete_v1": ["Cases:write"],
+    # Case Templates operations
+    "queries_templates_get_v1": ["Case Templates:read"],
+    "entities_templates_get_v1": ["Case Templates:read"],
 }
 
 

--- a/falcon_mcp/modules/cases.py
+++ b/falcon_mcp/modules/cases.py
@@ -1,0 +1,509 @@
+"""
+Case Management module for Falcon MCP Server.
+
+This module provides tools for managing CrowdStrike cases, including searching,
+creating, updating, and managing evidence and tags.
+"""
+
+from typing import Any
+
+from mcp.server import FastMCP
+from mcp.server.fastmcp.resources import TextResource
+from mcp.types import ToolAnnotations
+from pydantic import AnyUrl, Field
+
+from falcon_mcp.common.errors import _format_error_response
+from falcon_mcp.common.logging import get_logger
+from falcon_mcp.modules.base import BaseModule
+from falcon_mcp.resources.cases import SEARCH_CASES_FQL_DOCUMENTATION
+
+logger = get_logger(__name__)
+
+
+class CasesModule(BaseModule):
+    """Case Management module for Falcon MCP Server.
+
+    This module provides tools for managing CrowdStrike cases including
+    case lifecycle, evidence attachment, tagging, and template listing.
+
+    Required API Scopes:
+    - Cases:read
+    - Cases:write
+    - Case Templates:read
+    """
+
+    def register_tools(self, server: FastMCP) -> None:
+        self._add_tool(server=server, method=self.search_cases, name="search_cases")
+        self._add_tool(server=server, method=self.get_cases, name="get_cases")
+        self._add_tool(
+            server=server,
+            method=self.create_case,
+            name="create_case",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        self._add_tool(
+            server=server,
+            method=self.update_case,
+            name="update_case",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        self._add_tool(
+            server=server,
+            method=self.add_case_alert_evidence,
+            name="add_case_alert_evidence",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        self._add_tool(
+            server=server,
+            method=self.add_case_event_evidence,
+            name="add_case_event_evidence",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        self._add_tool(
+            server=server,
+            method=self.manage_case_tags,
+            name="manage_case_tags",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        self._add_tool(
+            server=server,
+            method=self.list_case_templates,
+            name="list_case_templates",
+        )
+
+    def register_resources(self, server: FastMCP) -> None:
+        resource = TextResource(
+            uri=AnyUrl("falcon://cases/search/fql-guide"),
+            name="falcon_search_cases_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_cases` tool.",
+            text=SEARCH_CASES_FQL_DOCUMENTATION,
+        )
+        self._add_resource(server, resource)
+
+    def search_cases(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter expression. See `falcon://cases/search/fql-guide` for syntax.",
+            examples=["status:'new'+severity:>70", "assigned_to_name:'Alice'"],
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            le=500,
+            description="Maximum number of cases to return (default: 10, max: 500).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index for pagination.",
+        ),
+        q: str | None = Field(
+            default=None,
+            description="Free-text search across all case metadata.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Sort order. Fields: created_timestamp, updated_timestamp, severity, status, name, reference_id. Formats: 'field.desc', 'field|asc'. Example: 'created_timestamp.desc'",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Find cases by criteria and return their complete details.
+
+        Use this to discover cases by status, severity, assignee, time range, or
+        evidence attributes. Consult falcon://cases/search/fql-guide before
+        constructing filter expressions. Returns full case records including
+        status, severity, evidence, assigned user, and analysis results.
+        """
+        case_ids = self._base_search_api_call(
+            operation="queries_cases_get_v1",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "q": q,
+                "sort": sort,
+            },
+            error_message="Failed to search cases",
+        )
+
+        if self._is_error(case_ids):
+            return self._format_fql_error_response(
+                [case_ids], filter, SEARCH_CASES_FQL_DOCUMENTATION
+            )
+
+        if not case_ids:
+            return self._format_fql_error_response(
+                [], filter, SEARCH_CASES_FQL_DOCUMENTATION
+            )
+
+        details = self._base_get_by_ids(
+            operation="entities_cases_post_v2",
+            ids=case_ids,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        return details
+
+    def get_cases(
+        self,
+        ids: list[str] = Field(
+            description="Case ID(s) to retrieve. These are opaque system IDs, not the human-readable reference_id.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve details for case IDs you already have.
+
+        Use when you have specific case IDs from search results or external
+        references. For discovering cases by criteria, use falcon_search_cases
+        instead. Returns full case records.
+        """
+        return self._base_get_by_ids(
+            operation="entities_cases_post_v2",
+            ids=ids,
+        )
+
+    def create_case(
+        self,
+        name: str = Field(
+            description="Case name (max 256 characters).",
+        ),
+        severity: int = Field(
+            description="Severity level (1-100). 1=Informational, ~25=Low, ~50=Medium, ~75=High, 100=Critical.",
+            ge=1,
+            le=100,
+        ),
+        description: str | None = Field(
+            default=None,
+            description="Case description (max 2048 characters).",
+        ),
+        status: str | None = Field(
+            default=None,
+            description="Initial status. Values: new, in_progress. Defaults to 'new' if omitted.",
+        ),
+        assigned_to_user_uuid: str | None = Field(
+            default=None,
+            description="UUID of the user to assign the case to.",
+        ),
+        tags: list[str] | None = Field(
+            default=None,
+            description="Tags to apply (128 combined character limit across all tags).",
+        ),
+        template_id: str | None = Field(
+            default=None,
+            description="Template ID to apply to the case.",
+        ),
+        alert_ids: list[str] | None = Field(
+            default=None,
+            description="Alert composite IDs to attach as evidence (from Alerts v2 API). Max 100 total evidence items.",
+        ),
+        event_ids: list[str] | None = Field(
+            default=None,
+            description="LogScale event IDs to attach as evidence (from falcon_search_ngsiem). Max 100 total evidence items.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Create a new case in CrowdStrike.
+
+        Provide a name and severity at minimum. Optionally attach alert or event
+        evidence, assign a user, apply a template, and set tags. Returns the
+        created case record.
+        """
+        body: dict[str, Any] = {
+            "name": name,
+            "severity": severity,
+        }
+
+        if description is not None:
+            body["description"] = description
+        if status is not None:
+            body["status"] = status
+        if assigned_to_user_uuid is not None:
+            body["assigned_to_user_uuid"] = assigned_to_user_uuid
+        if tags is not None:
+            body["tags"] = tags
+        if template_id is not None:
+            body["template"] = {"id": template_id}
+
+        evidence: dict[str, Any] = {}
+        if alert_ids:
+            evidence["alerts"] = [{"id": aid} for aid in alert_ids]
+        if event_ids:
+            evidence["events"] = [{"id": eid} for eid in event_ids]
+        if evidence:
+            body["evidence"] = evidence
+
+        result = self._base_query_api_call(
+            operation="entities_cases_put_v2",
+            body_params=body,
+            error_message="Failed to create case",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def update_case(
+        self,
+        id: str = Field(
+            description="Case ID to update (the opaque system ID, not reference_id).",
+        ),
+        name: str | None = Field(
+            default=None,
+            description="New case name.",
+        ),
+        description: str | None = Field(
+            default=None,
+            description="New case description.",
+        ),
+        status: str | None = Field(
+            default=None,
+            description="New status. Values: new, in_progress, closed, reopened.",
+        ),
+        severity: int | None = Field(
+            default=None,
+            description="New severity (1-100).",
+            ge=1,
+            le=100,
+        ),
+        assigned_to_user_uuid: str | None = Field(
+            default=None,
+            description="UUID of user to assign. Use remove_user_assignment=True to unassign instead.",
+        ),
+        remove_user_assignment: bool | None = Field(
+            default=None,
+            description="Set to True to remove the current user assignment.",
+        ),
+        template_id: str | None = Field(
+            default=None,
+            description="Template ID to apply to the case.",
+        ),
+        expected_version: int | None = Field(
+            default=None,
+            description="Expected case version for optimistic concurrency. If provided and mismatched, the update returns 409 Conflict.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Update an existing case's fields.
+
+        Provide the case ID and any fields to change. Use expected_version for
+        optimistic concurrency control to prevent conflicting updates. Returns the
+        updated case record with incremented version.
+        """
+        fields: dict[str, Any] = {}
+        if name is not None:
+            fields["name"] = name
+        if description is not None:
+            fields["description"] = description
+        if status is not None:
+            fields["status"] = status
+        if severity is not None:
+            fields["severity"] = severity
+        if assigned_to_user_uuid is not None:
+            fields["assigned_to_user_uuid"] = assigned_to_user_uuid
+        if remove_user_assignment is not None:
+            fields["remove_user_assignment"] = remove_user_assignment
+        if template_id is not None:
+            fields["template"] = {"id": template_id}
+
+        if not fields:
+            return [
+                _format_error_response(
+                    "At least one field to update must be provided.",
+                    operation="entities_cases_patch_v2",
+                )
+            ]
+
+        body: dict[str, Any] = {
+            "id": id,
+            "fields": fields,
+        }
+        if expected_version is not None:
+            body["expected_version"] = expected_version
+
+        result = self._base_query_api_call(
+            operation="entities_cases_patch_v2",
+            body_params=body,
+            error_message="Failed to update case",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def add_case_alert_evidence(
+        self,
+        id: str = Field(
+            description="Case ID to add alert evidence to.",
+        ),
+        alert_ids: list[str] = Field(
+            description="Alert composite IDs to attach (from Alerts v2 API). Max 100 total evidence items per case.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Attach alert evidence to an existing case.
+
+        Provide alert composite_id values from the Alerts v2 API (e.g. from
+        falcon_search_detections). Each case supports a maximum of 100 combined
+        evidence items. Returns the updated case record.
+        """
+        body = {
+            "id": id,
+            "alerts": [{"id": aid} for aid in alert_ids],
+        }
+
+        result = self._base_query_api_call(
+            operation="entities_alert_evidence_post_v1",
+            body_params=body,
+            error_message="Failed to add alert evidence",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def add_case_event_evidence(
+        self,
+        id: str = Field(
+            description="Case ID to add event evidence to.",
+        ),
+        event_ids: list[str] = Field(
+            description="LogScale event IDs to attach (from falcon_search_ngsiem). Max 100 total evidence items per case.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Attach LogScale event evidence to an existing case.
+
+        Provide event IDs obtained from falcon_search_ngsiem or the Falcon
+        console. Each case supports a maximum of 100 combined evidence items.
+        Returns the updated case record.
+        """
+        body = {
+            "id": id,
+            "events": [{"id": eid} for eid in event_ids],
+        }
+
+        result = self._base_query_api_call(
+            operation="entities_event_evidence_post_v1",
+            body_params=body,
+            error_message="Failed to add event evidence",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def manage_case_tags(
+        self,
+        id: str = Field(
+            description="Case ID to manage tags for.",
+        ),
+        action: str = Field(
+            description="Action to perform. Values: 'add' or 'remove'.",
+        ),
+        tags: list[str] = Field(
+            description="Tags to add or remove. 128 combined character limit across all tags on a case.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Add or remove tags on a case.
+
+        Set action to 'add' to attach new tags, or 'remove' to delete existing
+        tags. Returns the updated case record.
+        """
+        if action == "add":
+            body = {"id": id, "tags": tags}
+            result = self._base_query_api_call(
+                operation="entities_case_tags_post_v1",
+                body_params=body,
+                error_message="Failed to add case tags",
+                default_result=[],
+            )
+        elif action == "remove":
+            result = self._base_query_api_call(
+                operation="entities_case_tags_delete_v1",
+                query_params={"id": id, "tag": tags},
+                error_message="Failed to remove case tags",
+                default_result=[],
+            )
+        else:
+            return [
+                _format_error_response(
+                    "Invalid action. Must be 'add' or 'remove'.",
+                    operation="entities_case_tags_post_v1",
+                )
+            ]
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def list_case_templates(
+        self,
+        limit: int = Field(
+            default=50,
+            ge=1,
+            le=200,
+            description="Maximum number of templates to return (default: 50, max: 200).",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index for pagination.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """List available case templates.
+
+        Use to discover templates that can be applied when creating or updating
+        cases. Returns template details including name, custom fields, and SLA
+        configuration.
+        """
+        template_ids = self._base_search_api_call(
+            operation="queries_templates_get_v1",
+            search_params={"limit": limit, "offset": offset},
+            error_message="Failed to query case templates",
+        )
+
+        if self._is_error(template_ids):
+            return [template_ids]
+
+        if not template_ids:
+            return []
+
+        details = self._base_get_by_ids(
+            operation="entities_templates_get_v1",
+            ids=template_ids,
+            use_params=True,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        return details

--- a/falcon_mcp/resources/cases.py
+++ b/falcon_mcp/resources/cases.py
@@ -1,0 +1,306 @@
+"""
+Contains Cases resources.
+"""
+
+from falcon_mcp.common.utils import generate_md_table
+
+SEARCH_CASES_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Description",
+    ),
+    (
+        "id",
+        "String",
+        "System-level case identifier (opaque base64 string).",
+    ),
+    (
+        "reference_id",
+        "String",
+        "Human-readable case ID (e.g. ABC-1234). Case-sensitive, full match required.",
+    ),
+    (
+        "status",
+        "String",
+        """
+        Case status. Values:
+        - new: Newly created case
+        - in_progress: Under investigation
+        - closed: Investigation completed
+        - reopened: Previously closed, now active again
+        Ex: new
+        """,
+    ),
+    (
+        "severity",
+        "Integer",
+        """
+        Numeric severity (1-100).
+        Informational=1, Low~25, Medium~50, High~75, Critical=100.
+        Ex: 70
+        """,
+    ),
+    (
+        "name",
+        "String",
+        "Case name. Ex: Suspicious lateral movement",
+    ),
+    (
+        "description",
+        "String",
+        "Case description text.",
+    ),
+    (
+        "all_text",
+        "String",
+        "Full-text search across all searchable case fields.",
+    ),
+    (
+        "created_timestamp",
+        "Timestamp",
+        "Case creation time in ISO 8601 UTC. Ex: 2025-01-01T00:00:00Z",
+    ),
+    (
+        "updated_timestamp",
+        "Timestamp",
+        "Last modification time in ISO 8601 UTC. Ex: 2025-06-01T00:00:00Z",
+    ),
+    (
+        "assigned_to_uuid",
+        "String",
+        "UUID of assigned user.",
+    ),
+    (
+        "assigned_to_name",
+        "String",
+        "Display name of assigned user.",
+    ),
+    (
+        "created_by",
+        "String",
+        "Creator email or API client ID.",
+    ),
+    (
+        "modified_by",
+        "String",
+        "Last modifier email or API client ID.",
+    ),
+    (
+        "tags",
+        "String",
+        "Tags applied to the case.",
+    ),
+    (
+        "cid",
+        "String",
+        "Customer ID (Flight Control multi-CID scenarios).",
+    ),
+    (
+        "alerts",
+        "String",
+        "Alert IDs attached as evidence.",
+    ),
+    (
+        "events",
+        "String",
+        "LogScale event details in evidence.",
+    ),
+    (
+        "data_domains",
+        "String",
+        "Data domains from evidence (e.g. Endpoint, Identity, Cloud).",
+    ),
+    (
+        "source_vendors",
+        "String",
+        "Source vendors from evidence.",
+    ),
+    (
+        "source_products",
+        "String",
+        "Source products from evidence.",
+    ),
+    (
+        "tactic_ids",
+        "String",
+        "MITRE ATT&CK tactic IDs from evidence. Ex: TA0006",
+    ),
+    (
+        "tactics",
+        "String",
+        "MITRE ATT&CK tactic names from evidence. Ex: Credential Access",
+    ),
+    (
+        "technique_ids",
+        "String",
+        "MITRE ATT&CK technique IDs from evidence. Ex: T1003",
+    ),
+    (
+        "techniques",
+        "String",
+        "MITRE ATT&CK technique names from evidence.",
+    ),
+    (
+        "aids",
+        "String",
+        "Agent IDs from evidence.",
+    ),
+    (
+        "hostnames",
+        "String",
+        "Hostnames from evidence.",
+    ),
+    (
+        "ips",
+        "String",
+        "IP addresses from evidence.",
+    ),
+    (
+        "email_addresses",
+        "String",
+        "Email addresses from evidence.",
+    ),
+    (
+        "sha256s",
+        "String",
+        "SHA-256 hashes from evidence.",
+    ),
+    (
+        "md5s",
+        "String",
+        "MD5 hashes from evidence.",
+    ),
+    (
+        "usernames",
+        "String",
+        "Usernames from evidence.",
+    ),
+    (
+        "command_lines",
+        "String",
+        "Command lines from evidence.",
+    ),
+    (
+        "file_names",
+        "String",
+        "File names from evidence.",
+    ),
+    (
+        "image_file_names",
+        "String",
+        "Image file names from evidence.",
+    ),
+    (
+        "cloud_providers",
+        "String",
+        "Cloud provider. Values: aws, azure, gcp",
+    ),
+    (
+        "cloud_account_ids",
+        "String",
+        "Cloud account IDs from evidence.",
+    ),
+    (
+        "cloud_regions",
+        "String",
+        "Cloud regions from evidence. Ex: eu-west-2",
+    ),
+    (
+        "cloud_instance_ids",
+        "String",
+        "Cloud instance IDs from evidence.",
+    ),
+    (
+        "cloud_availability_zones",
+        "String",
+        "Cloud availability zones from evidence.",
+    ),
+    (
+        "cloud_service_names",
+        "String",
+        "Cloud service names from evidence.",
+    ),
+    (
+        "case_template_id",
+        "String",
+        "Template ID applied to the case.",
+    ),
+    (
+        "case_template_name",
+        "String",
+        "Template name applied to the case.",
+    ),
+    (
+        "sla_name",
+        "String",
+        "SLA name from the case template.",
+    ),
+    (
+        "sla_active_timer.status",
+        "String",
+        "SLA timer status. Values: pending, in_progress, paused, achieved, missed",
+    ),
+    (
+        "sla_active_timer_time_due",
+        "String",
+        "SLA deadline as epoch timestamp.",
+    ),
+]
+
+SEARCH_CASES_FQL_DOCUMENTATION = r"""Falcon Query Language (FQL) - Search Cases Guide
+
+=== BASIC SYNTAX ===
+field_name:[operator]'value'
+
+=== OPERATORS ===
+- = (default): field_name:'value'
+- !: field_name:!'value' (not equal)
+- >, >=, <, <=: field_name:>50 (comparison)
+- *: field_name:'prefix*' (wildcard)
+
+=== DATA TYPES ===
+- String: 'value'
+- Integer: 123 (no quotes)
+- Timestamp: 'YYYY-MM-DDTHH:MM:SSZ'
+
+=== COMBINING ===
+- + = AND: status:'new'+severity:>50
+- , = OR: status:'new',status:'in_progress'
+
+=== SORT OPTIONS ===
+Valid sort fields: id, created_timestamp, updated_timestamp, severity, status, name, reference_id
+
+Sort formats: 'field.asc', 'field.desc', 'field|asc', 'field|desc'
+Examples: 'created_timestamp.desc', 'severity|desc'
+
+=== falcon_search_cases FQL filter available fields ===
+
+""" + generate_md_table(SEARCH_CASES_FQL_FILTERS) + """
+
+=== COMPLEX FILTER EXAMPLES ===
+
+# Open high-severity cases
+status:'new'+severity:>70
+
+# Cases in progress or reopened
+status:'in_progress',status:'reopened'
+
+# Cases created in the last week
+created_timestamp:>'2025-05-10T00:00:00Z'+status:'new'
+
+# Cases with specific MITRE tactic
+tactic_ids:'TA0006'+severity:>50
+
+# Cases assigned to a user
+assigned_to_name:'Alice Anderson'+status:'in_progress'
+
+# Cases by reference ID
+reference_id:'ABC-1234'
+
+# Unassigned high-severity cases
+assigned_to_uuid:!'*'+severity:>70
+
+# Cases with cloud evidence
+cloud_providers:'aws'+status:'new'
+"""

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -29,6 +29,10 @@ OUTPUT_DIR = PROJECT_ROOT / "docs-site" / "src" / "content" / "docs" / "modules"
 # Titles and descriptions are auto-derived from module docstrings.
 # Add entries here when you need a custom title, slug, or description.
 MODULE_METADATA: dict[str, dict[str, Any]] = {
+    "cases": {
+        "title": "Case Management",
+        "slug": "cases",
+    },
     "cloud": {
         "title": "Cloud Security",
     },
@@ -54,6 +58,35 @@ MODULE_METADATA: dict[str, dict[str, Any]] = {
 
 # Natural language prompt examples for each tool, shown in generated docs
 TOOL_EXAMPLES: dict[str, list[str]] = {
+    # Cases
+    "falcon_search_cases": [
+        "Show me all open high-severity cases",
+        "Find cases assigned to me that are in progress",
+    ],
+    "falcon_get_cases": [
+        "Get details for this case ID",
+    ],
+    "falcon_create_case": [
+        "Create a high-severity case for the suspicious lateral movement investigation",
+        "Open a new case and attach these alert IDs as evidence",
+    ],
+    "falcon_update_case": [
+        "Close case ABC-1234",
+        "Assign this case to the SOC analyst and set severity to critical",
+    ],
+    "falcon_add_case_alert_evidence": [
+        "Attach these detection alerts to the open case",
+    ],
+    "falcon_add_case_event_evidence": [
+        "Add these NGSIEM event IDs to the case as evidence",
+    ],
+    "falcon_manage_case_tags": [
+        "Tag this case with 'ransomware' and 'priority'",
+        "Remove the 'false-positive' tag from this case",
+    ],
+    "falcon_list_case_templates": [
+        "Show me the available case templates",
+    ],
     # Cloud
     "falcon_search_kubernetes_containers": [
         "Find all containers running in AWS clusters",

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -60,32 +60,32 @@ MODULE_METADATA: dict[str, dict[str, Any]] = {
 TOOL_EXAMPLES: dict[str, list[str]] = {
     # Cases
     "falcon_search_cases": [
-        "Show me all open high-severity cases",
-        "Find cases assigned to me that are in progress",
+        "Show me any open cases with high severity or above",
+        "What cases have been created in the last 24 hours?",
     ],
     "falcon_get_cases": [
-        "Get details for this case ID",
+        "Pull up the full details on that case",
     ],
     "falcon_create_case": [
-        "Create a high-severity case for the suspicious lateral movement investigation",
-        "Open a new case and attach these alert IDs as evidence",
+        "Create a critical case called 'Suspicious lateral movement from WORKSTATION-42'",
+        "Open a high-severity case for the credential theft alerts and attach them as evidence",
     ],
     "falcon_update_case": [
-        "Close case ABC-1234",
-        "Assign this case to the SOC analyst and set severity to critical",
+        "Set that case to in_progress and assign it to the analyst",
+        "Close the case — investigation is complete",
     ],
     "falcon_add_case_alert_evidence": [
-        "Attach these detection alerts to the open case",
+        "Attach these detection alerts to the case",
     ],
     "falcon_add_case_event_evidence": [
         "Add these NGSIEM event IDs to the case as evidence",
     ],
     "falcon_manage_case_tags": [
-        "Tag this case with 'ransomware' and 'priority'",
-        "Remove the 'false-positive' tag from this case",
+        "Tag that case with 'ransomware' and 'escalated'",
+        "Remove the 'escalated' tag from that case",
     ],
     "falcon_list_case_templates": [
-        "Show me the available case templates",
+        "What case templates are available?",
     ],
     # Cloud
     "falcon_search_kubernetes_containers": [

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -1,0 +1,274 @@
+"""Integration tests for the Cases module."""
+
+import time
+
+import pytest
+
+from falcon_mcp.modules.cases import CasesModule
+from tests.integration.utils.base_integration_test import BaseIntegrationTest
+
+
+@pytest.mark.integration
+class TestCasesIntegration(BaseIntegrationTest):
+    """Integration tests for Cases module with real API calls.
+
+    Validates:
+    - Correct FalconPy operation names (queries_cases_get_v1, entities_cases_post_v2, etc.)
+    - Two-step search pattern returns full details, not just IDs
+    - POST body usage for get_cases
+    - Create (PUT) and update (PATCH) body formats
+    - Evidence attachment body format (alert objects, not strings)
+    - Tag management asymmetry (POST body add vs DELETE query params remove)
+    - Template listing with GET query params (use_params=True)
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_module(self, falcon_client):
+        """Set up the cases module with a real client."""
+        self.module = CasesModule(falcon_client)
+
+    # -------------------------------------------------------------------------
+    # Operation Name Validation
+    # -------------------------------------------------------------------------
+
+    def test_operation_names_search(self):
+        """Validate queries_cases_get_v1 and entities_cases_post_v2 are correct."""
+        result = self.call_method(self.module.search_cases, limit=1)
+        self.assert_no_error(result, context="search operation names")
+
+    def test_operation_names_templates(self):
+        """Validate queries_templates_get_v1 and entities_templates_get_v1 are correct."""
+        result = self.call_method(self.module.list_case_templates, limit=1)
+        self.assert_no_error(result, context="template operation names")
+
+    # -------------------------------------------------------------------------
+    # Search Tests
+    # -------------------------------------------------------------------------
+
+    def test_search_cases_returns_details(self):
+        """Test that search_cases returns full case details, not just IDs.
+
+        Validates the two-step search pattern:
+        1. queries_cases_get_v1 returns case IDs
+        2. entities_cases_post_v2 returns full details
+        """
+        result = self.call_method(self.module.search_cases, limit=5)
+
+        self.assert_no_error(result, context="search_cases")
+        self.assert_valid_list_response(result, min_length=0, context="search_cases")
+
+        if len(result) > 0:
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["id", "name", "status", "severity"],
+                context="search_cases full details",
+            )
+
+    def test_search_cases_with_filter(self):
+        """Test search_cases with FQL filter."""
+        result = self.call_method(
+            self.module.search_cases,
+            filter="status:'new'",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="search_cases with filter")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_cases with filter"
+        )
+
+    def test_search_cases_with_sort(self):
+        """Test search_cases with sort parameter."""
+        result = self.call_method(
+            self.module.search_cases,
+            sort="created_timestamp.desc",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="search_cases with sort")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_cases with sort"
+        )
+
+    def test_search_cases_with_q(self):
+        """Test search_cases with free-text search."""
+        result = self.call_method(
+            self.module.search_cases,
+            q="test",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="search_cases with q")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_cases with q"
+        )
+
+    # -------------------------------------------------------------------------
+    # Get Tests
+    # -------------------------------------------------------------------------
+
+    def test_get_cases_with_valid_id(self):
+        """Test get_cases with a valid case ID from search."""
+        search_result = self.call_method(self.module.search_cases, limit=1)
+
+        if not search_result or len(search_result) == 0:
+            self.skip_with_warning(
+                "No cases available to test get_cases",
+                context="test_get_cases_with_valid_id",
+            )
+
+        case_id = self.get_first_id(search_result, id_field="id")
+        if not case_id:
+            self.skip_with_warning(
+                "Could not extract case ID from search results",
+                context="test_get_cases_with_valid_id",
+            )
+
+        result = self.call_method(self.module.get_cases, ids=[case_id])
+
+        self.assert_no_error(result, context="get_cases")
+        self.assert_valid_list_response(result, min_length=1, context="get_cases")
+        self.assert_search_returns_details(
+            result,
+            expected_fields=["id", "name", "status", "severity"],
+            context="get_cases",
+        )
+
+    # -------------------------------------------------------------------------
+    # Create / Update / Tag Round-trip
+    # -------------------------------------------------------------------------
+
+    def test_create_update_tag_roundtrip(self):
+        """Full lifecycle: create a case, update it, add/remove tags, verify.
+
+        Creates a unique test case, updates fields, manages tags, then
+        verifies the final state. The case is left in 'closed' state as cleanup.
+        """
+        unique_name = f"falcon-mcp-test-{int(time.time())}"
+
+        # Step 1: Create
+        create_result = self.call_method(
+            self.module.create_case,
+            name=unique_name,
+            severity=25,
+            description="Integration test case - safe to delete",
+            status="new",
+        )
+
+        self.assert_no_error(create_result, context="create_case")
+        self.assert_valid_list_response(
+            create_result, min_length=1, context="create_case"
+        )
+
+        case = create_result[0]
+        assert isinstance(case, dict), f"Expected dict, got {type(case)}"
+        assert "id" in case, f"Missing 'id' in created case. Fields: {list(case.keys())}"
+
+        case_id = case["id"]
+        case_version = case.get("version", 1)
+
+        # Step 2: Update (change status and severity)
+        update_result = self.call_method(
+            self.module.update_case,
+            id=case_id,
+            status="in_progress",
+            severity=50,
+            expected_version=case_version,
+        )
+
+        self.assert_no_error(update_result, context="update_case")
+        self.assert_valid_list_response(
+            update_result, min_length=1, context="update_case"
+        )
+
+        updated_case = update_result[0]
+        assert updated_case.get("status") == "in_progress", (
+            f"Expected status 'in_progress', got '{updated_case.get('status')}'"
+        )
+
+        # Step 3: Add tags
+        tag_add_result = self.call_method(
+            self.module.manage_case_tags,
+            id=case_id,
+            action="add",
+            tags=["mcp-test", "integration"],
+        )
+
+        self.assert_no_error(tag_add_result, context="add tags")
+
+        # Step 4: Remove one tag
+        tag_remove_result = self.call_method(
+            self.module.manage_case_tags,
+            id=case_id,
+            action="remove",
+            tags=["integration"],
+        )
+
+        self.assert_no_error(tag_remove_result, context="remove tags")
+
+        # Step 5: Verify final state
+        get_result = self.call_method(self.module.get_cases, ids=[case_id])
+
+        self.assert_no_error(get_result, context="verify final state")
+        self.assert_valid_list_response(
+            get_result, min_length=1, context="verify final state"
+        )
+
+        final_case = get_result[0]
+        assert final_case.get("status") == "in_progress"
+        assert "mcp-test" in (final_case.get("tags") or [])
+        assert "integration" not in (final_case.get("tags") or [])
+
+        # Step 6: Close the case (cleanup)
+        updated_version = final_case.get("version", case_version + 2)
+        close_result = self.call_method(
+            self.module.update_case,
+            id=case_id,
+            status="closed",
+            expected_version=updated_version,
+        )
+        self.assert_no_error(close_result, context="close case cleanup")
+
+    # -------------------------------------------------------------------------
+    # Template Tests
+    # -------------------------------------------------------------------------
+
+    def test_list_case_templates(self):
+        """Test that list_case_templates returns template details."""
+        result = self.call_method(self.module.list_case_templates, limit=5)
+
+        self.assert_no_error(result, context="list_case_templates")
+        self.assert_valid_list_response(
+            result, min_length=0, context="list_case_templates"
+        )
+
+        if len(result) > 0:
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["id", "name"],
+                context="list_case_templates details",
+            )
+
+    # -------------------------------------------------------------------------
+    # FQL Filter Validation
+    # -------------------------------------------------------------------------
+
+    def test_fql_filter_by_severity(self):
+        """Test FQL filter by severity range."""
+        result = self.call_method(
+            self.module.search_cases,
+            filter="severity:>50",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="FQL severity filter")
+
+    def test_fql_filter_combined(self):
+        """Test FQL combined filter."""
+        result = self.call_method(
+            self.module.search_cases,
+            filter="status:'new'+severity:>50",
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="FQL combined filter")

--- a/tests/modules/test_cases.py
+++ b/tests/modules/test_cases.py
@@ -1,0 +1,656 @@
+"""
+Tests for the Cases module.
+"""
+
+import unittest
+
+from mcp.types import ToolAnnotations
+
+from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
+from falcon_mcp.modules.cases import CasesModule
+from tests.modules.utils.test_modules import TestModules
+
+
+class TestCasesModule(TestModules):
+    """Test cases for the Cases module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(CasesModule)
+
+    # -------------------------------------------------------------------------
+    # Registration Tests
+    # -------------------------------------------------------------------------
+
+    def test_register_tools(self):
+        """Test that all 8 case management tools are registered with correct prefixed names."""
+        expected_tools = [
+            "falcon_search_cases",
+            "falcon_get_cases",
+            "falcon_create_case",
+            "falcon_update_case",
+            "falcon_add_case_alert_evidence",
+            "falcon_add_case_event_evidence",
+            "falcon_manage_case_tags",
+            "falcon_list_case_templates",
+        ]
+        self.assert_tools_registered(expected_tools)
+
+    def test_register_resources(self):
+        """Test that the FQL guide resource is registered."""
+        expected_resources = [
+            "falcon_search_cases_fql_guide",
+        ]
+        self.assert_resources_registered(expected_resources)
+
+    # -------------------------------------------------------------------------
+    # Annotation Tests
+    # -------------------------------------------------------------------------
+
+    def test_mutating_tools_have_correct_annotations(self):
+        """Test that write tools have readOnlyHint=False, non-destructive annotations."""
+        self.module.register_tools(self.mock_server)
+
+        mutating_annotations = ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=True,
+        )
+
+        for tool_name in [
+            "falcon_create_case",
+            "falcon_update_case",
+            "falcon_add_case_alert_evidence",
+            "falcon_add_case_event_evidence",
+            "falcon_manage_case_tags",
+        ]:
+            self.assert_tool_annotations(tool_name, mutating_annotations)
+
+    def test_read_only_tools_have_default_annotations(self):
+        """Test that search/get/list tools have read-only annotations."""
+        self.module.register_tools(self.mock_server)
+
+        for tool_name in [
+            "falcon_search_cases",
+            "falcon_get_cases",
+            "falcon_list_case_templates",
+        ]:
+            self.assert_tool_annotations(tool_name, READ_ONLY_ANNOTATIONS)
+
+    # -------------------------------------------------------------------------
+    # Search Tests
+    # -------------------------------------------------------------------------
+
+    def test_search_cases_success(self):
+        """Test two-step search: query for IDs then fetch full details."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["case-id-1", "case-id-2"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "case-id-1", "name": "Case One", "severity": 75},
+                    {"id": "case-id-2", "name": "Case Two", "severity": 50},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_cases(filter="status:'new'", limit=10)
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+
+        first_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(first_call[0][0], "queries_cases_get_v1")
+        self.assertEqual(first_call[1]["parameters"]["filter"], "status:'new'")
+        self.assertEqual(first_call[1]["parameters"]["limit"], 10)
+
+        second_call = self.mock_client.command.call_args_list[1]
+        self.assertEqual(second_call[0][0], "entities_cases_post_v2")
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "case-id-1")
+        self.assertEqual(result[1]["id"], "case-id-2")
+
+    def test_search_cases_empty_results(self):
+        """Test that empty query results return FQL guide response."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.search_cases(filter="status:'nonexistent'")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertEqual(result["results"], [])
+        self.assertIn("fql_guide", result)
+        self.assertIn("hint", result)
+        self.assertIn("No results matched", result["hint"])
+
+    def test_search_cases_search_error(self):
+        """Test that query API error returns FQL guide response."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid FQL syntax"}]},
+        }
+
+        result = self.module.search_cases(filter="bad filter!!!")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 1)
+        self.assertIn("error", result["results"][0])
+        self.assertIn("fql_guide", result)
+        self.assertIn("hint", result)
+
+    def test_search_cases_details_error(self):
+        """Test that details API error is returned wrapped in a list."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["case-id-1"]},
+        }
+        details_response = {
+            "status_code": 500,
+            "body": {"errors": [{"message": "Internal server error"}]},
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_cases(filter="status:'new'")
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    # -------------------------------------------------------------------------
+    # Get Tests
+    # -------------------------------------------------------------------------
+
+    def test_get_cases_success(self):
+        """Test getting cases by IDs returns full case records."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "case-id-1", "name": "Test Case", "severity": 80},
+                ]
+            },
+        }
+
+        result = self.module.get_cases(ids=["case-id-1"])
+
+        self.mock_client.command.assert_called_once_with(
+            "entities_cases_post_v2",
+            body={"ids": ["case-id-1"]},
+        )
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "case-id-1")
+
+    def test_get_cases_error(self):
+        """Test that get cases API error returns an error dict."""
+        self.mock_client.command.return_value = {
+            "status_code": 404,
+            "body": {"errors": [{"message": "Case not found"}]},
+        }
+
+        result = self.module.get_cases(ids=["nonexistent-case-id"])
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    # -------------------------------------------------------------------------
+    # Create Tests
+    # -------------------------------------------------------------------------
+
+    def test_create_case_success(self):
+        """Test creating a case with name and severity returns created record."""
+        self.mock_client.command.return_value = {
+            "status_code": 201,
+            "body": {
+                "resources": [
+                    {"id": "new-case-id", "name": "My Case", "severity": 75}
+                ]
+            },
+        }
+
+        result = self.module.create_case(
+            name="My Case",
+            severity=75,
+            description=None,
+            status=None,
+            assigned_to_user_uuid=None,
+            tags=None,
+            template_id=None,
+            alert_ids=None,
+            event_ids=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "entities_cases_put_v2")
+        body = call_args[1]["body"]
+        self.assertEqual(body["name"], "My Case")
+        self.assertEqual(body["severity"], 75)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "new-case-id")
+
+    def test_create_case_with_evidence(self):
+        """Test that alert_ids and event_ids are converted to object format."""
+        self.mock_client.command.return_value = {
+            "status_code": 201,
+            "body": {"resources": [{"id": "new-case-id", "name": "Evidence Case"}]},
+        }
+
+        self.module.create_case(
+            name="Evidence Case",
+            severity=50,
+            description=None,
+            status=None,
+            assigned_to_user_uuid=None,
+            tags=None,
+            template_id=None,
+            alert_ids=["alert-1", "alert-2"],
+            event_ids=["event-1"],
+        )
+
+        call_args = self.mock_client.command.call_args
+        body = call_args[1]["body"]
+        self.assertIn("evidence", body)
+        self.assertEqual(body["evidence"]["alerts"], [{"id": "alert-1"}, {"id": "alert-2"}])
+        self.assertEqual(body["evidence"]["events"], [{"id": "event-1"}])
+
+    def test_create_case_with_template(self):
+        """Test that template_id is nested as {"template": {"id": "..."}}."""
+        self.mock_client.command.return_value = {
+            "status_code": 201,
+            "body": {"resources": [{"id": "new-case-id", "name": "Template Case"}]},
+        }
+
+        self.module.create_case(
+            name="Template Case",
+            severity=25,
+            description=None,
+            status=None,
+            assigned_to_user_uuid=None,
+            tags=None,
+            template_id="tmpl-abc-123",
+            alert_ids=None,
+            event_ids=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        body = call_args[1]["body"]
+        self.assertEqual(body["template"], {"id": "tmpl-abc-123"})
+
+    def test_create_case_error(self):
+        """Test that create case API error is returned wrapped in a list."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Validation failed"}]},
+        }
+
+        result = self.module.create_case(
+            name="Bad Case",
+            severity=50,
+            description=None,
+            status=None,
+            assigned_to_user_uuid=None,
+            tags=None,
+            template_id=None,
+            alert_ids=None,
+            event_ids=None,
+        )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    # -------------------------------------------------------------------------
+    # Update Tests
+    # -------------------------------------------------------------------------
+
+    def test_update_case_success(self):
+        """Test updating a case sends id and updated fields correctly."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "case-id-1", "name": "Updated Name", "status": "in_progress"}
+                ]
+            },
+        }
+
+        result = self.module.update_case(
+            id="case-id-1",
+            name="Updated Name",
+            status="in_progress",
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "entities_cases_patch_v2")
+        body = call_args[1]["body"]
+        self.assertEqual(body["id"], "case-id-1")
+        self.assertIn("fields", body)
+        self.assertEqual(body["fields"]["name"], "Updated Name")
+        self.assertEqual(body["fields"]["status"], "in_progress")
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+
+    def test_update_case_with_expected_version(self):
+        """Test that expected_version is included in the request body."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "case-id-1", "version": 3}]},
+        }
+
+        self.module.update_case(
+            id="case-id-1",
+            severity=90,
+            expected_version=2,
+        )
+
+        call_args = self.mock_client.command.call_args
+        body = call_args[1]["body"]
+        self.assertEqual(body["expected_version"], 2)
+        self.assertEqual(body["fields"]["severity"], 90)
+
+    def test_update_case_no_fields(self):
+        """Test that updating with no fields returns a validation error."""
+        result = self.module.update_case(
+            id="case-id-1",
+            name=None,
+            description=None,
+            status=None,
+            severity=None,
+            assigned_to_user_uuid=None,
+            remove_user_assignment=None,
+            template_id=None,
+            expected_version=None,
+        )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+        self.mock_client.command.assert_not_called()
+
+    def test_update_case_with_template(self):
+        """Test that template_id in update is nested as {"template": {"id": "..."}}."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "case-id-1"}]},
+        }
+
+        self.module.update_case(id="case-id-1", template_id="tmpl-xyz-789")
+
+        call_args = self.mock_client.command.call_args
+        body = call_args[1]["body"]
+        self.assertEqual(body["fields"]["template"], {"id": "tmpl-xyz-789"})
+
+    # -------------------------------------------------------------------------
+    # Evidence Tests
+    # -------------------------------------------------------------------------
+
+    def test_add_alert_evidence_success(self):
+        """Test adding alert evidence with correct body format."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "case-id-1"}]},
+        }
+
+        result = self.module.add_case_alert_evidence(
+            id="case-id-1",
+            alert_ids=["alert-composite-1", "alert-composite-2"],
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "entities_alert_evidence_post_v1",
+            body={
+                "id": "case-id-1",
+                "alerts": [{"id": "alert-composite-1"}, {"id": "alert-composite-2"}],
+            },
+        )
+        self.assertIsInstance(result, list)
+
+    def test_add_event_evidence_success(self):
+        """Test adding event evidence with correct body format."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "case-id-1"}]},
+        }
+
+        result = self.module.add_case_event_evidence(
+            id="case-id-1",
+            event_ids=["event-id-1", "event-id-2"],
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "entities_event_evidence_post_v1",
+            body={
+                "id": "case-id-1",
+                "events": [{"id": "event-id-1"}, {"id": "event-id-2"}],
+            },
+        )
+        self.assertIsInstance(result, list)
+
+    # -------------------------------------------------------------------------
+    # Tag Tests
+    # -------------------------------------------------------------------------
+
+    def test_manage_tags_add(self):
+        """Test adding tags sends POST body with id and tags."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "case-id-1", "tags": ["tag1", "tag2"]}]},
+        }
+
+        result = self.module.manage_case_tags(
+            id="case-id-1",
+            action="add",
+            tags=["tag1", "tag2"],
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "entities_case_tags_post_v1",
+            body={"id": "case-id-1", "tags": ["tag1", "tag2"]},
+        )
+        self.assertIsInstance(result, list)
+
+    def test_manage_tags_remove(self):
+        """Test removing tags sends DELETE with query parameters (not body)."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "case-id-1", "tags": []}]},
+        }
+
+        result = self.module.manage_case_tags(
+            id="case-id-1",
+            action="remove",
+            tags=["tag1"],
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "entities_case_tags_delete_v1")
+        # DELETE must use query parameters, not body
+        self.assertIn("parameters", call_args[1])
+        self.assertNotIn("body", call_args[1])
+        self.assertEqual(call_args[1]["parameters"]["id"], "case-id-1")
+        self.assertEqual(call_args[1]["parameters"]["tag"], ["tag1"])
+
+        self.assertIsInstance(result, list)
+
+    def test_manage_tags_invalid_action(self):
+        """Test that an invalid action returns an error without calling the API."""
+        result = self.module.manage_case_tags(
+            id="case-id-1",
+            action="invalid_action",
+            tags=["tag1"],
+        )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+        self.mock_client.command.assert_not_called()
+
+    # -------------------------------------------------------------------------
+    # Template Tests
+    # -------------------------------------------------------------------------
+
+    def test_list_templates_success(self):
+        """Test two-step template listing: query IDs then fetch details with use_params=True."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["tmpl-id-1", "tmpl-id-2"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "tmpl-id-1", "name": "Incident Template"},
+                    {"id": "tmpl-id-2", "name": "Alert Template"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.list_case_templates(limit=50)
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+
+        first_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(first_call[0][0], "queries_templates_get_v1")
+
+        # Verify the second call uses query parameters (use_params=True → GET)
+        second_call = self.mock_client.command.call_args_list[1]
+        self.assertEqual(second_call[0][0], "entities_templates_get_v1")
+        self.assertIn("parameters", second_call[1])
+        self.assertNotIn("body", second_call[1])
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "tmpl-id-1")
+
+    def test_list_templates_empty(self):
+        """Test that empty template query returns an empty list (no FQL guide)."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.list_case_templates()
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, [])
+
+    # -------------------------------------------------------------------------
+    # Security Validation Tests
+    # -------------------------------------------------------------------------
+
+    def test_search_cases_with_special_characters_in_filter(self):
+        """Test that special characters in the filter are passed safely to the API."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        filter_with_special = "status:'new'+name:*';DROP TABLE--*"
+        self.module.search_cases(filter=filter_with_special)
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["parameters"]["filter"], filter_with_special)
+
+    def test_create_case_permission_error(self):
+        """Test that a 403 permission error on create case returns error response."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied, authorization failed"}]},
+        }
+
+        result = self.module.create_case(
+            name="Unauthorized Case",
+            severity=50,
+            description=None,
+            status=None,
+            assigned_to_user_uuid=None,
+            tags=None,
+            template_id=None,
+            alert_ids=None,
+            event_ids=None,
+        )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    def test_update_case_conflict_error(self):
+        """Test that a 409 conflict on update case returns error response."""
+        self.mock_client.command.return_value = {
+            "status_code": 409,
+            "body": {"errors": [{"message": "Version conflict"}]},
+        }
+
+        result = self.module.update_case(
+            id="case-id-1",
+            name="Conflicting Update",
+            expected_version=1,
+        )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    def test_add_alert_evidence_permission_error(self):
+        """Test that a 403 error on add alert evidence returns error response."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied"}]},
+        }
+
+        result = self.module.add_case_alert_evidence(
+            id="case-id-1",
+            alert_ids=["alert-1"],
+        )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    def test_manage_tags_add_with_long_tags(self):
+        """Test that long tag values are passed through to the API."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "case-id-1"}]},
+        }
+
+        long_tag = "x" * 128
+        self.module.manage_case_tags(id="case-id-1", action="add", tags=[long_tag])
+
+        call_args = self.mock_client.command.call_args
+        body = call_args[1]["body"]
+        self.assertIn(long_tag, body["tags"])
+
+    def test_list_templates_error(self):
+        """Test that a template query error is wrapped in a list."""
+        self.mock_client.command.return_value = {
+            "status_code": 500,
+            "body": {"errors": [{"message": "Internal server error"}]},
+        }
+
+        result = self.module.list_case_templates()
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -54,6 +54,12 @@ MUTATING_TOOL_ALLOWLIST: set[str] = {
     # cloud module (cspm suppression rules)
     "falcon_create_cspm_suppression_rule",
     "falcon_delete_cspm_suppression_rules",
+    # cases module
+    "falcon_create_case",
+    "falcon_update_case",
+    "falcon_add_case_alert_evidence",
+    "falcon_add_case_event_evidence",
+    "falcon_manage_case_tags",
 }
 
 RESOURCE_URI_PATTERN = re.compile(r"^falcon://[a-z0-9-]+(/[a-z0-9-]+)+/[a-z]+-guide$")


### PR DESCRIPTION
New Case Management module, picking up where the Incidents module left off (removed in #368). Eight tools covering the full case lifecycle through the FalconPy CaseManagement class.

Read-only: `falcon_search_cases` (two-step query+get with FQL), `falcon_get_cases` (by known IDs), `falcon_list_case_templates` (two-step, GET params)

Write: `falcon_create_case` (PUT, inline evidence at creation), `falcon_update_case` (PATCH, optimistic concurrency via expected_version), `falcon_add_case_alert_evidence`, `falcon_add_case_event_evidence`, `falcon_manage_case_tags` (add/remove)

Some gotchas from live API validation worth knowing about:
- Evidence IDs have to be objects `[{"id": "..."}]`, not plain strings — the SDK payload builders don't check this
- `update_case_fields` needs everything nested under a `"fields"` key — flat body returns 200 but silently changes nothing
- Tag management is asymmetric: add is POST with body, remove is DELETE with query params
- `get_templates` is a GET endpoint so it needs `use_params=True` in `_base_get_by_ids`

FQL resource covers 40+ filter fields validated against the live API. 31 unit tests, 11 integration tests (full create/update/tag/close roundtrip), regenerated module docs.

Closes #386