### PR TITLE
fix(modules/cloud): return int count from count_kubernetes_containers

### DIFF
--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -223,7 +223,7 @@ class CloudModule(BaseModule):
 
         Use this for aggregate counts without returning full container details. Consult
         falcon://cloud/kubernetes-containers/fql-guide before constructing filter
-        expressions.
+        expressions. Returns the matching container count as an integer.
         """
 
         # Prepare parameters

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -243,13 +243,12 @@ class CloudModule(BaseModule):
         result = handle_api_response(
             response,
             operation=operation,
-            error_message="Failed to perform operation",
-            default_result=[],
+            error_message="Failed to count Kubernetes containers",
+            default_result=0,
         )
 
-        # ReadContainerCount returns [{"count": N}]; extract the count to match the -> int contract
         if isinstance(result, list) and result and isinstance(result[0], dict):
-            return result[0].get("count", 0)
+            return result[0].get("count") or 0
         return result
 
     def search_images_vulnerabilities(

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -223,7 +223,7 @@ class CloudModule(BaseModule):
 
         Use this for aggregate counts without returning full container details. Consult
         falcon://cloud/kubernetes-containers/fql-guide before constructing filter
-        expressions. Returns the count as a single-element list.
+        expressions.
         """
 
         # Prepare parameters
@@ -240,12 +240,17 @@ class CloudModule(BaseModule):
         response = self.client.command(operation, parameters=params)
 
         # Handle the response
-        return handle_api_response(
+        result = handle_api_response(
             response,
             operation=operation,
             error_message="Failed to perform operation",
             default_result=[],
         )
+
+        # ReadContainerCount returns [{"count": N}]; extract the count to match the -> int contract
+        if isinstance(result, list) and result and isinstance(result[0], dict):
+            return result[0].get("count", 0)
+        return result
 
     def search_images_vulnerabilities(
         self,

--- a/tests/modules/test_cloud.py
+++ b/tests/modules/test_cloud.py
@@ -98,7 +98,7 @@ class TestCloudModule(TestModules):
         }
         self.mock_client.command.return_value = mock_response
 
-        result = self.module.search_kubernetes_containers(filter="invalid_filter")
+        result = self.module.count_kubernetes_containers(filter="invalid_filter")
 
         self.assertIsInstance(result, dict)
         self.assertIn("error", result)

--- a/tests/modules/test_cloud.py
+++ b/tests/modules/test_cloud.py
@@ -76,7 +76,7 @@ class TestCloudModule(TestModules):
         self.assertIn("details", result)
 
     def test_count_kubernetes_containers(self):
-        """Test count for kubernetes containers returns an int (issue #382)."""
+        """Test count for kubernetes containers returns an int."""
         mock_response = {"status_code": 200, "body": {"resources": [{"count": 500}]}}
         self.mock_client.command.return_value = mock_response
 

--- a/tests/modules/test_cloud.py
+++ b/tests/modules/test_cloud.py
@@ -76,8 +76,8 @@ class TestCloudModule(TestModules):
         self.assertIn("details", result)
 
     def test_count_kubernetes_containers(self):
-        """Test count for kubernetes containers."""
-        mock_response = {"status_code": 200, "body": {"resources": [500]}}
+        """Test count for kubernetes containers returns an int (issue #382)."""
+        mock_response = {"status_code": 200, "body": {"resources": [{"count": 500}]}}
         self.mock_client.command.return_value = mock_response
 
         result = self.module.count_kubernetes_containers(filter="cloud_region:'us-1'")
@@ -87,7 +87,8 @@ class TestCloudModule(TestModules):
         first_call = self.mock_client.command.call_args_list[0]
         self.assertEqual(first_call[0][0], "ReadContainerCount")
         self.assertEqual(first_call[1]["parameters"]["filter"], "cloud_region:'us-1'")
-        self.assertEqual(result, [500])
+        self.assertEqual(result, 500)
+        self.assertIsInstance(result, int)
 
     def test_count_kubernetes_containers_errors(self):
         """Test count for kubernetes containers with API error."""


### PR DESCRIPTION
`count_kubernetes_containers` is annotated `-> int` but `ReadContainerCount` returns `[{"count": N}]`, so the tool returned a list instead of a number. This extracts the count value so the return matches the annotation and the tool's intent, with error responses still passed through unchanged. Closes #382.