### PR TITLE
docs: add Case Management to README module table

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Full docs are available at **[crowdstrike.github.io/falcon-mcp](https://crowdstr
 | Module | Description |
 |--------|-------------|
 | Core | Basic connectivity and system information |
+| [Case Management](https://crowdstrike.github.io/falcon-mcp/modules/cases/) | Case lifecycle management, evidence attachment, tagging, and templates |
 | [Cloud Security](https://crowdstrike.github.io/falcon-mcp/modules/cloud/) | Kubernetes containers, image vulnerabilities, CSPM asset inventory, IOM findings, and suppression rules |
 | [Custom IOA](https://crowdstrike.github.io/falcon-mcp/modules/custom-ioa/) | Create and manage Custom IOA behavioral detection rules and rule groups |
 | [Detections](https://crowdstrike.github.io/falcon-mcp/modules/detections/) | Find and analyze detections to understand malicious activity |


### PR DESCRIPTION
Missed adding the new Cases module to the README table in #388. Alphabetically slotted between Core and Cloud Security.