### PR TITLE
fix(modules/correlation-rules): align API fields with live behavior

### DIFF
--- a/falcon_mcp/modules/correlation_rules.py
+++ b/falcon_mcp/modules/correlation_rules.py
@@ -75,7 +75,7 @@ class CorrelationRulesModule(BaseModule):
         filter: str | None = Field(
             default=None,
             description="FQL filter expression. See `falcon://correlation-rules/search/fql-guide` for syntax.",
-            examples={"status:'active'+severity:>50", "tactic:'TA0001'"},
+            examples={"status:'active'+severity:>50", "mitre_attack.tactic_id:'TA0001'"},
         ),
         limit: int = Field(
             default=20,
@@ -97,8 +97,8 @@ class CorrelationRulesModule(BaseModule):
 
         Use this to find detection rules by name, status, severity, or MITRE tactic/technique.
         Consult falcon://correlation-rules/search/fql-guide before constructing filter expressions.
-        Returns full rule objects including all versions; filter with state:'published' to get
-        one result per rule. Returns search logic, schedule, and versioning info.
+        Returns full rule objects; use the `rule_id` field when passing results to update or
+        delete tools. Filter with state:'published' to get one result per rule.
         """
         result = self._base_search_api_call(
             operation="combined_rules_get_v2",
@@ -165,21 +165,22 @@ class CorrelationRulesModule(BaseModule):
         trigger_mode: str = Field(
             default="summary",
             description="How alerts are triggered per evaluation window.",
-            examples={"summary", "per_event"},
+            examples={"summary", "verbose"},
+        ),
+        use_ingest_time: bool = Field(
+            default=False,
+            description="Use event ingest time instead of event timestamp for the lookback window.",
         ),
         description: str | None = Field(
             default=None,
             description="Optional description explaining what the rule detects and why.",
         ),
-        tactic: str | None = Field(
+        mitre_attack: list[dict[str, str]] | None = Field(
             default=None,
-            description="MITRE ATT&CK tactic ID. Example: 'TA0001'",
-            examples={"TA0001", "TA0002", "TA0008"},
-        ),
-        technique: str | None = Field(
-            default=None,
-            description="MITRE ATT&CK technique ID. Example: 'T1059'",
-            examples={"T1059", "T1078", "T1021"},
+            description=(
+                "MITRE ATT&CK mapping as a list of objects with tactic_id and technique_id. "
+                "Example: [{'tactic_id': 'TA0002', 'technique_id': 'T1059'}]"
+            ),
         ),
         comment: str | None = Field(
             default=None,
@@ -202,6 +203,7 @@ class CorrelationRulesModule(BaseModule):
                 "outcome": search_outcome,
                 "lookback": lookback,
                 "trigger_mode": trigger_mode,
+                "use_ingest_time": use_ingest_time,
             },
             "operation": {
                 "schedule": {
@@ -212,10 +214,8 @@ class CorrelationRulesModule(BaseModule):
 
         if description is not None:
             body["description"] = description
-        if tactic is not None:
-            body["tactic"] = tactic
-        if technique is not None:
-            body["technique"] = technique
+        if mitre_attack is not None:
+            body["mitre_attack"] = mitre_attack
         if comment is not None:
             body["comment"] = comment
 
@@ -234,7 +234,7 @@ class CorrelationRulesModule(BaseModule):
     def update_correlation_rule(
         self,
         rule_id: str = Field(
-            description="Rule ID to update. Retrieve from `falcon_search_correlation_rules`.",
+            description="Rule ID to update. Use the `rule_id` field from `falcon_search_correlation_rules` results.",
         ),
         name: str | None = Field(
             default=None,
@@ -264,15 +264,18 @@ class CorrelationRulesModule(BaseModule):
         trigger_mode: str | None = Field(
             default=None,
             description="Updated trigger mode.",
-            examples={"summary", "per_event"},
+            examples={"summary", "verbose"},
         ),
-        tactic: str | None = Field(
+        use_ingest_time: bool | None = Field(
             default=None,
-            description="Updated MITRE ATT&CK tactic ID. Example: 'TA0001'",
+            description="Use event ingest time instead of event timestamp for the lookback window.",
         ),
-        technique: str | None = Field(
+        mitre_attack: list[dict[str, str]] | None = Field(
             default=None,
-            description="Updated MITRE ATT&CK technique ID. Example: 'T1059'",
+            description=(
+                "Updated MITRE ATT&CK mapping as a list of objects with tactic_id and technique_id. "
+                "Example: [{'tactic_id': 'TA0002', 'technique_id': 'T1059'}]"
+            ),
         ),
         comment: str | None = Field(
             default=None,
@@ -285,7 +288,6 @@ class CorrelationRulesModule(BaseModule):
         step needed. To enable/disable a rule, set status to 'active' or 'inactive'.
         Only provided fields are changed; omitted fields retain current values.
         """
-        # PATCH API takes rule_id in the "id" body field
         body: dict[str, Any] = {"id": rule_id}
 
         if name is not None:
@@ -298,12 +300,16 @@ class CorrelationRulesModule(BaseModule):
             body["severity"] = severity
         if comment is not None:
             body["comment"] = comment
-        if tactic is not None:
-            body["tactic"] = tactic
-        if technique is not None:
-            body["technique"] = technique
+        if mitre_attack is not None:
+            body["mitre_attack"] = mitre_attack
 
-        if search_filter is not None or lookback is not None or trigger_mode is not None:
+        search_fields_set = (
+            search_filter is not None
+            or lookback is not None
+            or trigger_mode is not None
+            or use_ingest_time is not None
+        )
+        if search_fields_set:
             search: dict[str, Any] = {}
             if search_filter is not None:
                 search["filter"] = search_filter
@@ -311,6 +317,8 @@ class CorrelationRulesModule(BaseModule):
                 search["lookback"] = lookback
             if trigger_mode is not None:
                 search["trigger_mode"] = trigger_mode
+            if use_ingest_time is not None:
+                search["use_ingest_time"] = use_ingest_time
             body["search"] = search
 
         # PATCH endpoint requires body as a list of rule dicts
@@ -331,7 +339,7 @@ class CorrelationRulesModule(BaseModule):
     def delete_correlation_rules(
         self,
         ids: list[str] = Field(
-            description="Rule IDs to delete. Retrieve from `falcon_search_correlation_rules`.",
+            description="Rule IDs to delete. Use the `rule_id` field from `falcon_search_correlation_rules` results.",
         ),
         comment: str | None = Field(
             default=None,

--- a/falcon_mcp/resources/correlation_rules.py
+++ b/falcon_mcp/resources/correlation_rules.py
@@ -61,20 +61,20 @@ SEARCH_CORRELATION_RULES_FQL_FILTERS = [
         """
     ),
     (
-        "tactic",
+        "mitre_attack.tactic_id",
         "String",
         """
-        MITRE ATT&CK tactic ID. Uses ATT&CK tactic IDs,
-        not names.
-        Ex: tactic:'TA0001', tactic:'TA0002'
+        MITRE ATT&CK tactic ID from the mitre_attack mapping.
+        Uses ATT&CK tactic IDs, not names.
+        Ex: mitre_attack.tactic_id:'TA0001'
         """
     ),
     (
-        "technique",
+        "mitre_attack.technique_id",
         "String",
         """
-        MITRE ATT&CK technique ID.
-        Ex: technique:'T1059', technique:'T1003'
+        MITRE ATT&CK technique ID from the mitre_attack mapping.
+        Ex: mitre_attack.technique_id:'T1059'
         """
     ),
     (
@@ -137,7 +137,7 @@ field_name:[operator]'value'
 
 === COMBINING ===
 • + = AND: status:'active'+severity:>50
-• , = OR: tactic:'TA0001',tactic:'TA0002'
+• , = OR: mitre_attack.tactic_id:'TA0001',mitre_attack.tactic_id:'TA0002'
 
 === SORT OPTIONS ===
 Sort fields: created_on, last_updated_on, name, severity, status
@@ -163,10 +163,11 @@ These are distinct fields:
 
 A rule can be active but unpublished, or published but inactive.
 
-=== TACTIC FORMAT ===
-Tactic field uses MITRE ATT&CK tactic IDs (TA####), not names.
-• ✅ Correct: tactic:'TA0001'
-• ❌ Wrong: tactic:'Execution'
+=== MITRE ATT&CK MAPPING ===
+The mitre_attack field uses ATT&CK tactic IDs (TA####) and technique IDs (T####).
+Filter on nested fields:
+• ✅ Correct: mitre_attack.tactic_id:'TA0001'
+• ❌ Wrong: mitre_attack.tactic_id:'Execution'
 
 Common tactic IDs:
 • TA0001: Initial Access
@@ -191,7 +192,7 @@ Common tactic IDs:
 status:'active'+severity:>=70
 
 # Published rules covering a MITRE tactic
-state:'published'+tactic:'TA0001'
+state:'published'+mitre_attack.tactic_id:'TA0001'
 
 # Recently updated published rules
 state:'published'+last_updated_on:>'2025-01-01'
@@ -203,10 +204,10 @@ name:~'PowerShell'
 status:'active'+severity:>=90
 
 # Rules for a specific technique
-technique:'T1059'
+mitre_attack.technique_id:'T1059'
 
 # Active rules covering lateral movement or credential access
-status:'active'+(tactic:'TA0008',tactic:'TA0006')
+status:'active'+(mitre_attack.tactic_id:'TA0008',mitre_attack.tactic_id:'TA0006')
 
 # High-severity active rules updated recently
 status:'active'+severity:>=70+last_updated_on:>'2025-01-01'

--- a/tests/integration/test_correlation_rules.py
+++ b/tests/integration/test_correlation_rules.py
@@ -1,5 +1,6 @@
 """Integration tests for the Correlation Rules module."""
 
+import time
 import warnings
 
 import pytest
@@ -253,7 +254,8 @@ class TestCorrelationRulesIntegration(BaseIntegrationTest):
             f"Expected rule_id '{rule_id}', got '{updated.get('rule_id')}'"
         )
 
-        # Restore original description — warn if cleanup fails
+        # Restore original description — wait for version transition to settle
+        time.sleep(3)
         restore_result = self.call_method(
             self.module.update_correlation_rule,
             rule_id=rule_id,

--- a/tests/modules/test_correlation_rules.py
+++ b/tests/modules/test_correlation_rules.py
@@ -132,10 +132,10 @@ class TestCorrelationRulesModule(TestModules):
             ]},
         }
 
-        self.module.search_correlation_rules(filter="tactic:'TA0001'")
+        self.module.search_correlation_rules(filter="mitre_attack.tactic_id:'TA0001'")
 
         call_args = self.mock_client.command.call_args
-        self.assertEqual(call_args[1]["parameters"]["filter"], "tactic:'TA0001'")
+        self.assertEqual(call_args[1]["parameters"]["filter"], "mitre_attack.tactic_id:'TA0001'")
 
     def test_search_empty_results_returns_fql_guide(self):
         """Test that empty resources return a dict with fql_guide key."""
@@ -189,6 +189,7 @@ class TestCorrelationRulesModule(TestModules):
             schedule="@every 1h0m",
             status="active",
             trigger_mode="summary",
+            use_ingest_time=False,
         )
 
         call_args = self.mock_client.command.call_args
@@ -203,15 +204,14 @@ class TestCorrelationRulesModule(TestModules):
         self.assertEqual(body["search"]["outcome"], "detection")
         self.assertEqual(body["search"]["lookback"], "1h0m")
         self.assertEqual(body["search"]["trigger_mode"], "summary")
-        self.assertNotIn("execution_mode", body["search"])
-        self.assertNotIn("use_ingest_time", body["search"])
+        self.assertEqual(body["search"]["use_ingest_time"], False)
         self.assertEqual(body["operation"]["schedule"]["definition"], "@every 1h0m")
 
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
 
     def test_create_with_optional_params(self):
-        """Test that description, tactic, technique, and comment appear in the body."""
+        """Test that description, mitre_attack, and comment appear in the body."""
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {"resources": [{"id": "v1", "rule_id": "r1", "name": "Rule"}]},
@@ -223,19 +223,20 @@ class TestCorrelationRulesModule(TestModules):
             search_filter="#event=ProcessRollup2",
             severity=50,
             description="Detects suspicious activity",
-            tactic="TA0001",
-            technique="T1059",
+            mitre_attack=[{"tactic_id": "TA0001", "technique_id": "T1059"}],
             comment="Creating for audit trail",
         )
 
         body = self.mock_client.command.call_args[1]["body"]
         self.assertEqual(body["description"], "Detects suspicious activity")
-        self.assertEqual(body["tactic"], "TA0001")
-        self.assertEqual(body["technique"], "T1059")
+        self.assertEqual(
+            body["mitre_attack"],
+            [{"tactic_id": "TA0001", "technique_id": "T1059"}],
+        )
         self.assertEqual(body["comment"], "Creating for audit trail")
 
     def test_create_custom_defaults(self):
-        """Test overriding search_outcome, lookback, schedule, status, and trigger_mode."""
+        """Test overriding search_outcome, lookback, schedule, status, trigger_mode, and use_ingest_time."""
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {"resources": [{"id": "v1", "rule_id": "r1", "name": "Rule"}]},
@@ -250,14 +251,16 @@ class TestCorrelationRulesModule(TestModules):
             lookback="24h0m",
             schedule="@every 24h0m",
             status="inactive",
-            trigger_mode="per_event",
+            trigger_mode="verbose",
+            use_ingest_time=True,
         )
 
         body = self.mock_client.command.call_args[1]["body"]
         self.assertEqual(body["status"], "inactive")
         self.assertEqual(body["search"]["outcome"], "case")
         self.assertEqual(body["search"]["lookback"], "24h0m")
-        self.assertEqual(body["search"]["trigger_mode"], "per_event")
+        self.assertEqual(body["search"]["trigger_mode"], "verbose")
+        self.assertEqual(body["search"]["use_ingest_time"], True)
         self.assertEqual(body["operation"]["schedule"]["definition"], "@every 24h0m")
 
     def test_create_error_returns_error_list(self):
@@ -323,8 +326,8 @@ class TestCorrelationRulesModule(TestModules):
             search_filter=None,
             lookback=None,
             trigger_mode=None,
-            tactic=None,
-            technique=None,
+            use_ingest_time=None,
+            mitre_attack=None,
             comment=None,
         )
 
@@ -336,7 +339,7 @@ class TestCorrelationRulesModule(TestModules):
         self.assertNotIn("status", body)
 
     def test_update_search_fields_nested(self):
-        """Test that search_filter, lookback, and trigger_mode go into body['search']."""
+        """Test that search_filter, lookback, trigger_mode, and use_ingest_time go into body['search']."""
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {"resources": [{"id": "v2", "rule_id": "r1"}]},
@@ -346,14 +349,16 @@ class TestCorrelationRulesModule(TestModules):
             rule_id="r1",
             search_filter="#event=NetworkConnect",
             lookback="24h0m",
-            trigger_mode="per_event",
+            trigger_mode="verbose",
+            use_ingest_time=True,
         )
 
         body = self.mock_client.command.call_args[1]["body"][0]
         self.assertIn("search", body)
         self.assertEqual(body["search"]["filter"], "#event=NetworkConnect")
         self.assertEqual(body["search"]["lookback"], "24h0m")
-        self.assertEqual(body["search"]["trigger_mode"], "per_event")
+        self.assertEqual(body["search"]["trigger_mode"], "verbose")
+        self.assertEqual(body["search"]["use_ingest_time"], True)
 
     def test_update_error_returns_error_list(self):
         """Test that an update API error is returned wrapped in a list."""


### PR DESCRIPTION
Fixes three API mismatches in the correlation rules module, all validated against the live API:

- Swapped the separate `tactic`/`technique` string params for a `mitre_attack` array (`[{tactic_id, technique_id}]`). Both formats work on write but `mitre_attack` is what the API returns and what we should be using going forward.
- `trigger_mode` — `per_event` straight up 400s. The valid values are `summary` and `verbose`.
- Added `use_ingest_time` bool to the search block. The API accepts it on create and persists it correctly.

The delete endpoint's `ids` param was also validated against the live API and confirmed working correctly as-is.