### PR TITLE
chore: remove docs-site from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,17 +33,6 @@ updates:
       - "dependencies"
       - "github-actions"
 
-  # Docs site npm dependencies (pnpm lockfile)
-  - package-ecosystem: "npm"
-    directory: "/docs-site"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "deps(docs):"
-    labels:
-      - "dependencies"
-      - "docs"
-
   # Docker configuration
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
The docs site is moving to a separate repository, so the npm/docs-site dependabot entry is no longer needed. This prevents new PRs from being opened for deps that won't be managed here going forward.

Also closed PRs #394 and #374 which were already open for this ecosystem.