### PR TITLE
fix(modules/idp): resolve FieldInfo defaults before building search_criteria

### DIFF
--- a/falcon_mcp/common/utils.py
+++ b/falcon_mcp/common/utils.py
@@ -13,6 +13,11 @@ from .logging import get_logger
 logger = get_logger(__name__)
 
 
+def unwrap_field_default(value: Any) -> Any:
+    """Resolve a Pydantic FieldInfo object to its actual default value."""
+    return value.default if hasattr(value, "default") else value
+
+
 def filter_none_values(data: dict[str, Any]) -> dict[str, Any]:
     """Remove None values from a dictionary.
 

--- a/falcon_mcp/modules/idp.py
+++ b/falcon_mcp/modules/idp.py
@@ -14,7 +14,7 @@ from mcp.server import FastMCP
 from pydantic import Field
 
 from falcon_mcp.common.logging import get_logger
-from falcon_mcp.common.utils import sanitize_input
+from falcon_mcp.common.utils import sanitize_input, unwrap_field_default
 from falcon_mcp.modules.base import BaseModule
 
 logger = get_logger(__name__)
@@ -119,23 +119,20 @@ class IdpModule(BaseModule):
         logger.debug("Starting comprehensive entity investigation")
 
         # Resolve unset Pydantic Field defaults to avoid leaking FieldInfo objects (issue #384)
-        def _unwrap(value):
-            return value.default if hasattr(value, "default") else value
-
-        entity_ids = _unwrap(entity_ids)
-        entity_names = _unwrap(entity_names)
-        email_addresses = _unwrap(email_addresses)
-        ip_addresses = _unwrap(ip_addresses)
-        domain_names = _unwrap(domain_names)
-        investigation_types = _unwrap(investigation_types)
-        timeline_start_time = _unwrap(timeline_start_time)
-        timeline_end_time = _unwrap(timeline_end_time)
-        timeline_event_types = _unwrap(timeline_event_types)
-        relationship_depth = _unwrap(relationship_depth)
-        limit = _unwrap(limit)
-        include_associations = _unwrap(include_associations)
-        include_accounts = _unwrap(include_accounts)
-        include_incidents = _unwrap(include_incidents)
+        entity_ids = unwrap_field_default(entity_ids)
+        entity_names = unwrap_field_default(entity_names)
+        email_addresses = unwrap_field_default(email_addresses)
+        ip_addresses = unwrap_field_default(ip_addresses)
+        domain_names = unwrap_field_default(domain_names)
+        investigation_types = unwrap_field_default(investigation_types)
+        timeline_start_time = unwrap_field_default(timeline_start_time)
+        timeline_end_time = unwrap_field_default(timeline_end_time)
+        timeline_event_types = unwrap_field_default(timeline_event_types)
+        relationship_depth = unwrap_field_default(relationship_depth)
+        limit = unwrap_field_default(limit)
+        include_associations = unwrap_field_default(include_associations)
+        include_accounts = unwrap_field_default(include_accounts)
+        include_incidents = unwrap_field_default(include_incidents)
 
         # Step 1: Validate inputs
         validation_error = self._validate_entity_identifiers(
@@ -1045,10 +1042,7 @@ class IdpModule(BaseModule):
         relationship_results = []
 
         for entity_id in entity_ids:
-            # Handle FieldInfo objects - extract the actual value
-            relationship_depth = options.get("relationship_depth", 2)
-            if hasattr(relationship_depth, "default"):
-                relationship_depth = relationship_depth.default
+            relationship_depth = unwrap_field_default(options.get("relationship_depth", 2))
 
             graphql_query = self._build_relationship_analysis_query(
                 entity_id=entity_id,

--- a/falcon_mcp/modules/idp.py
+++ b/falcon_mcp/modules/idp.py
@@ -118,6 +118,25 @@ class IdpModule(BaseModule):
         """
         logger.debug("Starting comprehensive entity investigation")
 
+        # Resolve unset Pydantic Field defaults to avoid leaking FieldInfo objects (issue #384)
+        def _unwrap(value):
+            return value.default if hasattr(value, "default") else value
+
+        entity_ids = _unwrap(entity_ids)
+        entity_names = _unwrap(entity_names)
+        email_addresses = _unwrap(email_addresses)
+        ip_addresses = _unwrap(ip_addresses)
+        domain_names = _unwrap(domain_names)
+        investigation_types = _unwrap(investigation_types)
+        timeline_start_time = _unwrap(timeline_start_time)
+        timeline_end_time = _unwrap(timeline_end_time)
+        timeline_event_types = _unwrap(timeline_event_types)
+        relationship_depth = _unwrap(relationship_depth)
+        limit = _unwrap(limit)
+        include_associations = _unwrap(include_associations)
+        include_accounts = _unwrap(include_accounts)
+        include_incidents = _unwrap(include_incidents)
+
         # Step 1: Validate inputs
         validation_error = self._validate_entity_identifiers(
             entity_ids,

--- a/tests/modules/test_idp.py
+++ b/tests/modules/test_idp.py
@@ -4,6 +4,8 @@ Tests for the IDP (Identity Protection) module.
 
 import unittest
 
+from pydantic.fields import FieldInfo
+
 from falcon_mcp.modules.idp import IdpModule
 from tests.modules.utils.test_modules import TestModules
 
@@ -244,8 +246,6 @@ class TestIdpModule(TestModules):
 
     def test_investigate_entity_error_response_has_no_fieldinfo(self):
         """Error responses must not leak raw Pydantic FieldInfo objects (issue #384)."""
-        from pydantic.fields import FieldInfo
-
         # Empty entity resolution so the error path builds search_criteria
         self.mock_client.command.return_value = {
             "status_code": 200,
@@ -266,6 +266,34 @@ class TestIdpModule(TestModules):
         assert_no_fieldinfo(result)
         self.assertEqual(result["search_criteria"]["entity_ids"], None)
         self.assertEqual(result["search_criteria"]["entity_names"], ["NonExistent User"])
+
+    def test_investigate_entity_zero_args_no_fieldinfo_leak(self):
+        """Zero-argument call must not leak FieldInfo objects in the error response."""
+        result = self.module.investigate_entity()
+
+        # Verify validation error returned
+        self.assertIn("error", result)
+        self.assertIn("investigation_summary", result)
+        self.assertEqual(result["investigation_summary"]["status"], "failed")
+
+        # Verify investigation_types resolved to actual default, not FieldInfo
+        self.assertEqual(
+            result["investigation_summary"]["investigation_types"],
+            ["entity_details"],
+        )
+
+        # Recursive check: no FieldInfo objects anywhere in the response
+        def assert_no_fieldinfo(obj):
+            if isinstance(obj, dict):
+                for value in obj.values():
+                    assert_no_fieldinfo(value)
+            elif isinstance(obj, list):
+                for value in obj:
+                    assert_no_fieldinfo(value)
+            else:
+                self.assertNotIsInstance(obj, FieldInfo)
+
+        assert_no_fieldinfo(result)
 
     def test_investigate_entity_with_geographic_location_data(self):
         """Test entity investigation includes geographic location data in timeline analysis."""

--- a/tests/modules/test_idp.py
+++ b/tests/modules/test_idp.py
@@ -242,6 +242,30 @@ class TestIdpModule(TestModules):
         self.assertEqual(result["investigation_summary"]["entity_count"], 0)
         self.assertIn("search_criteria", result)
 
+    def test_investigate_entity_error_response_has_no_fieldinfo(self):
+        """Error responses must not leak raw Pydantic FieldInfo objects (issue #384)."""
+        from pydantic.fields import FieldInfo
+
+        # Empty entity resolution so the error path builds search_criteria
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"data": {"entities": {"nodes": []}}},
+        }
+        result = self.module.investigate_entity(entity_names=["NonExistent User"])
+
+        def assert_no_fieldinfo(obj):
+            if isinstance(obj, dict):
+                for value in obj.values():
+                    assert_no_fieldinfo(value)
+            elif isinstance(obj, list):
+                for value in obj:
+                    assert_no_fieldinfo(value)
+            else:
+                self.assertNotIsInstance(obj, FieldInfo)
+
+        assert_no_fieldinfo(result)
+        self.assertEqual(result["search_criteria"]["entity_ids"], None)
+        self.assertEqual(result["search_criteria"]["entity_names"], ["NonExistent User"])
 
     def test_investigate_entity_with_geographic_location_data(self):
         """Test entity investigation includes geographic location data in timeline analysis."""


### PR DESCRIPTION
When `investigate_entity` is called without some parameters, `search_criteria` and `investigation_types` in the error response leaked raw Pydantic `FieldInfo` objects instead of the actual default values. This unwraps unset `Field` defaults at the start of the function, matching the existing `hasattr(x, "default")` handling in `_analyze_relationships_batch`. Closes #384.