### PR TITLE
Updates IDP entity resolution to use wildcard-capable GraphQL pattern filters.  Update descriptions to indicate support for samAccountName, UPNs.

### DIFF
--- a/falcon_mcp/modules/idp.py
+++ b/falcon_mcp/modules/idp.py
@@ -58,9 +58,10 @@ class IdpModule(BaseModule):
         email_addresses: str | None = Field(
             default=None,
             description=(
-                "SAM account, UPN, or Azure external identity pattern to search for "
-                "(e.g., 'jdoe', 'user@example.com', '*@example.com', "
-                "or 'john.doe_contoso.com#EXT#@tenant.onmicrosoft.com''). Supports '*' wildcards. "
+                "UPN, email address, or Azure external identity pattern to search for "
+                "(e.g., 'user@example.com', '*@example.com', "
+                "or 'john.doe_contoso.com#EXT#@tenant.onmicrosoft.com'). Supports '*' wildcards. "
+                "For AD samAccountName lookups, use domain_names + entity_names together instead. "
                 "When combined with other parameters, uses AND logic."
             ),
         ),
@@ -263,6 +264,25 @@ class IdpModule(BaseModule):
                     "status": "failed",
                 },
             }
+
+        if (entity_names and isinstance(entity_names, str) and entity_names.strip("* ") == "") or (
+            email_addresses
+            and isinstance(email_addresses, str)
+            and email_addresses.strip("* ") == ""
+        ):
+            return {
+                "error": (
+                    "entity_names/email_addresses cannot be a bare wildcard ('*'). "
+                    "Provide a more specific pattern (e.g., 'Admin*') or narrow the search."
+                ),
+                "investigation_summary": {
+                    "entity_count": 0,
+                    "investigation_types": investigation_types,
+                    "timestamp": datetime.utcnow().isoformat(),
+                    "status": "failed",
+                },
+            }
+
         return None
 
     def _create_error_response(

--- a/falcon_mcp/modules/idp.py
+++ b/falcon_mcp/modules/idp.py
@@ -47,13 +47,22 @@ class IdpModule(BaseModule):
             default=None,
             description="List of specific entity IDs to investigate (e.g., ['entity-001'])",
         ),
-        entity_names: list[str] | None = Field(
+        entity_names: str | None = Field(
             default=None,
-            description="List of entity names to search for (e.g., ['Administrator', 'John Doe']). When combined with other parameters, uses AND logic.",
+            description=(
+                "Entity display name pattern to search for "
+                "(e.g., 'John Doe' or 'Doe, John' or 'Administrator' or 'Admin*'). Supports '*' wildcards. "
+                "When combined with other parameters, uses AND logic."
+            ),
         ),
-        email_addresses: list[str] | None = Field(
+        email_addresses: str | None = Field(
             default=None,
-            description="List of email addresses to investigate (e.g., ['user@example.com']). When combined with other parameters, uses AND logic.",
+            description=(
+                "SAM account, UPN, or Azure external identity pattern to search for "
+                "(e.g., 'jdoe', 'user@example.com', '*@example.com', "
+                "or 'john.doe_contoso.com#EXT#@tenant.onmicrosoft.com''). Supports '*' wildcards. "
+                "When combined with other parameters, uses AND logic."
+            ),
         ),
         ip_addresses: list[str] | None = Field(
             default=None,
@@ -61,7 +70,7 @@ class IdpModule(BaseModule):
         ),
         domain_names: list[str] | None = Field(
             default=None,
-            description="List of domain names to search for (e.g., ['XDRHOLDINGS.COM', 'CORP.LOCAL']). When combined with other parameters, uses AND logic. Example: entity_names=['Administrator'] + domain_names=['DOMAIN.COM'] finds Administrator user in that specific domain.",
+            description="List of domain names to search for (e.g., ['XDRHOLDINGS.COM', 'CORP.LOCAL']). When combined with other parameters, uses AND logic. Example: entity_names='Administrator' + domain_names=['DOMAIN.COM'] finds Administrator user in that specific domain.",
         ),
         # Investigation Scope Control
         investigation_types: list[str] = Field(
@@ -825,7 +834,7 @@ class IdpModule(BaseModule):
         """Resolve entity IDs from various identifier types using unified AND-based query.
 
         All provided identifiers are combined using AND logic in a single GraphQL query.
-        For example: entity_names=["Administrator"] + domain_names=["XDRHOLDINGS.COM"]
+        For example: entity_names="Administrator" + domain_names=["XDRHOLDINGS.COM"]
         will find entities that match BOTH criteria.
 
         Returns:
@@ -948,10 +957,9 @@ class IdpModule(BaseModule):
         query_fields,
         query_filters,
     ):
-        if email_addresses and isinstance(email_addresses, list):
-            sanitized_emails = [sanitize_input(email) for email in email_addresses]
-            emails_json = json.dumps(sanitized_emails)
-            query_filters.append(f"secondaryDisplayNames: {emails_json}")
+        if email_addresses and isinstance(email_addresses, str):
+            sanitized_email = sanitize_input(email_addresses)
+            query_filters.append(f"secondaryDisplayNamePattern: {json.dumps(sanitized_email)}")
             query_filters.append("types: [USER]")
             query_fields.extend(["primaryDisplayName", "secondaryDisplayName"])
 
@@ -962,10 +970,9 @@ class IdpModule(BaseModule):
         query_filters,
     ):
         entity_names = identifiers.get("entity_names")
-        if entity_names and isinstance(entity_names, list):
-            sanitized_names = [sanitize_input(name) for name in entity_names]
-            names_json = json.dumps(sanitized_names)
-            query_filters.append(f"primaryDisplayNames: {names_json}")
+        if entity_names and isinstance(entity_names, str):
+            sanitized_name = sanitize_input(entity_names)
+            query_filters.append(f"primaryDisplayNamePattern: {json.dumps(sanitized_name)}")
             query_fields.append("primaryDisplayName")
 
     def _get_entity_details_batch(

--- a/tests/e2e/modules/test_idp.py
+++ b/tests/e2e/modules/test_idp.py
@@ -24,7 +24,7 @@ class TestIdpModuleE2E(BaseE2ETest):
                 {
                     "operation": "api_preempt_proxy_post_graphql",
                     "validator": lambda kwargs: (
-                        "primaryDisplayNames" in kwargs.get("body", {}).get("query", "")
+                        "primaryDisplayNamePattern" in kwargs.get("body", {}).get("query", "")
                         and "Wallace Muniz" in kwargs.get("body", {}).get("query", "")
                     ),
                     "response": {
@@ -148,9 +148,9 @@ class TestIdpModuleE2E(BaseE2ETest):
                 "Tool should be called with entity_names parameter",
             )
 
-            entity_names = tool_input.get("entity_names", [])
+            entity_names = tool_input.get("entity_names", "")
             self.assertTrue(
-                any("Wallace Muniz" in name for name in entity_names),
+                "Wallace Muniz" in entity_names,
                 f"Tool should be called with Wallace Muniz in entity_names: {entity_names}",
             )
 
@@ -180,9 +180,9 @@ class TestIdpModuleE2E(BaseE2ETest):
             # First call should be entity name search
             first_call_query = api_calls[0][1].get("body", {}).get("query", "")
             self.assertIn(
-                "primaryDisplayNames",
+                "primaryDisplayNamePattern",
                 first_call_query,
-                "First call should search by primaryDisplayNames",
+                "First call should search by primaryDisplayNamePattern",
             )
             self.assertIn(
                 "Wallace Muniz",

--- a/tests/integration/test_idp.py
+++ b/tests/integration/test_idp.py
@@ -28,7 +28,7 @@ class TestIdpIntegration(BaseIntegrationTest):
         """
         result = self.call_method(
             self.module.investigate_entity,
-            entity_names=["Administrator"],
+            entity_names="Administrator",
             investigation_types=["entity_details"],
             limit=5,
         )
@@ -47,11 +47,11 @@ class TestIdpIntegration(BaseIntegrationTest):
     def test_investigate_entity_with_email_addresses(self):
         """Test investigate_entity with email addresses.
 
-        Tests USER entity type resolution via secondaryDisplayNames filter.
+        Tests USER entity type resolution via secondaryDisplayNamePattern filter.
         """
         result = self.call_method(
             self.module.investigate_entity,
-            email_addresses=["admin@example.com"],
+            email_addresses="admin@example.com",
             investigation_types=["entity_details"],
             limit=5,
         )
@@ -66,7 +66,7 @@ class TestIdpIntegration(BaseIntegrationTest):
         """
         result = self.call_method(
             self.module.investigate_entity,
-            entity_names=["Administrator"],
+            entity_names="Administrator",
             domain_names=["CORP.LOCAL"],
             investigation_types=["entity_details"],
             limit=5,
@@ -83,7 +83,7 @@ class TestIdpIntegration(BaseIntegrationTest):
         # First, find an entity to investigate
         result = self.call_method(
             self.module.investigate_entity,
-            entity_names=["Administrator"],
+            entity_names="Administrator",
             investigation_types=["entity_details"],
             limit=1,
         )
@@ -123,7 +123,7 @@ class TestIdpIntegration(BaseIntegrationTest):
         # First, find an entity to investigate
         result = self.call_method(
             self.module.investigate_entity,
-            entity_names=["Administrator"],
+            entity_names="Administrator",
             investigation_types=["entity_details"],
             limit=1,
         )
@@ -164,7 +164,7 @@ class TestIdpIntegration(BaseIntegrationTest):
         # First, find an entity to investigate
         result = self.call_method(
             self.module.investigate_entity,
-            entity_names=["Administrator"],
+            entity_names="Administrator",
             investigation_types=["entity_details"],
             limit=1,
         )
@@ -200,7 +200,7 @@ class TestIdpIntegration(BaseIntegrationTest):
         """Test investigate_entity with multiple investigation types."""
         result = self.call_method(
             self.module.investigate_entity,
-            entity_names=["Administrator"],
+            entity_names="Administrator",
             investigation_types=["entity_details", "risk_assessment"],
             limit=5,
         )
@@ -231,7 +231,7 @@ class TestIdpIntegration(BaseIntegrationTest):
         """
         result = self.call_method(
             self.module.investigate_entity,
-            entity_names=["Administrator"],
+            entity_names="Administrator",
             investigation_types=["entity_details"],
             limit=1,
         )

--- a/tests/modules/test_idp.py
+++ b/tests/modules/test_idp.py
@@ -810,5 +810,60 @@ class TestIdpModule(TestModules):
         self.assertIn("ipAddress", file_event)
 
 
+    # ==========================================
+    # Bare-wildcard guard tests (Change 2)
+    # ==========================================
+
+    def test_bare_wildcard_entity_names_rejected(self):
+        """entity_names='*' must return an error dict without calling the API."""
+        result = self.module.investigate_entity(entity_names="*")
+
+        self.assertIn("error", result)
+        self.assertIn("investigation_summary", result)
+        self.assertEqual(result["investigation_summary"]["status"], "failed")
+        self.assertFalse(self.mock_client.command.called)
+
+    def test_bare_wildcard_email_addresses_rejected(self):
+        """email_addresses='*' must return an error dict without calling the API."""
+        result = self.module.investigate_entity(email_addresses="*")
+
+        self.assertIn("error", result)
+        self.assertIn("investigation_summary", result)
+        self.assertEqual(result["investigation_summary"]["status"], "failed")
+        self.assertFalse(self.mock_client.command.called)
+
+    def test_bare_wildcard_variants_rejected(self):
+        """'**' and '* ' (all stars/spaces) must be rejected without calling the API."""
+        for bad_value in ["**", "* ", " * "]:
+            with self.subTest(entity_names=bad_value):
+                self.mock_client.command.reset_mock()
+                result = self.module.investigate_entity(entity_names=bad_value)
+                self.assertIn("error", result)
+                self.assertEqual(result["investigation_summary"]["status"], "failed")
+                self.assertFalse(self.mock_client.command.called)
+
+    def test_partial_wildcard_entity_names_accepted(self):
+        """entity_names='Admin*' is a legitimate pattern and must reach the API."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"data": {"entities": {"nodes": []}}},
+        }
+
+        self.module.investigate_entity(entity_names="Admin*")
+
+        self.assertTrue(self.mock_client.command.called)
+
+    def test_partial_wildcard_email_addresses_accepted(self):
+        """email_addresses='*@example.com' is a legitimate pattern and must reach the API."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"data": {"entities": {"nodes": []}}},
+        }
+
+        self.module.investigate_entity(email_addresses="*@example.com")
+
+        self.assertTrue(self.mock_client.command.called)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/modules/test_idp.py
+++ b/tests/modules/test_idp.py
@@ -50,7 +50,7 @@ class TestIdpModule(TestModules):
 
         # Call investigate_entity with basic parameters
         result = self.module.investigate_entity(
-            entity_names=["Test User"],
+            entity_names="Test User",
             investigation_types=["entity_details"],
             limit=10,
         )
@@ -63,6 +63,73 @@ class TestIdpModule(TestModules):
         self.assertIn("entity_details", result)
         self.assertEqual(result["investigation_summary"]["status"], "completed")
         self.assertGreater(result["investigation_summary"]["entity_count"], 0)
+
+    def test_investigate_entity_uses_primary_display_name_pattern(self):
+        """Entity name resolution should use wildcard-capable GraphQL patterns."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"data": {"entities": {"nodes": []}}},
+        }
+
+        self.module.investigate_entity(entity_names="Admin*")
+
+        query = self.mock_client.command.call_args.kwargs["body"]["query"]
+        self.assertIn('primaryDisplayNamePattern: "Admin*"', query)
+        self.assertNotIn("primaryDisplayNames:", query)
+
+    def test_investigate_entity_uses_email_address_pattern(self):
+        """Email resolution should use wildcard-capable email address patterns."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"data": {"entities": {"nodes": []}}},
+        }
+
+        self.module.investigate_entity(email_addresses="*@example.com")
+
+        query = self.mock_client.command.call_args.kwargs["body"]["query"]
+        self.assertIn('secondaryDisplayNamePattern: "*@example.com"', query)
+        self.assertIn("types: [USER]", query)
+        self.assertNotIn("secondaryDisplayNames:", query)
+
+    def test_investigate_entity_uses_domain_filter(self):
+        """Domain resolution should use list-based GraphQL domain filters."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"data": {"entities": {"nodes": []}}},
+        }
+
+        self.module.investigate_entity(domain_names=["CORP.LOCAL"])
+
+        query = self.mock_client.command.call_args.kwargs["body"]["query"]
+        self.assertIn('domains: ["CORP.LOCAL"]', query)
+        self.assertNotIn("domainPattern:", query)
+
+    def test_investigate_entity_exact_name_uses_pattern_argument(self):
+        """Exact-looking entity names should still use the pattern argument."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"data": {"entities": {"nodes": []}}},
+        }
+
+        self.module.investigate_entity(entity_names="Administrator")
+
+        query = self.mock_client.command.call_args.kwargs["body"]["query"]
+        self.assertIn('primaryDisplayNamePattern: "Administrator"', query)
+        self.assertNotIn("primaryDisplayNames:", query)
+
+    def test_investigate_entity_combines_name_pattern_and_domain_filter(self):
+        """Name patterns and domain filters should still combine with AND logic."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"data": {"entities": {"nodes": []}}},
+        }
+
+        self.module.investigate_entity(entity_names="Admin*", domain_names=["CORP.LOCAL"])
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        query = self.mock_client.command.call_args.kwargs["body"]["query"]
+        self.assertIn('primaryDisplayNamePattern: "Admin*"', query)
+        self.assertIn('domains: ["CORP.LOCAL"]', query)
 
     def test_investigate_entity_with_multiple_investigation_types(self):
         """Test entity investigation with multiple investigation types."""
@@ -183,7 +250,7 @@ class TestIdpModule(TestModules):
 
         # Call investigate_entity with multiple investigation types
         result = self.module.investigate_entity(
-            email_addresses=["admin@example.com"],
+            email_addresses="admin@example.com",
             investigation_types=[
                 "entity_details",
                 "timeline_analysis",
@@ -235,7 +302,7 @@ class TestIdpModule(TestModules):
         self.mock_client.command.return_value = mock_response
 
         # Call investigate_entity
-        result = self.module.investigate_entity(entity_names=["NonExistent User"])
+        result = self.module.investigate_entity(entity_names="NonExistent User")
 
         # Verify result indicates no entities found
         self.assertIn("error", result)
@@ -251,7 +318,7 @@ class TestIdpModule(TestModules):
             "status_code": 200,
             "body": {"data": {"entities": {"nodes": []}}},
         }
-        result = self.module.investigate_entity(entity_names=["NonExistent User"])
+        result = self.module.investigate_entity(entity_names="NonExistent User")
 
         def assert_no_fieldinfo(obj):
             if isinstance(obj, dict):
@@ -265,7 +332,7 @@ class TestIdpModule(TestModules):
 
         assert_no_fieldinfo(result)
         self.assertEqual(result["search_criteria"]["entity_ids"], None)
-        self.assertEqual(result["search_criteria"]["entity_names"], ["NonExistent User"])
+        self.assertEqual(result["search_criteria"]["entity_names"], "NonExistent User")
 
     def test_investigate_entity_zero_args_no_fieldinfo_leak(self):
         """Zero-argument call must not leak FieldInfo objects in the error response."""
@@ -386,7 +453,7 @@ class TestIdpModule(TestModules):
 
         # Call investigate_entity with timeline analysis to get geographic data
         result = self.module.investigate_entity(
-            entity_names=["Global User"],
+            entity_names="Global User",
             investigation_types=["timeline_analysis"],
             timeline_start_time="2024-01-01T00:00:00Z",
             timeline_end_time="2024-01-02T23:59:59Z",
@@ -499,7 +566,7 @@ class TestIdpModule(TestModules):
 
         # Call investigate_entity with entity details to get geographic associations
         result = self.module.investigate_entity(
-            entity_names=["Travel User"],
+            entity_names="Travel User",
             investigation_types=["entity_details"],
             include_associations=True,
             limit=50,
@@ -624,7 +691,7 @@ class TestIdpModule(TestModules):
 
         # Call investigate_entity with timeline analysis
         result = self.module.investigate_entity(
-            entity_names=["Global Executive"],
+            entity_names="Global Executive",
             investigation_types=["timeline_analysis"],
             timeline_start_time="2024-01-01T00:00:00Z",
             timeline_end_time="2024-01-04T23:59:59Z",
@@ -716,7 +783,7 @@ class TestIdpModule(TestModules):
 
         # Call investigate_entity with timeline analysis
         result = self.module.investigate_entity(
-            entity_names=["File User"],
+            entity_names="File User",
             investigation_types=["timeline_analysis"],
             limit=50,
         )


### PR DESCRIPTION
Previously, `idp_investigate_entity` used exact-match list filters:

- `primaryDisplayNames`
- `secondaryDisplayNames`

This PR changes name and email resolution to use wildcard-capable filters:

- `primaryDisplayNamePattern`
- `secondaryDisplayNamePattern`

This creates more flexibility for an agent to search for a user's account, especially if the user's display name is estimated.  For example, searching for the account name for "John Doe" is now much easier if the agent does not know if the user's display name is "John Doe" or "Doe, John" or "John C. Doe".).

Also updated descriptions to inform an agent it can search for samAccountName and other UPNs via secondaryDisplayNamePattern.  Prior, the descriptions limited searches to email addresses only -- secondaryDisplayName can also contain samAccountName (DOMAIN.COM\jdoe) and User Principal Name (john.doe@mydomain.com, john.doe@domain.local).

There is a slight schema change:  entity_names and email_addresses goes from list[str] | None to str | None. That is cleaner for wildcard pattern search.  As the public tool is presented via MCP, the contract change should be picked up automatically by calling agents.