### PR TITLE
feat(client): add proxy configuration for outbound Falcon API connections

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -56,6 +56,11 @@ FALCON_BASE_URL=https://api.us-2.crowdstrike.com
 # Only applies to sse and streamable-http transports
 #FALCON_MCP_API_KEY=
 
+# HTTP/HTTPS proxy URL for outbound Falcon API connections
+# Use this in enterprise or restricted network environments
+# Example: http://proxy.corp.example.com:8080
+#FALCON_PROXY_URL=
+
 # =============================================================================
 # Development & E2E Testing Configuration
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,12 @@ FALCON_BASE_URL=https://api.us-2.crowdstrike.com
 # Only applies to sse and streamable-http transports
 #FALCON_MCP_API_KEY=
 
+# =============================================================================
+# Optional: Proxy Configuration
+# =============================================================================
+# HTTP/HTTPS proxy URL for outbound Falcon API connections
+# Use this in enterprise or restricted network environments that require
+# traffic to be routed through a corporate proxy
+# Example: http://proxy.corp.example.com:8080
+#FALCON_PROXY_URL=
+

--- a/docs-site/src/content/docs/getting-started/configuration.md
+++ b/docs-site/src/content/docs/getting-started/configuration.md
@@ -27,6 +27,7 @@ Configure your CrowdStrike API credentials and server settings using environment
 | `FALCON_MCP_PORT` | `8000` | Port for HTTP transports |
 | `FALCON_MCP_STATELESS_HTTP` | `false` | Stateless mode for scalable deployments (required for AWS AgentCore) |
 | `FALCON_MCP_API_KEY` | — | API key for HTTP transport authentication |
+| `FALCON_PROXY_URL` | — | HTTP/HTTPS proxy URL for outbound API connections |
 
 ## Using a .env File
 
@@ -61,6 +62,7 @@ FALCON_BASE_URL=https://api.crowdstrike.com
 #FALCON_MCP_PORT=8000
 #FALCON_MCP_STATELESS_HTTP=false
 #FALCON_MCP_API_KEY=your-api-key
+#FALCON_PROXY_URL=http://proxy.corp.example.com:8080
 ```
 
 ## Module Selection

--- a/docs-site/src/content/docs/usage/cli.md
+++ b/docs-site/src/content/docs/usage/cli.md
@@ -73,6 +73,7 @@ falcon-mcp --help
 | `--api-key` | `FALCON_MCP_API_KEY` | — | API key for HTTP transport auth |
 | `--stateless-http` | `FALCON_MCP_STATELESS_HTTP` | `false` | Stateless mode for scalable deployments |
 | `--member-cid` | `FALCON_MEMBER_CID` | — | Flight Control child CID |
+| `--proxy` | `FALCON_PROXY_URL` | — | HTTP/HTTPS proxy for outbound API connections |
 
 ## Using as a Library
 
@@ -102,7 +103,8 @@ server = FalconMCPServer(
     client_id="your-client-id",
     client_secret="your-client-secret",
     base_url="https://api.us-2.crowdstrike.com",
-    enabled_modules=["detections", "hosts"]
+    enabled_modules=["detections", "hosts"],
+    proxy="http://proxy.corp.example.com:8080",
 )
 server.run()
 ```

--- a/falcon_mcp/client.py
+++ b/falcon_mcp/client.py
@@ -29,6 +29,7 @@ class FalconClient:
         client_id: str | None = None,
         client_secret: str | None = None,
         member_cid: str | None = None,
+        proxy: str | None = None,
     ):
         """Initialize the Falcon client.
 
@@ -39,6 +40,8 @@ class FalconClient:
             client_id: Falcon API Client ID (defaults to FALCON_CLIENT_ID env var)
             client_secret: Falcon API Client Secret (defaults to FALCON_CLIENT_SECRET env var)
             member_cid: Child CID for Flight Control (MSSP) support (defaults to FALCON_MEMBER_CID env var)
+            proxy: HTTP/HTTPS proxy URL for outbound Falcon API connections (defaults to FALCON_PROXY_URL env var).
+                   Example: "http://proxy.corp.example.com:8080"
         """
         # Get credentials from parameters or environment variables (parameters take precedence)
         self.client_id = client_id or os.environ.get("FALCON_CLIENT_ID")
@@ -51,6 +54,7 @@ class FalconClient:
             "FALCON_MCP_USER_AGENT_COMMENT"
         )
         self.member_cid = member_cid or os.environ.get("FALCON_MEMBER_CID")
+        self.proxy = proxy or os.environ.get("FALCON_PROXY_URL")
 
         if not self.client_id or not self.client_secret:
             raise ValueError(
@@ -70,6 +74,10 @@ class FalconClient:
         # Only include member_cid if it's provided
         if self.member_cid:
             api_params["member_cid"] = self.member_cid
+
+        # Only include proxy if configured; APIHarnessV2 expects {"https": url}
+        if self.proxy:
+            api_params["proxy"] = {"https": self.proxy}
 
         # Initialize the Falcon API client using APIHarnessV2
         self.client = APIHarnessV2(**api_params)

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -47,6 +47,7 @@ class FalconMCPServer:
         host: str = "127.0.0.1",
         port: int = 8000,
         member_cid: str | None = None,
+        proxy: str | None = None,
     ):
         """Initialize the Falcon MCP server.
 
@@ -62,6 +63,7 @@ class FalconMCPServer:
             host: Host to bind to for HTTP transports (default: 127.0.0.1)
             port: Port to listen on for HTTP transports (default: 8000)
             member_cid: Child CID for Flight Control (MSSP) support (defaults to FALCON_MEMBER_CID env var)
+            proxy: HTTP/HTTPS proxy URL for outbound Falcon API connections (defaults to FALCON_PROXY_URL env var)
         """
         # Store configuration
         self.base_url = base_url
@@ -86,6 +88,7 @@ class FalconMCPServer:
             client_id=client_id,
             client_secret=client_secret,
             member_cid=member_cid,
+            proxy=proxy,
         )
 
         # Authenticate with the Falcon API
@@ -374,6 +377,14 @@ def parse_args() -> argparse.Namespace:
         help="Child CID for Flight Control (MSSP) support (env: FALCON_MEMBER_CID)",
     )
 
+    # Proxy configuration
+    parser.add_argument(
+        "--proxy",
+        default=os.environ.get("FALCON_PROXY_URL"),
+        help="HTTP/HTTPS proxy URL for outbound Falcon API connections (env: FALCON_PROXY_URL). "
+        "Example: http://proxy.corp.example.com:8080",
+    )
+
     return parser.parse_args()
 
 
@@ -397,6 +408,7 @@ def main() -> None:
             host=args.host,
             port=args.port,
             member_cid=args.member_cid,
+            proxy=args.proxy,
         )
         logger.info("Starting server with %s transport", args.transport)
         server.run(args.transport)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -400,6 +400,72 @@ class TestFalconClient(unittest.TestCase):
 
     @patch("falcon_mcp.client.os.environ.get")
     @patch("falcon_mcp.client.APIHarnessV2")
+    def test_client_initialization_with_proxy(self, mock_apiharness, mock_environ_get):
+        """Test that proxy parameter is forwarded to APIHarnessV2."""
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+        }.get(key, default)
+        mock_apiharness.return_value = MagicMock()
+
+        _client = FalconClient(proxy="http://proxy.corp.example.com:8080")
+
+        mock_apiharness.assert_called_once()
+        call_args = mock_apiharness.call_args[1]
+        self.assertEqual(call_args["proxy"], {"https": "http://proxy.corp.example.com:8080"})
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_client_proxy_from_env_var(self, mock_apiharness, mock_environ_get):
+        """Test that FALCON_PROXY_URL env var is used when no proxy param is passed."""
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+            "FALCON_PROXY_URL": "http://proxy.env.example.com:3128",
+        }.get(key, default)
+        mock_apiharness.return_value = MagicMock()
+
+        _client = FalconClient()
+
+        mock_apiharness.assert_called_once()
+        call_args = mock_apiharness.call_args[1]
+        self.assertEqual(call_args["proxy"], {"https": "http://proxy.env.example.com:3128"})
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_client_proxy_param_overrides_env_var(self, mock_apiharness, mock_environ_get):
+        """Test that explicit proxy param takes precedence over FALCON_PROXY_URL env var."""
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+            "FALCON_PROXY_URL": "http://proxy.env.example.com:3128",
+        }.get(key, default)
+        mock_apiharness.return_value = MagicMock()
+
+        _client = FalconClient(proxy="http://proxy.param.example.com:8080")
+
+        mock_apiharness.assert_called_once()
+        call_args = mock_apiharness.call_args[1]
+        self.assertEqual(call_args["proxy"], {"https": "http://proxy.param.example.com:8080"})
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_client_initialization_without_proxy(self, mock_apiharness, mock_environ_get):
+        """Test that proxy key is absent from APIHarnessV2 call when no proxy is configured."""
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "test-client-id",
+            "FALCON_CLIENT_SECRET": "test-client-secret",
+        }.get(key, default)
+        mock_apiharness.return_value = MagicMock()
+
+        _client = FalconClient()
+
+        mock_apiharness.assert_called_once()
+        call_args = mock_apiharness.call_args[1]
+        self.assertNotIn("proxy", call_args)
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
     def test_auth_failure_message_401(self, mock_apiharness, mock_environ_get):
         """Test auth failure message for invalid credentials (HTTP 401)."""
         mock_environ_get.side_effect = lambda key, default=None: {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -488,6 +488,36 @@ class TestFalconMCPServer(unittest.TestCase):
         self.assertIsNone(call_args["member_cid"])
 
 
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.FastMCP")
+    def test_server_initialization_with_proxy(self, mock_fastmcp, mock_client):
+        """Test server initialization with proxy parameter is forwarded to FalconClient."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.authenticate.return_value = True
+        mock_client.return_value = mock_client_instance
+        mock_fastmcp.return_value = MagicMock()
+
+        _server = FalconMCPServer(proxy="http://proxy.corp.example.com:8080")
+
+        mock_client.assert_called_once()
+        call_args = mock_client.call_args[1]
+        self.assertEqual(call_args["proxy"], "http://proxy.corp.example.com:8080")
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.FastMCP")
+    def test_server_initialization_without_proxy(self, mock_fastmcp, mock_client):
+        """Test server initialization without proxy passes None to FalconClient."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.authenticate.return_value = True
+        mock_client.return_value = mock_client_instance
+        mock_fastmcp.return_value = MagicMock()
+
+        _server = FalconMCPServer()
+
+        mock_client.assert_called_once()
+        call_args = mock_client.call_args[1]
+        self.assertIsNone(call_args["proxy"])
+
     @patch("falcon_mcp.server.get_version", return_value="1.2.3")
     def test_version_flag(self, _mock_version):
         """Test --version flag prints version and exits."""


### PR DESCRIPTION
Adds a `--proxy` CLI flag (and `FALCON_PROXY_URL` env var) for routing Falcon API traffic through a corporate proxy. The URL gets converted to the `{"https": url}` dict that FalconPy expects — all CrowdStrike endpoints are HTTPS so a single URL covers it.

Also updated the config guide, CLI docs, and both `.env` example files so people can actually find it.

Closes #405