### PR TITLE
feat(modules/rtr-admin): add RTR admin module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Full docs are available at **[crowdstrike.github.io/falcon-mcp](https://crowdstr
 | [NGSIEM](https://crowdstrike.github.io/falcon-mcp/modules/ngsiem/) | Execute CQL queries against Next-Gen SIEM |
 | [Quarantine](https://crowdstrike.github.io/falcon-mcp/modules/quarantine/) | Search quarantine records, preview action counts, and release, unrelease, or delete quarantined files |
 | [Real Time Response](https://crowdstrike.github.io/falcon-mcp/modules/rtr/) | Audit, summarize, and run read-only RTR triage workflows |
+| [Real Time Response Admin](https://crowdstrike.github.io/falcon-mcp/modules/rtr-admin/) | Inspect RTR Admin assets, classify command risk, preview payloads, and execute approved admin workflows |
 | [Scheduled Reports](https://crowdstrike.github.io/falcon-mcp/modules/scheduled-reports/) | Manage scheduled reports and download report files |
 | [Sensor Usage](https://crowdstrike.github.io/falcon-mcp/modules/sensor-usage/) | Access and analyze sensor usage data |
 | [Serverless](https://crowdstrike.github.io/falcon-mcp/modules/serverless/) | Search for vulnerabilities in serverless functions |

--- a/docs-site/src/content/docs/modules/cloud.md
+++ b/docs-site/src/content/docs/modules/cloud.md
@@ -2,7 +2,7 @@
 title: Cloud Security
 description: Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets
 sidebar:
-  order: 10
+  order: 11
 ---
 
 Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Containers Inventory, Images Vulnerabilities, Cloud Assets

--- a/docs-site/src/content/docs/modules/correlationrules.md
+++ b/docs-site/src/content/docs/modules/correlationrules.md
@@ -2,7 +2,7 @@
 title: Correlation Rules
 description: Correlation Rules module for CrowdStrike Falcon.
 sidebar:
-  order: 10
+  order: 12
 ---
 
 Correlation Rules module for CrowdStrike Falcon.

--- a/docs-site/src/content/docs/modules/custom-ioa.md
+++ b/docs-site/src/content/docs/modules/custom-ioa.md
@@ -2,7 +2,7 @@
 title: Custom IOA
 description: Searching, creating, updating, and deleting Custom IOA (Indicators of Attack) behavioral rules and rule groups using Falcon Custom IOA Service Collection endpoints
 sidebar:
-  order: 10
+  order: 13
 ---
 
 Searching, creating, updating, and deleting Custom IOA (Indicators of Attack) behavioral rules and rule groups using Falcon Custom IOA Service Collection endpoints

--- a/docs-site/src/content/docs/modules/data-protection.md
+++ b/docs-site/src/content/docs/modules/data-protection.md
@@ -2,7 +2,7 @@
 title: Data Protection
 description: Provides read-only access to Data Protection configuration data — classifications, policies, and content patterns — so an LLM can reason about why a Data Protection detection fired
 sidebar:
-  order: 10
+  order: 14
 ---
 
 Provides read-only access to Data Protection configuration data — classifications, policies, and content patterns — so an LLM can reason about why a Data Protection detection fired

--- a/docs-site/src/content/docs/modules/detections.md
+++ b/docs-site/src/content/docs/modules/detections.md
@@ -2,7 +2,7 @@
 title: Detections
 description: Accessing and analyzing CrowdStrike Falcon detections
 sidebar:
-  order: 10
+  order: 15
 ---
 
 Accessing and analyzing CrowdStrike Falcon detections

--- a/docs-site/src/content/docs/modules/discover.md
+++ b/docs-site/src/content/docs/modules/discover.md
@@ -2,7 +2,7 @@
 title: Discover
 description: Accessing and managing CrowdStrike Falcon Discover applications and unmanaged assets
 sidebar:
-  order: 10
+  order: 16
 ---
 
 Accessing and managing CrowdStrike Falcon Discover applications and unmanaged assets

--- a/docs-site/src/content/docs/modules/firewall.md
+++ b/docs-site/src/content/docs/modules/firewall.md
@@ -2,7 +2,7 @@
 title: Firewall Management
 description: Searching and managing firewall rules and rule groups
 sidebar:
-  order: 10
+  order: 17
 ---
 
 Searching and managing firewall rules and rule groups

--- a/docs-site/src/content/docs/modules/hosts.md
+++ b/docs-site/src/content/docs/modules/hosts.md
@@ -2,7 +2,7 @@
 title: Hosts
 description: Accessing and managing CrowdStrike Falcon hosts/devices
 sidebar:
-  order: 10
+  order: 18
 ---
 
 Accessing and managing CrowdStrike Falcon hosts/devices

--- a/docs-site/src/content/docs/modules/idp.md
+++ b/docs-site/src/content/docs/modules/idp.md
@@ -2,7 +2,7 @@
 title: Identity Protection
 description: Accessing and managing CrowdStrike Falcon Identity Protection capabilities
 sidebar:
-  order: 10
+  order: 19
 ---
 
 Accessing and managing CrowdStrike Falcon Identity Protection capabilities

--- a/docs-site/src/content/docs/modules/intel.md
+++ b/docs-site/src/content/docs/modules/intel.md
@@ -2,7 +2,7 @@
 title: Intel
 description: Accessing and analyzing CrowdStrike Falcon intelligence data
 sidebar:
-  order: 10
+  order: 20
 ---
 
 Accessing and analyzing CrowdStrike Falcon intelligence data
@@ -23,7 +23,7 @@ Generate a MITRE ATT&CK report for a given threat actor.
 
 Accepts an actor name (e.g., 'WARP PANDA') or numeric ID. Returns MITRE ATT&CK
 tactics, techniques, and procedures (TTPs) for the actor. JSON format returns a
-decoded string; CSV format returns CSV text.
+parsed list of dicts; CSV format returns raw CSV text.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/ioc.md
+++ b/docs-site/src/content/docs/modules/ioc.md
@@ -2,7 +2,7 @@
 title: IOC
 description: Searching, creating, and deleting custom IOCs using Falcon IOC Service Collection endpoints
 sidebar:
-  order: 10
+  order: 21
 ---
 
 Searching, creating, and deleting custom IOCs using Falcon IOC Service Collection endpoints

--- a/docs-site/src/content/docs/modules/ngsiem.md
+++ b/docs-site/src/content/docs/modules/ngsiem.md
@@ -2,7 +2,7 @@
 title: NGSIEM
 description: Running search queries against CrowdStrike's Next-Gen SIEM via the asynchronous job-based search API
 sidebar:
-  order: 10
+  order: 22
 ---
 
 Running search queries against CrowdStrike's Next-Gen SIEM via the asynchronous job-based search API

--- a/docs-site/src/content/docs/modules/overview.md
+++ b/docs-site/src/content/docs/modules/overview.md
@@ -23,7 +23,7 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 | [IOC](/falcon-mcp/modules/ioc/) | `IOC Management:read`, `IOC Management:write` | Searching, creating, and deleting custom IOCs using Falcon IOC Service Collection endpoints |
 | [NGSIEM](/falcon-mcp/modules/ngsiem/) | `NGSIEM:read`, `NGSIEM:write` | Running search queries against CrowdStrike's Next-Gen SIEM via the asynchronous job-based search API |
 | [Quarantine](/falcon-mcp/modules/quarantine/) | `Quarantined Files:read`, `Quarantined Files:write` | Investigating quarantined files and applying quarantine actions during triage and remediation workflows |
-| [Real Time Response](/falcon-mcp/modules/rtr/) | `Real time response:read`, `real-time-response-audit:read`, `Real time response:write` | Initiating and inspecting RTR sessions and for executing read-only RTR commands during host investigations |
+| [Real Time Response](/falcon-mcp/modules/rtr/) | `Real time response:read`, `real-time-response-audit:read`, `Real time response:write` | Initiating and inspecting RTR sessions and executing read-only RTR commands during host investigations |
 | [Real Time Response Admin](/falcon-mcp/modules/rtr-admin/) | `Real time response (admin):write` | Inspect RTR Admin assets, classify command risk, preview payloads, and execute approved single-host admin workflows. |
 | [Scheduled Reports](/falcon-mcp/modules/scheduled-reports/) | `Scheduled Reports:read` | Accessing and managing CrowdStrike Falcon scheduled reports and scheduled searches |
 | [Sensor Usage](/falcon-mcp/modules/sensor-usage/) | `Sensor Usage:read` | Accessing CrowdStrike Falcon sensor usage data |

--- a/docs-site/src/content/docs/modules/overview.md
+++ b/docs-site/src/content/docs/modules/overview.md
@@ -24,6 +24,7 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 | [NGSIEM](/falcon-mcp/modules/ngsiem/) | `NGSIEM:read`, `NGSIEM:write` | Running search queries against CrowdStrike's Next-Gen SIEM via the asynchronous job-based search API |
 | [Quarantine](/falcon-mcp/modules/quarantine/) | `Quarantined Files:read`, `Quarantined Files:write` | Investigating quarantined files and applying quarantine actions during triage and remediation workflows |
 | [Real Time Response](/falcon-mcp/modules/rtr/) | `Real time response:read`, `real-time-response-audit:read`, `Real time response:write` | Initiating and inspecting RTR sessions and for executing read-only RTR commands during host investigations |
+| [Real Time Response Admin](/falcon-mcp/modules/rtr-admin/) | `Real time response (admin):write` | Inspect RTR Admin assets, classify command risk, preview payloads, and execute approved single-host admin workflows. |
 | [Scheduled Reports](/falcon-mcp/modules/scheduled-reports/) | `Scheduled Reports:read` | Accessing and managing CrowdStrike Falcon scheduled reports and scheduled searches |
 | [Sensor Usage](/falcon-mcp/modules/sensor-usage/) | `Sensor Usage:read` | Accessing CrowdStrike Falcon sensor usage data |
 | [Serverless](/falcon-mcp/modules/serverless/) | `Falcon Container Image:read` | Accessing and managing CrowdStrike Falcon Serverless Vulnerabilities |

--- a/docs-site/src/content/docs/modules/quarantine.md
+++ b/docs-site/src/content/docs/modules/quarantine.md
@@ -2,7 +2,7 @@
 title: Quarantine
 description: Investigating quarantined files and applying quarantine actions during triage and remediation workflows
 sidebar:
-  order: 10
+  order: 23
 ---
 
 Investigating quarantined files and applying quarantine actions during triage and remediation workflows

--- a/docs-site/src/content/docs/modules/rtr-admin.md
+++ b/docs-site/src/content/docs/modules/rtr-admin.md
@@ -69,7 +69,9 @@ falcon_search_rtr_put_files. This is a read-only Falcon call, but the
 returned content can be sensitive because put-files may contain scripts,
 binaries, or operational payloads staged for RTR `put` workflows.
 Text content is returned for model review; binary content returns size
-metadata and a safe error instead of raw bytes.
+metadata and a safe error instead of raw bytes. Treat retrieval results
+as sensitive regardless of inventory `file_type`; live testing showed
+binary-tagged inventory can still retrieve text content.
 
 **Example prompts:**
 
@@ -115,10 +117,10 @@ falcon_check_rtr_admin_command_status with the returned cloud_request_id.
 Search RTR custom scripts and return full metadata records.
 
 Use this to find reusable custom RTR scripts by name, platform, or
-permission type, or to look up known script IDs with an `id` filter.
-Consult falcon://rtr-admin/scripts/search/fql-guide before constructing
-filter expressions. Returns full script records including name, content,
-platform, and permission details.
+permission type. Consult falcon://rtr-admin/scripts/search/fql-guide
+before constructing filter expressions. Returns full script records,
+including script content; treat the response as sensitive operational
+material.
 
 **Example prompts:**
 
@@ -135,8 +137,8 @@ Search CrowdStrike-provided Falcon scripts and return full records.
 Use this to find CrowdStrike-provided RTR scripts by name or platform,
 or to look up known script IDs with an `id` filter. Consult
 falcon://rtr-admin/falcon-scripts/search/fql-guide before constructing
-filter expressions. Returns full script records including name,
-description, and platform.
+filter expressions. Returns full script records; treat any returned
+script content as sensitive operational material.
 
 **Example prompts:**
 
@@ -150,10 +152,9 @@ description, and platform.
 Search RTR put-files and return full metadata records.
 
 Use this to review put-file inventory before considering an admin
-command that references staged content, or to look up known put-file IDs
-with an `id` filter. Consult falcon://rtr-admin/put-files/search/fql-guide
-before constructing filter expressions. Returns full put-file metadata
-records.
+command that references staged content. Consult
+falcon://rtr-admin/put-files/search/fql-guide before constructing
+filter expressions. Returns full put-file metadata records.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/rtr-admin.md
+++ b/docs-site/src/content/docs/modules/rtr-admin.md
@@ -1,0 +1,153 @@
+---
+title: Real Time Response Admin
+description: Inspect RTR Admin assets, classify command risk, preview payloads, and execute approved single-host admin workflows.
+sidebar:
+  order: 10
+---
+
+Inspect RTR Admin assets, classify command risk, preview payloads, and execute approved single-host admin workflows.
+
+## API Scopes
+
+- `Real time response (admin):write`
+
+## Tools
+
+### `falcon_check_rtr_admin_command_status`
+
+**Required scopes:** `Real time response (admin):write`
+
+Retrieve status and output for a prior RTR Admin command.
+
+This is a read-only status lookup. It cannot start a new command.
+
+**Example prompts:**
+
+- "Check the output for this RTR Admin cloud request ID"
+
+### `falcon_classify_rtr_admin_command`
+
+Classify an RTR Admin command without executing it.
+
+Use this before designing or approving any RTR Admin execution flow.
+This policy helper is intentionally local and does not call Falcon.
+
+**Example prompts:**
+
+- "Classify this RTR Admin command before I decide whether to run it"
+
+### `falcon_execute_rtr_admin_command`
+
+:::caution
+This tool performs destructive operations.
+:::
+
+**Required scopes:** `Real time response (admin):write`
+
+Execute an RTR Admin command on a single host.
+
+High-impact commands are blocked before the Falcon API call unless the
+exact operator approval phrase for this payload is supplied.
+
+**Example prompts:**
+
+- "Run this approved RTR Admin command against the existing RTR session"
+
+### `falcon_get_rtr_falcon_script_details`
+
+**Required scopes:** `Real time response (admin):write`
+
+Retrieve CrowdStrike-provided Falcon script metadata and content by ID.
+
+**Example prompts:**
+
+- "Show me the details for that Falcon script"
+
+### `falcon_get_rtr_put_file_details`
+
+**Required scopes:** `Real time response (admin):write`
+
+Retrieve RTR put-file metadata by ID.
+
+This tool intentionally returns metadata only. It does not expose
+put-file content retrieval in the first RTR Admin slice.
+
+**Example prompts:**
+
+- "Get metadata for this RTR put-file ID"
+
+### `falcon_get_rtr_admin_script_details`
+
+**Required scopes:** `Real time response (admin):write`
+
+Retrieve custom RTR script metadata and content by script ID.
+
+**Example prompts:**
+
+- "Pull the details for that RTR Admin script ID"
+
+### `falcon_preview_rtr_admin_command`
+
+**Required scopes:** `Real time response (admin):write`
+
+Preview an RTR Admin command payload without executing it.
+
+This tool returns the exact Falcon operation and body shape that a later
+execution tool would use, plus local policy classification. It never
+calls Falcon and cannot execute the command.
+
+**Example prompts:**
+
+- "Preview the exact RTR Admin payload for this command before running it"
+
+### `falcon_search_rtr_falcon_scripts`
+
+**Required scopes:** `Real time response (admin):write`
+
+Search CrowdStrike-provided Falcon scripts and return full records.
+
+Use this to find CrowdStrike-provided RTR scripts by name or platform.
+Consult falcon://rtr-admin/falcon-scripts/search/fql-guide before
+constructing filter expressions.
+
+**Example prompts:**
+
+- "Find CrowdStrike-provided Falcon scripts for Windows collection"
+
+### `falcon_search_rtr_put_files`
+
+**Required scopes:** `Real time response (admin):write`
+
+Search RTR put-files and return full metadata records.
+
+Use this to review put-file inventory before considering an admin
+command that references staged content. Consult
+falcon://rtr-admin/put-files/search/fql-guide before constructing
+filter expressions.
+
+**Example prompts:**
+
+- "Search RTR put-files with collector in the name"
+
+### `falcon_search_rtr_admin_scripts`
+
+**Required scopes:** `Real time response (admin):write`
+
+Search RTR custom scripts and return full metadata records.
+
+Use this to find reusable custom RTR scripts by name, platform, or
+permission type. Consult falcon://rtr-admin/scripts/search/fql-guide
+before constructing filter expressions.
+
+**Example prompts:**
+
+- "Find Windows RTR Admin scripts with triage in the name"
+- "Show me private custom RTR scripts I could review for this host"
+
+## Resources
+
+- **`falcon://rtr-admin/scripts/search/fql-guide`**: Contains the guide for the `filter` param of the custom RTR script search tool.
+- **`falcon://rtr-admin/falcon-scripts/search/fql-guide`**: Contains the guide for the `filter` param of the Falcon script search tool.
+- **`falcon://rtr-admin/put-files/search/fql-guide`**: Contains the guide for the `filter` param of the RTR put-file search tool.
+- **`falcon://rtr-admin/workflows/admin-guide`**: Contains RTR Admin inventory, preview, execution, and polling guidance.
+- **`falcon://rtr-admin/commands/runscript-guide`**: Contains RTR Admin runscript raw command construction guidance.

--- a/docs-site/src/content/docs/modules/rtr-admin.md
+++ b/docs-site/src/content/docs/modules/rtr-admin.md
@@ -70,8 +70,8 @@ returned content can be sensitive because put-files may contain scripts,
 binaries, or operational payloads staged for RTR `put` workflows.
 Text content is returned for model review; binary content returns size
 metadata and a safe error instead of raw bytes. Treat retrieval results
-as sensitive regardless of inventory `file_type`; live testing showed
-binary-tagged inventory can still retrieve text content.
+as sensitive regardless of inventory `file_type`; binary-tagged
+inventory can still retrieve text content.
 
 **Example prompts:**
 

--- a/docs-site/src/content/docs/modules/rtr-admin.md
+++ b/docs-site/src/content/docs/modules/rtr-admin.md
@@ -19,7 +19,9 @@ Inspect RTR Admin assets, classify command risk, preview payloads, and execute a
 
 Retrieve status and output for a prior RTR Admin command.
 
-This is a read-only status lookup. It cannot start a new command.
+Use this to poll for command completion after execution. This is a
+read-only status lookup that cannot start a new command. Returns
+completion status, stdout, stderr, and sequence information.
 
 **Example prompts:**
 
@@ -31,6 +33,7 @@ Classify an RTR Admin command without executing it.
 
 Use this before designing or approving any RTR Admin execution flow.
 This policy helper is intentionally local and does not call Falcon.
+Returns category, risk level, approval requirements, and explanation.
 
 **Example prompts:**
 
@@ -46,45 +49,14 @@ This tool performs destructive operations.
 
 Execute an RTR Admin command on a single host.
 
-High-impact commands are blocked before the Falcon API call unless the
-exact operator approval phrase for this payload is supplied.
+Use after previewing and classifying the command. High-impact commands
+are blocked unless the exact operator approval phrase is supplied.
+Returns submission status, cloud_request_id for polling, and
+classification enforcement details.
 
 **Example prompts:**
 
 - "Run this approved RTR Admin command against the existing RTR session"
-
-### `falcon_get_rtr_falcon_script_details`
-
-**Required scopes:** `Real time response (admin):write`
-
-Retrieve CrowdStrike-provided Falcon script metadata and content by ID.
-
-**Example prompts:**
-
-- "Show me the details for that Falcon script"
-
-### `falcon_get_rtr_put_file_details`
-
-**Required scopes:** `Real time response (admin):write`
-
-Retrieve RTR put-file metadata by ID.
-
-This tool intentionally returns metadata only. It does not expose
-put-file content retrieval in the first RTR Admin slice.
-
-**Example prompts:**
-
-- "Get metadata for this RTR put-file ID"
-
-### `falcon_get_rtr_admin_script_details`
-
-**Required scopes:** `Real time response (admin):write`
-
-Retrieve custom RTR script metadata and content by script ID.
-
-**Example prompts:**
-
-- "Pull the details for that RTR Admin script ID"
 
 ### `falcon_preview_rtr_admin_command`
 
@@ -100,15 +72,34 @@ calls Falcon and cannot execute the command.
 
 - "Preview the exact RTR Admin payload for this command before running it"
 
+### `falcon_search_rtr_admin_scripts`
+
+**Required scopes:** `Real time response (admin):write`
+
+Search RTR custom scripts and return full metadata records.
+
+Use this to find reusable custom RTR scripts by name, platform, or
+permission type, or to look up known script IDs with an `id` filter.
+Consult falcon://rtr-admin/scripts/search/fql-guide before constructing
+filter expressions. Returns full script records including name, content,
+platform, and permission details.
+
+**Example prompts:**
+
+- "Find Windows RTR Admin scripts with triage in the name"
+- "Show me private custom RTR scripts I could review for this host"
+
 ### `falcon_search_rtr_falcon_scripts`
 
 **Required scopes:** `Real time response (admin):write`
 
 Search CrowdStrike-provided Falcon scripts and return full records.
 
-Use this to find CrowdStrike-provided RTR scripts by name or platform.
-Consult falcon://rtr-admin/falcon-scripts/search/fql-guide before
-constructing filter expressions.
+Use this to find CrowdStrike-provided RTR scripts by name or platform,
+or to look up known script IDs with an `id` filter. Consult
+falcon://rtr-admin/falcon-scripts/search/fql-guide before constructing
+filter expressions. Returns full script records including name,
+description, and platform.
 
 **Example prompts:**
 
@@ -121,28 +112,14 @@ constructing filter expressions.
 Search RTR put-files and return full metadata records.
 
 Use this to review put-file inventory before considering an admin
-command that references staged content. Consult
-falcon://rtr-admin/put-files/search/fql-guide before constructing
-filter expressions.
+command that references staged content, or to look up known put-file IDs
+with an `id` filter. Consult falcon://rtr-admin/put-files/search/fql-guide
+before constructing filter expressions. Returns full put-file metadata
+records.
 
 **Example prompts:**
 
 - "Search RTR put-files with collector in the name"
-
-### `falcon_search_rtr_admin_scripts`
-
-**Required scopes:** `Real time response (admin):write`
-
-Search RTR custom scripts and return full metadata records.
-
-Use this to find reusable custom RTR scripts by name, platform, or
-permission type. Consult falcon://rtr-admin/scripts/search/fql-guide
-before constructing filter expressions.
-
-**Example prompts:**
-
-- "Find Windows RTR Admin scripts with triage in the name"
-- "Show me private custom RTR scripts I could review for this host"
 
 ## Resources
 

--- a/docs-site/src/content/docs/modules/rtr-admin.md
+++ b/docs-site/src/content/docs/modules/rtr-admin.md
@@ -2,7 +2,7 @@
 title: Real Time Response Admin
 description: Inspect RTR Admin assets, classify command risk, preview payloads, and execute approved single-host admin workflows.
 sidebar:
-  order: 10
+  order: 25
 ---
 
 Inspect RTR Admin assets, classify command risk, preview payloads, and execute approved single-host admin workflows.
@@ -58,6 +58,23 @@ classification enforcement details.
 
 - "Run this approved RTR Admin command against the existing RTR session"
 
+### `falcon_get_rtr_put_file_contents`
+
+**Required scopes:** `Real time response (admin):write`
+
+Retrieve the stored contents of one RTR put-file by ID.
+
+Use this only after selecting a specific put-file from
+falcon_search_rtr_put_files. This is a read-only Falcon call, but the
+returned content can be sensitive because put-files may contain scripts,
+binaries, or operational payloads staged for RTR `put` workflows.
+Text content is returned for model review; binary content returns size
+metadata and a safe error instead of raw bytes.
+
+**Example prompts:**
+
+- "Retrieve the contents for RTR put-file ID abc123"
+
 ### `falcon_preview_rtr_admin_command`
 
 **Required scopes:** `Real time response (admin):write`
@@ -71,6 +88,25 @@ calls Falcon and cannot execute the command.
 **Example prompts:**
 
 - "Preview the exact RTR Admin payload for this command before running it"
+
+### `falcon_run_rtr_admin_command_and_wait`
+
+:::caution
+This tool performs destructive operations.
+:::
+
+**Required scopes:** `Real time response (admin):write`
+
+Execute an RTR Admin command and poll until completion or timeout.
+
+This is a convenience workflow for single-host admin commands. It uses
+the same local classification and approval gate as
+falcon_execute_rtr_admin_command, then polls
+falcon_check_rtr_admin_command_status with the returned cloud_request_id.
+
+**Example prompts:**
+
+- "Run this approved RTR Admin command and wait for stdout and stderr"
 
 ### `falcon_search_rtr_admin_scripts`
 
@@ -88,6 +124,7 @@ platform, and permission details.
 
 - "Find Windows RTR Admin scripts with triage in the name"
 - "Show me private custom RTR scripts I could review for this host"
+- "Look up RTR Admin script ID abc123 with an id filter"
 
 ### `falcon_search_rtr_falcon_scripts`
 
@@ -104,6 +141,7 @@ description, and platform.
 **Example prompts:**
 
 - "Find CrowdStrike-provided Falcon scripts for Windows collection"
+- "Look up Falcon script ID abc123 with an id filter"
 
 ### `falcon_search_rtr_put_files`
 
@@ -120,6 +158,7 @@ records.
 **Example prompts:**
 
 - "Search RTR put-files with collector in the name"
+- "Look up RTR put-file ID abc123 with an id filter"
 
 ## Resources
 
@@ -128,3 +167,31 @@ records.
 - **`falcon://rtr-admin/put-files/search/fql-guide`**: Contains the guide for the `filter` param of the RTR put-file search tool.
 - **`falcon://rtr-admin/workflows/admin-guide`**: Contains RTR Admin inventory, preview, execution, and polling guidance.
 - **`falcon://rtr-admin/commands/runscript-guide`**: Contains RTR Admin runscript raw command construction guidance.
+- **`falcon://rtr-admin/policy/command-guide`**: Contains RTR Admin command classification policy and command categories.
+- **`falcon://rtr-admin/approval/packet-guide`**: Contains the approval packet template for high-impact RTR Admin commands.
+
+## Prompts
+
+### `falcon_plan_rtr_admin_action`
+
+**Title:** Plan RTR Admin Action
+
+Plan a safe RTR Admin workflow before using execution tools.
+
+### `falcon_build_rtr_admin_approval_packet`
+
+**Title:** Build RTR Admin Approval Packet
+
+Create an operator approval packet for a high-impact RTR Admin command.
+
+### `falcon_review_rtr_admin_runscript`
+
+**Title:** Review RTR Admin Runscript
+
+Review an RTR Admin runscript command string for safety and quoting risks.
+
+### `falcon_interpret_rtr_admin_status`
+
+**Title:** Interpret RTR Admin Status
+
+Interpret RTR Admin command status output and suggest next safe steps.

--- a/docs-site/src/content/docs/modules/rtr.md
+++ b/docs-site/src/content/docs/modules/rtr.md
@@ -1,11 +1,11 @@
 ---
 title: Real Time Response
-description: Initiating and inspecting RTR sessions and for executing read-only RTR commands during host investigations
+description: Initiating and inspecting RTR sessions and executing read-only RTR commands during host investigations
 sidebar:
-  order: 10
+  order: 24
 ---
 
-Initiating and inspecting RTR sessions and for executing read-only RTR commands during host investigations
+Initiating and inspecting RTR sessions and executing read-only RTR commands during host investigations
 
 ## API Scopes
 

--- a/docs-site/src/content/docs/modules/rtr.md
+++ b/docs-site/src/content/docs/modules/rtr.md
@@ -178,7 +178,7 @@ constructing filter expressions.
 **Example prompts:**
 
 - "Show me RTR audit activity from the last 7 days"
-- "Who used RTR against host BRR-WB-LIB-22?"
+- "Who used RTR against host EXAMPLE-WIN-22?"
 
 ### `falcon_search_rtr_sessions`
 

--- a/docs-site/src/content/docs/modules/scheduled-reports.md
+++ b/docs-site/src/content/docs/modules/scheduled-reports.md
@@ -2,7 +2,7 @@
 title: Scheduled Reports
 description: Accessing and managing CrowdStrike Falcon scheduled reports and scheduled searches
 sidebar:
-  order: 10
+  order: 26
 ---
 
 Accessing and managing CrowdStrike Falcon scheduled reports and scheduled searches

--- a/docs-site/src/content/docs/modules/sensor-usage.md
+++ b/docs-site/src/content/docs/modules/sensor-usage.md
@@ -2,7 +2,7 @@
 title: Sensor Usage
 description: Accessing CrowdStrike Falcon sensor usage data
 sidebar:
-  order: 10
+  order: 27
 ---
 
 Accessing CrowdStrike Falcon sensor usage data

--- a/docs-site/src/content/docs/modules/serverless.md
+++ b/docs-site/src/content/docs/modules/serverless.md
@@ -2,7 +2,7 @@
 title: Serverless
 description: Accessing and managing CrowdStrike Falcon Serverless Vulnerabilities
 sidebar:
-  order: 10
+  order: 28
 ---
 
 Accessing and managing CrowdStrike Falcon Serverless Vulnerabilities

--- a/docs-site/src/content/docs/modules/shield.md
+++ b/docs-site/src/content/docs/modules/shield.md
@@ -2,7 +2,7 @@
 title: Shield
 description: Shield module for CrowdStrike Falcon.
 sidebar:
-  order: 10
+  order: 29
 ---
 
 Shield module for CrowdStrike Falcon.

--- a/docs-site/src/content/docs/modules/spotlight.md
+++ b/docs-site/src/content/docs/modules/spotlight.md
@@ -2,7 +2,7 @@
 title: Spotlight
 description: Accessing and managing CrowdStrike Falcon Spotlight vulnerabilities
 sidebar:
-  order: 10
+  order: 30
 ---
 
 Accessing and managing CrowdStrike Falcon Spotlight vulnerabilities

--- a/docs/development/rtr-admin-hardening-findings.md
+++ b/docs/development/rtr-admin-hardening-findings.md
@@ -1,0 +1,151 @@
+# RTR Admin Hardening Findings
+
+This sidecar captures planning lessons and follow-up findings from the RTR Admin
+module hardening pass. It is intentionally separate from generated module docs
+and from private agent metadata.
+
+## Module Planning Lessons from PR #410
+
+Use this note before planning new Falcon MCP modules or expanding sensitive
+module surfaces.
+
+### Start with the Codebase Shape
+
+Before drafting tools from FalconPy operations, inspect nearby modules and mirror
+the local grammar:
+
+- `register_tools()` method names should match registered tool names.
+- Search tools should generally return full records, not raw IDs.
+- FQL guidance should live in resource guides when it is more than a short field
+  description.
+- Docs, generated module metadata, API scope mappings, registry support, unit
+  tests, and integration tests are part of the module slice.
+
+For RTR-style work, inspect `falcon_mcp/modules/rtr.py` and similar
+search/detail modules before adding new tools.
+
+### Treat Tool Count as API Design
+
+Do not add a separate MCP tool just because Falcon exposes a separate operation.
+Add a tool only when it gives the operator or model a distinct workflow.
+
+For query -> get APIs:
+
+- Prefer one `search_*` tool that queries IDs and returns full details.
+- If known IDs can be expressed through FQL, document `id:` filters instead of
+  adding redundant `get_*_details` tools.
+- Keep separate `get_*` tools only when they are established in comparable
+  modules or provide a meaningfully different input/output contract.
+
+PR #410 cleanup removed three redundant `get_*_details` tools because the same
+lookup could be handled by `id:` filters through search.
+
+### Plan from the Operator Workflow
+
+For sensitive or high-impact modules, plan the workflow before coding endpoints:
+
+1. Inventory or search the relevant assets.
+2. Classify the intended action locally when possible.
+3. Preview exact target, payload, risk, and approval requirements.
+4. Execute only the smallest safe first slice.
+5. Poll or retrieve status separately.
+
+Keep upload, update, delete, batch, and content-retrieval surfaces out of the
+first slice unless the requested workflow requires them.
+
+### Classify Risk Before Encoding Policy
+
+For command execution modules, enumerate the command set before implementation:
+
+- read-only commands
+- evidence collection commands
+- sensitive collection commands
+- high-impact or destructive commands
+- commands blocked until later review
+- unknown commands
+
+Approval hashes should key on stable execution material. Avoid including
+display-only or drift-prone fields, such as hostnames, if they can break an
+otherwise valid approval phrase.
+
+### Review Checklist
+
+Before opening or updating a module PR, verify:
+
+- Tool names, method names, docs, and tests use the same naming pattern.
+- Search tools return full details and use existing query -> get helpers.
+- Redundant get-by-ID tools were not added when FQL `id:` filters work.
+- The API scope map covers every Falcon operation used.
+- Resources describe FQL fields and examples without bloating tool parameter
+  descriptions.
+- Mutating or execution tools have explicit MCP annotations.
+- Execution tools verify `base_command` matches the first token of
+  `command_string`.
+- Workflow helpers such as `run_*_and_wait` must reuse the same execution policy
+  gate as the lower-level execution tool, then poll the documented status
+  operation. Do not let convenience helpers bypass approval or target review.
+- Treat content retrieval tools as sensitive even when they are read-only API
+  calls. Put-file contents may expose scripts, binaries, or operational payloads.
+- Cross-check command policy names against the FalconPy docs/source when editing
+  classifiers. For example, keep documented `unmount` behavior from falling into
+  the unknown bucket just because older notes used `umount`.
+- Spend CodeRabbit after edits and local validation settle. If full review hits
+  file-count or rate limits, run the smallest meaningful `--dir` scopes and
+  record any incomplete scope explicitly.
+- Tests cover registered tool count, API call shape, ID lookup behavior, local
+  validation, safety policy, and any approval phrase logic.
+- The PR summary states what was intentionally left out of the first slice.
+
+## Follow-Up Backlog from RTR Admin Hardening
+
+Captured 2026-06-02 during the RTR Admin module hardening pass. These were found
+while reviewing the branch, but were intentionally not fixed in the RTR Admin PR
+because they are pre-existing, out of scope, tooling-only, or already identified
+as false positives.
+
+### Existing Detections Resource Issues
+
+CodeRabbit flagged these during a scoped `falcon_mcp` review, but the files were
+not changed by the RTR Admin branch. Handle them in a separate detections/docs
+cleanup PR.
+
+- `falcon_mcp/resources/detections.py`: FQL examples mix `+` and `,` without
+  explicit grouping. Confirm Falcon FQL precedence and update examples such as
+  the name-based high/critical filters and product combinations so the intended
+  AND/OR behavior is unambiguous.
+- `falcon_mcp/resources/detections.py`: Critical severity guidance says
+  `severity:>=80`, but the "Unassigned critical alerts from last 24 hours"
+  numeric example uses `severity:>=90`. Decide whether the example means all
+  critical detections or only the highest critical band, then align the wording
+  and threshold.
+
+### Existing Test and Repo Health Warnings
+
+These warnings are not caused by RTR Admin directly, but they showed up in the
+full validation pass and should be reviewed when we do repo-health cleanup.
+
+- `tests/common/test_api_scopes.py::test_no_unused_scope_mappings` warns that
+  `entities_classification_get_v2`, `entities_content_pattern_get`, and
+  `entities_policy_get_v2` may be unused. Audit the scope-extraction test versus
+  `falcon_mcp/modules/data_protection.py` before removing anything; the
+  operations appear to be used by the Data Protection module.
+- `falcon_mcp/modules/idp.py` still uses `datetime.utcnow()` in timestamp
+  payloads. Replace with timezone-aware UTC values and update any tests or
+  expected output that assume naive timestamps.
+- `tests/test_tools_list_output_schema.py::test_tools_list_payload_within_budget`
+  warns that the full `tools/list` payload exceeds the 120,000 byte soft budget.
+  Review schema verbosity, default module selection, and client guidance before
+  hiding or relaxing the warning.
+
+### CodeRabbit and Review Tooling Notes
+
+- Full uncommitted CodeRabbit review failed because the branch diff was over
+  CodeRabbit's 150-file limit. Use focused `--dir` reviews, compare against a
+  closer base, or commit/split work before asking for a broad review.
+- Final scoped CodeRabbit reviews were run for `falcon_mcp`, `scripts`, `tests`,
+  and `docs-site/src/content/docs/modules`; each completed with 0 findings after
+  the hardening fixes.
+- CodeRabbit reported EOF-newline issues for `rtr.md` and `rtr-admin.md`, but a
+  byte-level check showed both files already ended with newline byte `10`. Treat
+  those specific findings as false positives unless they reappear after a fresh
+  regeneration.

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -90,6 +90,15 @@ API_SCOPE_REQUIREMENTS = {
     "RTR_ListFilesV2": ["Real time response:write"],
     "RTRAuditSessions": ["real-time-response-audit:read"],
     "RTR_AggregateSessions": ["Real time response:read"],
+    # Real Time Response Admin operations
+    "RTR_ListScripts": ["Real time response (admin):write"],
+    "RTR_GetScriptsV2": ["Real time response (admin):write"],
+    "RTR_ListFalconScripts": ["Real time response (admin):write"],
+    "RTR_GetFalconScripts": ["Real time response (admin):write"],
+    "RTR_ListPut_Files": ["Real time response (admin):write"],
+    "RTR_GetPut_FilesV2": ["Real time response (admin):write"],
+    "RTR_CheckAdminCommandStatus": ["Real time response (admin):write"],
+    "RTR_ExecuteAdminCommand": ["Real time response (admin):write"],
     # Quarantine operations
     "QueryQuarantineFiles": ["Quarantined Files:read"],
     "GetQuarantineFiles": ["Quarantined Files:read"],

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -97,6 +97,7 @@ API_SCOPE_REQUIREMENTS = {
     "RTR_GetFalconScripts": ["Real time response (admin):write"],
     "RTR_ListPut_Files": ["Real time response (admin):write"],
     "RTR_GetPut_FilesV2": ["Real time response (admin):write"],
+    "RTR_GetPutFileContents": ["Real time response (admin):write"],
     "RTR_CheckAdminCommandStatus": ["Real time response (admin):write"],
     "RTR_ExecuteAdminCommand": ["Real time response (admin):write"],
     # Quarantine operations

--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -9,6 +9,7 @@ from typing import Any, Callable
 
 from mcp import Resource
 from mcp.server import FastMCP
+from mcp.server.fastmcp.prompts import Prompt
 from mcp.types import ToolAnnotations
 
 from falcon_mcp.client import FalconClient
@@ -39,6 +40,7 @@ class BaseModule(ABC):
         self.client = client
         self.tools: list[str] = []  # List to track registered tools
         self.resources: list[str] = []  # List to track registered resources
+        self.prompts: list[str] = []  # List to track registered prompts
 
     @abstractmethod
     def register_tools(self, server: FastMCP) -> None:
@@ -50,6 +52,13 @@ class BaseModule(ABC):
 
     def register_resources(self, server: FastMCP) -> None:
         """Register resources with the MCP Server.
+
+        Args:
+            server: MCP server instance
+        """
+
+    def register_prompts(self, server: FastMCP) -> None:
+        """Register prompts with the MCP Server.
 
         Args:
             server: MCP server instance
@@ -93,6 +102,34 @@ class BaseModule(ABC):
         resource_uri = resource.uri
         self.resources.append(str(resource_uri))
         logger.debug("Added resource: %s", resource_uri)
+
+    def _add_prompt(
+        self,
+        server: FastMCP,
+        method: Callable[..., Any],
+        name: str,
+        title: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        """Add a prompt to the MCP server and track it.
+
+        Args:
+            server: MCP server instance
+            method: Method to register as a prompt template
+            name: Prompt name
+            title: Optional human-readable prompt title
+            description: Optional prompt description
+        """
+        prefixed_name = f"falcon_{name}"
+        prompt = Prompt.from_function(
+            method,
+            name=prefixed_name,
+            title=title,
+            description=description,
+        )
+        server.add_prompt(prompt)
+        self.prompts.append(prefixed_name)
+        logger.debug("Added prompt: %s", prefixed_name)
 
     def _base_get_by_ids(
         self,

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -194,7 +194,7 @@ class RTRModule(BaseModule):
         filter: str | None = Field(
             default=None,
             description="FQL filter expression. See `falcon://rtr/sessions/search/fql-guide` for syntax.",
-            examples=["hostname:'BRR-WB-LIB-22'", "aid:'2c5c4e7738...'"],
+            examples=["hostname:'EXAMPLE-WIN-22'", "aid:'2c5c4e7738...'"],
         ),
         limit: int = Field(
             default=10,
@@ -259,7 +259,7 @@ class RTRModule(BaseModule):
         filter: str | None = Field(
             default=None,
             description=AUDIT_RTR_SESSIONS_EMBEDDED_FQL_SYNTAX,
-            examples=["created_at:>'now-7d'", "hostname:'BRR-WB-LIB-22'+created_at:>'now-7d'"],
+            examples=["created_at:>'now-7d'", "hostname:'EXAMPLE-WIN-22'+created_at:>'now-7d'"],
         ),
         limit: int = Field(
             default=10,

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -1,7 +1,7 @@
 """
 Real Time Response module for Falcon MCP Server.
 
-This module provides tools for initiating and inspecting RTR sessions and for
+This module provides tools for initiating and inspecting RTR sessions and
 executing read-only RTR commands during host investigations.
 """
 

--- a/falcon_mcp/modules/rtr_admin.py
+++ b/falcon_mcp/modules/rtr_admin.py
@@ -598,8 +598,8 @@ class RTRAdminModule(BaseModule):
         binaries, or operational payloads staged for RTR `put` workflows.
         Text content is returned for model review; binary content returns size
         metadata and a safe error instead of raw bytes. Treat retrieval results
-        as sensitive regardless of inventory `file_type`; live testing showed
-        binary-tagged inventory can still retrieve text content.
+        as sensitive regardless of inventory `file_type`; binary-tagged
+        inventory can still retrieve text content.
         """
         file_id = unwrap_field_default(file_id)
 
@@ -1604,8 +1604,8 @@ class RTRAdminModule(BaseModule):
     def _put_file_content_warning(self) -> str:
         return (
             "RTR put-file content retrieval is sensitive regardless of inventory "
-            "file_type. Live testing showed put-file metadata can say binary while "
-            "retrieval returns text content."
+            "file_type. Put-file metadata can say binary while retrieval returns "
+            "text content."
         )
 
     def _annotate_put_file_content(self, item: dict[str, Any]) -> dict[str, Any]:
@@ -1642,8 +1642,8 @@ class RTRAdminModule(BaseModule):
         tokens = command_string.split()
         if len(tokens) > 3 and [token.lower() for token in tokens[:2]] == ["reg", "query"]:
             return [
-                "`reg query` reached Falcon with HTTP 400 during live testing when more "
-                "than two arguments followed `reg`. Keep the query shape to "
+                "`reg query` can return Falcon HTTP 400 when more than two "
+                "arguments follow `reg`. Keep the query shape to "
                 "`reg query <key>` or quote paths with spaces before live use."
             ]
         return []

--- a/falcon_mcp/modules/rtr_admin.py
+++ b/falcon_mcp/modules/rtr_admin.py
@@ -8,6 +8,7 @@ updates, or deletes.
 
 import hashlib
 import json
+import time
 from typing import Any
 
 from mcp.server import FastMCP
@@ -15,10 +16,11 @@ from mcp.server.fastmcp.resources import TextResource
 from mcp.types import ToolAnnotations
 from pydantic import AnyUrl, Field
 
-from falcon_mcp.common.errors import _format_error_response
+from falcon_mcp.common.errors import _format_error_response, handle_api_response
 from falcon_mcp.common.utils import prepare_api_parameters, unwrap_field_default
 from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.resources.rtr_admin import (
+    RTR_ADMIN_APPROVAL_PACKET_TEMPLATE,
     RTR_ADMIN_RUNSCRIPT_RAW_GUIDE,
     RTR_ADMIN_TOOL_USE_GUIDE,
     SEARCH_RTR_ADMIN_SCRIPTS_FQL_DOCUMENTATION,
@@ -67,6 +69,7 @@ BLOCKED_ADMIN_COMMANDS = {
     "shutdown",
     "tar",
     "umount",
+    "unmount",
     "unmap",
     "zip",
 }
@@ -104,6 +107,11 @@ class RTRAdminModule(BaseModule):
         )
         self._add_tool(
             server=server,
+            method=self.get_rtr_put_file_contents,
+            name="get_rtr_put_file_contents",
+        )
+        self._add_tool(
+            server=server,
             method=self.check_rtr_admin_command_status,
             name="check_rtr_admin_command_status",
         )
@@ -121,6 +129,17 @@ class RTRAdminModule(BaseModule):
             server=server,
             method=self.execute_rtr_admin_command,
             name="execute_rtr_admin_command",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        self._add_tool(
+            server=server,
+            method=self.run_rtr_admin_command_and_wait,
+            name="run_rtr_admin_command_and_wait",
             annotations=ToolAnnotations(
                 readOnlyHint=False,
                 destructiveHint=True,
@@ -162,10 +181,211 @@ class RTRAdminModule(BaseModule):
                 description="Contains RTR Admin runscript raw command construction guidance.",
                 text=RTR_ADMIN_RUNSCRIPT_RAW_GUIDE,
             ),
+            TextResource(
+                uri=AnyUrl("falcon://rtr-admin/policy/command-guide"),
+                name="falcon_rtr_admin_command_policy_guide",
+                description="Contains RTR Admin command classification policy and command categories.",
+                text=self._command_policy_guide(),
+            ),
+            TextResource(
+                uri=AnyUrl("falcon://rtr-admin/approval/packet-guide"),
+                name="falcon_rtr_admin_approval_packet_template",
+                description="Contains the approval packet template for high-impact RTR Admin commands.",
+                text=RTR_ADMIN_APPROVAL_PACKET_TEMPLATE,
+            ),
         ]
 
         for resource in resources:
             self._add_resource(server, resource)
+
+    def register_prompts(self, server: FastMCP) -> None:
+        """Register prompts with the MCP server."""
+        self._add_prompt(
+            server=server,
+            method=self.plan_rtr_admin_action,
+            name="plan_rtr_admin_action",
+            title="Plan RTR Admin Action",
+            description="Plan a safe RTR Admin workflow before using execution tools.",
+        )
+        self._add_prompt(
+            server=server,
+            method=self.build_rtr_admin_approval_packet,
+            name="build_rtr_admin_approval_packet",
+            title="Build RTR Admin Approval Packet",
+            description="Create an operator approval packet for a high-impact RTR Admin command.",
+        )
+        self._add_prompt(
+            server=server,
+            method=self.review_rtr_admin_runscript,
+            name="review_rtr_admin_runscript",
+            title="Review RTR Admin Runscript",
+            description="Review an RTR Admin runscript command string for safety and quoting risks.",
+        )
+        self._add_prompt(
+            server=server,
+            method=self.interpret_rtr_admin_status,
+            name="interpret_rtr_admin_status",
+            title="Interpret RTR Admin Status",
+            description="Interpret RTR Admin command status output and suggest next safe steps.",
+        )
+
+    def plan_rtr_admin_action(
+        self,
+        objective: str = Field(description="Operator objective for the RTR Admin workflow."),
+        target_hostname: str | None = Field(
+            default=None,
+            description="Optional hostname under review.",
+        ),
+        session_id: str | None = Field(
+            default=None,
+            description="Optional RTR session ID if one is already known.",
+        ),
+        device_id: str | None = Field(
+            default=None,
+            description="Optional Falcon device AID if one is already known.",
+        ),
+        ticket: str | None = Field(
+            default=None,
+            description="Optional ticket, case, or incident identifier.",
+        ),
+    ) -> str:
+        """Plan a safe RTR Admin action before calling execution tools."""
+        return "\n".join(
+            [
+                "Plan an RTR Admin action using the existing RTR Admin MCP surface.",
+                "",
+                "Context:",
+                *self._prompt_context_lines(
+                    objective=objective,
+                    target_hostname=target_hostname,
+                    session_id=session_id,
+                    device_id=device_id,
+                    ticket=ticket,
+                ),
+                "",
+                "Workflow:",
+                "1. Use inventory/search tools only if reusable scripts or put-files need review.",
+                "   Use `falcon_get_rtr_put_file_contents` only after selecting a specific put-file ID.",
+                "2. Use `falcon_classify_rtr_admin_command` before any execution planning.",
+                "3. Use `falcon_preview_rtr_admin_command` to inspect payload, target, policy, and approval gate.",
+                "4. For high-impact commands, build an approval packet and wait for explicit operator approval.",
+                "5. Use `falcon_run_rtr_admin_command_and_wait` for focused single-host commands when direct output is needed.",
+                "6. Use `falcon_execute_rtr_admin_command` plus `falcon_check_rtr_admin_command_status` when manual polling is better.",
+                "",
+                "Do not invent new tools, bypass the approval phrase, or place RTR controller actions inside raw scripts.",
+            ]
+        )
+
+    def build_rtr_admin_approval_packet(
+        self,
+        base_command: str = Field(description="RTR Admin base command under review."),
+        command_string: str = Field(description="Exact RTR Admin command string under review."),
+        session_id: str = Field(description="RTR session ID that would receive the command."),
+        device_id: str | None = Field(default=None, description="Optional Falcon device AID."),
+        target_hostname: str | None = Field(default=None, description="Optional hostname."),
+        reason: str | None = Field(default=None, description="Reason for considering the command."),
+        ticket: str | None = Field(default=None, description="Ticket, case, or incident identifier."),
+        expected_effect: str | None = Field(
+            default=None,
+            description="Expected endpoint effect if the command is executed.",
+        ),
+        persist: bool = Field(default=False, description="Whether the command would persist offline."),
+    ) -> str:
+        """Create an approval-packet prompt for a high-impact RTR Admin command."""
+        return "\n".join(
+            [
+                "Build an RTR Admin approval packet for operator review.",
+                "",
+                "Command under review:",
+                f"- base_command: {base_command}",
+                f"- command_string: {command_string}",
+                f"- persist: {bool(persist)}",
+                "",
+                "Target:",
+                *self._prompt_context_lines(
+                    target_hostname=target_hostname,
+                    session_id=session_id,
+                    device_id=device_id,
+                    ticket=ticket,
+                    reason=reason,
+                    expected_effect=expected_effect,
+                ),
+                "",
+                "Required steps:",
+                "1. Confirm `base_command` matches the first token of `command_string`.",
+                "2. Use `falcon_classify_rtr_admin_command` to get category, risk, and approval requirements.",
+                "3. Use `falcon_preview_rtr_admin_command` with reason, ticket, and expected_effect.",
+                "4. Copy the preview `approval_gate.approval_phrase` only after operator approval.",
+                "5. Execute once with `falcon_run_rtr_admin_command_and_wait`, or use `falcon_execute_rtr_admin_command` then poll status.",
+                "",
+                "Approval template resource: falcon://rtr-admin/approval/packet-guide",
+            ]
+        )
+
+    def review_rtr_admin_runscript(
+        self,
+        command_string: str = Field(description="RTR Admin runscript command string to review."),
+        target_platform: str | None = Field(
+            default=None,
+            description="Optional target platform such as windows, linux, or mac.",
+        ),
+        objective: str | None = Field(
+            default=None,
+            description="Optional operator objective for the script.",
+        ),
+    ) -> str:
+        """Review a runscript command string for safety and quoting risks."""
+        return "\n".join(
+            [
+                "Review this RTR Admin runscript command before preview or execution.",
+                "",
+                f"- command_string: {command_string}",
+                f"- target_platform: {target_platform or 'not provided'}",
+                f"- objective: {objective or 'not provided'}",
+                "",
+                "Checklist:",
+                "1. Confirm the command starts with `runscript` and uses the intended `-Raw` or `-CloudFile` shape.",
+                "2. Do not include RTR controller commands such as `get`, `put`, `cd`, or status polling inside raw script bodies.",
+                "3. Check quoting around triple backticks, shell quotes, and command-line arguments.",
+                "4. Prefer approved cloud scripts for reusable or multiline logic.",
+                "5. Use `falcon_preview_rtr_admin_command` before execution and require high-impact approval.",
+                "6. Prefer `falcon_run_rtr_admin_command_and_wait` only for focused commands where immediate output is needed.",
+                "",
+                "Reference resource: falcon://rtr-admin/commands/runscript-guide",
+            ]
+        )
+
+    def interpret_rtr_admin_status(
+        self,
+        command_status: str = Field(
+            description="RTR Admin command status result or summarized stdout/stderr to interpret.",
+        ),
+        base_command: str | None = Field(default=None, description="Optional base command."),
+        expected_effect: str | None = Field(
+            default=None,
+            description="Optional expected endpoint effect that was approved.",
+        ),
+    ) -> str:
+        """Interpret RTR Admin status output and suggest next safe steps."""
+        return "\n".join(
+            [
+                "Interpret RTR Admin command status output.",
+                "",
+                f"- base_command: {base_command or 'not provided'}",
+                f"- expected_effect: {expected_effect or 'not provided'}",
+                "",
+                "Status material:",
+                command_status,
+                "",
+                "Return:",
+                "1. Completion state and whether more `falcon_check_rtr_admin_command_status` polling is needed.",
+                "2. stdout/stderr findings tied to the approved command and expected effect.",
+                "3. Any evidence gaps or follow-up read-only checks.",
+                "4. Any warning that the output suggests unexpected endpoint impact.",
+                "",
+                "Do not suggest a second high-impact action without a fresh preview and approval packet.",
+            ]
+        )
 
     def search_rtr_admin_scripts(
         self,
@@ -350,6 +570,72 @@ class RTRAdminModule(BaseModule):
 
         return details
 
+    def get_rtr_put_file_contents(
+        self,
+        file_id: str = Field(
+            description="RTR put-file ID whose stored contents should be retrieved.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve the stored contents of one RTR put-file by ID.
+
+        Use this only after selecting a specific put-file from
+        falcon_search_rtr_put_files. This is a read-only Falcon call, but the
+        returned content can be sensitive because put-files may contain scripts,
+        binaries, or operational payloads staged for RTR `put` workflows.
+        Text content is returned for model review; binary content returns size
+        metadata and a safe error instead of raw bytes.
+        """
+        file_id = unwrap_field_default(file_id)
+
+        if not isinstance(file_id, str) or not file_id.strip():
+            return _format_error_response(
+                "file_id is required to retrieve RTR put-file contents. "
+                "No Falcon call was made."
+            )
+
+        prepared_params = prepare_api_parameters({"id": file_id})
+        response = self.client.command(
+            "RTR_GetPutFileContents",
+            parameters=prepared_params,
+        )
+
+        if isinstance(response, bytes):
+            try:
+                return {
+                    "id": file_id,
+                    "content": response.decode("utf-8"),
+                    "content_format": "text",
+                }
+            except UnicodeDecodeError:
+                return {
+                    "error": (
+                        "RTR put-file content is binary and cannot be returned "
+                        "as safe text for model consumption."
+                    ),
+                    "id": file_id,
+                    "content_format": "binary",
+                    "size_bytes": len(response),
+                }
+
+        if isinstance(response, dict):
+            status_code = response.get("status_code")
+            if status_code is None or status_code >= 300:
+                return handle_api_response(
+                    response,
+                    operation="RTR_GetPutFileContents",
+                    error_message="Failed to retrieve RTR put-file contents",
+                    default_result=[],
+                )
+
+            body = response.get("body", {})
+            if isinstance(body, dict) and "resources" in body:
+                return body.get("resources", [])
+            if body:
+                return {"id": file_id, "body": body}
+            return []
+
+        return {"error": f"Unexpected response type: {type(response).__name__}"}
+
     def check_rtr_admin_command_status(
         self,
         cloud_request_id: str = Field(
@@ -418,6 +704,17 @@ class RTRAdminModule(BaseModule):
         normalized = base_command.strip().lower()
         command_text = command_string.strip() if isinstance(command_string, str) else ""
         command_lower = command_text.lower()
+        command_base = command_lower.split(maxsplit=1)[0] if command_lower else None
+
+        if command_base and command_base != normalized:
+            return _format_error_response(
+                "base_command must match the first token of command_string. "
+                "No Falcon call was made.",
+                details={
+                    "base_command": normalized,
+                    "command_string_base": command_base,
+                },
+            )
 
         if normalized in READ_ONLY_ADMIN_COMMANDS:
             return self._classification(
@@ -777,6 +1074,201 @@ class RTRAdminModule(BaseModule):
             payload=payload,
         )
 
+    def run_rtr_admin_command_and_wait(
+        self,
+        base_command: str = Field(description="RTR Admin base command to execute."),
+        command_string: str = Field(description="Full RTR Admin command string to execute."),
+        session_id: str = Field(
+            description="RTR session ID to execute the command against.",
+        ),
+        device_id: str | None = Field(
+            default=None,
+            description="Optional device AID for human review. Falcon execution requires session_id.",
+        ),
+        command_id: int | None = Field(
+            default=None,
+            ge=0,
+            description="Optional command sequence ID sent as `id` in the Falcon body.",
+        ),
+        persist: bool = Field(
+            default=False,
+            description="Execute when the host returns to service. Defaults false.",
+        ),
+        target_hostname: str | None = Field(
+            default=None,
+            description="Optional hostname for human review. Not sent to Falcon.",
+        ),
+        reason: str | None = Field(
+            default=None,
+            description="Why this command is being executed.",
+        ),
+        ticket: str | None = Field(
+            default=None,
+            description="Ticket, case, or incident identifier for audit context.",
+        ),
+        expected_effect: str | None = Field(
+            default=None,
+            description="Expected endpoint effect of the command.",
+        ),
+        operator_approval: str | None = Field(
+            default=None,
+            description=(
+                "Exact approval phrase required for high-impact RTR Admin commands. "
+                "Get it from preview or from the approval-required response after "
+                "human review."
+            ),
+        ),
+        timeout_seconds: int = Field(
+            default=60,
+            ge=1,
+            le=600,
+            description="Maximum time to wait for command completion. Max: 600 seconds.",
+        ),
+        poll_interval_seconds: float = Field(
+            default=2.0,
+            ge=0.5,
+            le=30.0,
+            description="Seconds to wait between admin command status checks.",
+        ),
+    ) -> dict[str, Any]:
+        """Execute an RTR Admin command and poll until completion or timeout.
+
+        This is a convenience workflow for single-host admin commands. It uses
+        the same local classification and approval gate as
+        falcon_execute_rtr_admin_command, then polls
+        falcon_check_rtr_admin_command_status with the returned cloud_request_id.
+        """
+        timeout_seconds = unwrap_field_default(timeout_seconds)
+        poll_interval_seconds = unwrap_field_default(poll_interval_seconds)
+
+        execute_response = self.execute_rtr_admin_command(
+            base_command=base_command,
+            command_string=command_string,
+            session_id=session_id,
+            device_id=device_id,
+            command_id=command_id,
+            persist=persist,
+            target_hostname=target_hostname,
+            reason=reason,
+            ticket=ticket,
+            expected_effect=expected_effect,
+            operator_approval=operator_approval,
+        )
+
+        if self._is_error(execute_response):
+            execute_response["phase"] = "execute"
+            return execute_response
+
+        if not execute_response.get("submitted"):
+            execute_response["phase"] = "execute"
+            return execute_response
+
+        execute_result = execute_response.get("result")
+        if not isinstance(execute_result, list) or not execute_result:
+            return {
+                "error": "RTR Admin command execution did not return a command request.",
+                "phase": "execute",
+                "execution_response": execute_response,
+            }
+
+        command_request = execute_result[0]
+        if not isinstance(command_request, dict):
+            return {
+                "error": "RTR Admin command execution returned an unexpected response shape.",
+                "phase": "execute",
+                "execution_response": execute_response,
+            }
+
+        cloud_request_id = command_request.get("cloud_request_id")
+        if not cloud_request_id:
+            return {
+                "error": "RTR Admin command execution did not return a cloud_request_id.",
+                "phase": "execute",
+                "execution_response": execute_response,
+            }
+
+        deadline = time.monotonic() + timeout_seconds
+        status_chunks: list[dict[str, Any]] = []
+        sequence_id = 0
+
+        while True:
+            status_result = self._base_query_api_call(
+                operation="RTR_CheckAdminCommandStatus",
+                query_params={
+                    "cloud_request_id": cloud_request_id,
+                    "sequence_id": sequence_id,
+                },
+                error_message="Failed to check RTR Admin command status",
+            )
+
+            if self._is_error(status_result):
+                status_result["phase"] = "status"
+                status_result["cloud_request_id"] = cloud_request_id
+                status_result["execution_response"] = execute_response
+                return status_result
+
+            if isinstance(status_result, list):
+                status_chunks.extend(
+                    chunk for chunk in status_result if isinstance(chunk, dict)
+                )
+
+            complete = any(chunk.get("complete") is True for chunk in status_chunks)
+            if complete:
+                return self._format_admin_wait_result(
+                    cloud_request_id=cloud_request_id,
+                    command_request=command_request,
+                    execute_response=execute_response,
+                    status_chunks=status_chunks,
+                    complete=True,
+                    timed_out=False,
+                )
+
+            if time.monotonic() >= deadline:
+                return self._format_admin_wait_result(
+                    cloud_request_id=cloud_request_id,
+                    command_request=command_request,
+                    execute_response=execute_response,
+                    status_chunks=status_chunks,
+                    complete=False,
+                    timed_out=True,
+                )
+
+            if status_chunks:
+                sequence_id = status_chunks[-1].get("sequence_id", sequence_id)
+            time.sleep(poll_interval_seconds)
+
+    def _prompt_context_lines(self, **values: Any) -> list[str]:
+        lines = []
+        for key, value in values.items():
+            if isinstance(value, str) and value.strip():
+                lines.append(f"- {key}: {value.strip()}")
+            elif value is not None and not isinstance(value, str):
+                lines.append(f"- {key}: {value}")
+            else:
+                lines.append(f"- {key}: not provided")
+        return lines
+
+    def _command_policy_guide(self) -> str:
+        return "\n".join(
+            [
+                "RTR Admin Command Policy Guide",
+                "",
+                "This resource summarizes local RTR Admin command classification.",
+                "The execution tool enforces this policy before any Falcon call.",
+                "",
+                f"Read-only commands: {', '.join(sorted(READ_ONLY_ADMIN_COMMANDS))}",
+                f"Evidence collection commands: {', '.join(sorted(EVIDENCE_COLLECTION_COMMANDS))}",
+                f"Sensitive collection commands: {', '.join(sorted(SENSITIVE_COLLECTION_COMMANDS))}",
+                f"High-impact commands: {', '.join(sorted(BLOCKED_ADMIN_COMMANDS))}",
+                f"Read-only update subcommands: {', '.join(sorted(READ_ONLY_UPDATE_SUBCOMMANDS))}",
+                "",
+                "`reg query` is read-only; other registry subcommands require approval.",
+                "`runscript` is always high impact and requires approval.",
+                "Unknown commands are blocked until reviewed and explicitly allowlisted.",
+                "For execution, `base_command` must match the first token of `command_string`.",
+            ]
+        )
+
     def _classification(
         self,
         base_command: str,
@@ -796,7 +1288,7 @@ class RTRAdminModule(BaseModule):
             "can_execute_with_approval": can_execute_with_approval,
             "explanation": explanation,
             "blocked_reason": None if allowed_for_execution else explanation,
-            "requires_explicit_target": allowed_for_execution,
+            "requires_explicit_target": allowed_for_execution or can_execute_with_approval,
             "safety_disclaimer": RTR_ADMIN_SAFETY_DISCLAIMER,
         }
 
@@ -862,6 +1354,42 @@ class RTRAdminModule(BaseModule):
             )
 
         return response
+
+    def _format_admin_wait_result(
+        self,
+        cloud_request_id: str,
+        command_request: dict[str, Any],
+        execute_response: dict[str, Any],
+        status_chunks: list[dict[str, Any]],
+        complete: bool,
+        timed_out: bool,
+    ) -> dict[str, Any]:
+        """Format admin command-and-wait output for model-friendly consumption."""
+        stdout = "".join(
+            str(chunk.get("stdout", "")) for chunk in status_chunks if chunk.get("stdout")
+        )
+        stderr = "".join(
+            str(chunk.get("stderr", "")) for chunk in status_chunks if chunk.get("stderr")
+        )
+
+        result: dict[str, Any] = {
+            "cloud_request_id": cloud_request_id,
+            "complete": complete,
+            "timed_out": timed_out,
+            "execution": command_request,
+            "execution_response": execute_response,
+            "status": status_chunks,
+            "stdout": stdout,
+            "stderr": stderr,
+            "classification": execute_response.get("classification"),
+            "approval_gate": execute_response.get("approval_gate"),
+            "safety_disclaimer": RTR_ADMIN_SAFETY_DISCLAIMER,
+        }
+
+        if timed_out:
+            result["warning"] = "Timed out waiting for RTR Admin command completion."
+
+        return result
 
     def _enforce_admin_command_policy(
         self,

--- a/falcon_mcp/modules/rtr_admin.py
+++ b/falcon_mcp/modules/rtr_admin.py
@@ -19,9 +19,6 @@ from falcon_mcp.common.errors import _format_error_response
 from falcon_mcp.common.utils import prepare_api_parameters, unwrap_field_default
 from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.resources.rtr_admin import (
-    EMBEDDED_FALCON_SCRIPT_FQL_SYNTAX,
-    EMBEDDED_PUT_FILE_FQL_SYNTAX,
-    EMBEDDED_SCRIPT_FQL_SYNTAX,
     RTR_ADMIN_RUNSCRIPT_RAW_GUIDE,
     RTR_ADMIN_TOOL_USE_GUIDE,
     SEARCH_RTR_ADMIN_SCRIPTS_FQL_DOCUMENTATION,
@@ -33,24 +30,30 @@ READ_ONLY_ADMIN_COMMANDS = {
     "cat",
     "cd",
     "clear",
+    "csrutil",
     "env",
     "eventlog",
     "filehash",
     "getsid",
     "help",
     "history",
+    "ifconfig",
     "ipconfig",
     "ls",
     "mount",
     "netstat",
     "ps",
+    "pwd",
+    "users",
 }
 
 EVIDENCE_COLLECTION_COMMANDS = {"get"}
 SENSITIVE_COLLECTION_COMMANDS = {"memdump", "xmemdump"}
 BLOCKED_ADMIN_COMMANDS = {
     "cp",
+    "cswindiag",
     "encrypt",
+    "falconscript",
     "kill",
     "map",
     "mkdir",
@@ -59,8 +62,11 @@ BLOCKED_ADMIN_COMMANDS = {
     "put-and-run",
     "restart",
     "rm",
+    "rmdir",
     "run",
     "shutdown",
+    "tar",
+    "umount",
     "unmap",
     "zip",
 }
@@ -73,18 +79,6 @@ RTR_ADMIN_SAFETY_DISCLAIMER = (
     "only a PC chosen by the operator."
 )
 
-RTR_ADMIN_EXECUTION_ANNOTATIONS = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
-
-def _normalize_field_value(value: Any) -> Any:
-    """Unwrap direct-call Pydantic Field defaults into plain Python values."""
-    return unwrap_field_default(value)
-
 
 class RTRAdminModule(BaseModule):
     """Module for RTR Admin inventory and pre-execution safety checks."""
@@ -95,52 +89,37 @@ class RTRAdminModule(BaseModule):
         """Register tools with the MCP server."""
         self._add_tool(
             server=server,
-            method=self.search_scripts,
+            method=self.search_rtr_admin_scripts,
             name="search_rtr_admin_scripts",
         )
         self._add_tool(
             server=server,
-            method=self.get_script_details,
-            name="get_rtr_admin_script_details",
-        )
-        self._add_tool(
-            server=server,
-            method=self.search_falcon_scripts,
+            method=self.search_rtr_falcon_scripts,
             name="search_rtr_falcon_scripts",
         )
         self._add_tool(
             server=server,
-            method=self.get_falcon_script_details,
-            name="get_rtr_falcon_script_details",
-        )
-        self._add_tool(
-            server=server,
-            method=self.search_put_files,
+            method=self.search_rtr_put_files,
             name="search_rtr_put_files",
         )
         self._add_tool(
             server=server,
-            method=self.get_put_file_details,
-            name="get_rtr_put_file_details",
-        )
-        self._add_tool(
-            server=server,
-            method=self.check_admin_command_status,
+            method=self.check_rtr_admin_command_status,
             name="check_rtr_admin_command_status",
         )
         self._add_tool(
             server=server,
-            method=self.classify_admin_command,
+            method=self.classify_rtr_admin_command,
             name="classify_rtr_admin_command",
         )
         self._add_tool(
             server=server,
-            method=self.preview_admin_command,
+            method=self.preview_rtr_admin_command,
             name="preview_rtr_admin_command",
         )
         self._add_tool(
             server=server,
-            method=self.execute_admin_command,
+            method=self.execute_rtr_admin_command,
             name="execute_rtr_admin_command",
             annotations=ToolAnnotations(
                 readOnlyHint=False,
@@ -188,11 +167,11 @@ class RTRAdminModule(BaseModule):
         for resource in resources:
             self._add_resource(server, resource)
 
-    def search_scripts(
+    def search_rtr_admin_scripts(
         self,
         filter: str | None = Field(
             default=None,
-            description=EMBEDDED_SCRIPT_FQL_SYNTAX,
+            description="FQL filter expression. See `falcon://rtr-admin/scripts/search/fql-guide` for syntax.",
         ),
         limit: int = Field(
             default=10,
@@ -212,31 +191,48 @@ class RTRAdminModule(BaseModule):
         """Search RTR custom scripts and return full metadata records.
 
         Use this to find reusable custom RTR scripts by name, platform, or
-        permission type. Consult falcon://rtr-admin/scripts/search/fql-guide
-        before constructing filter expressions.
+        permission type, or to look up known script IDs with an `id` filter.
+        Consult falcon://rtr-admin/scripts/search/fql-guide before constructing
+        filter expressions. Returns full script records including name, content,
+        platform, and permission details.
         """
-        return self._search_and_get_details(
-            search_operation="RTR_ListScripts",
-            get_operation="RTR_GetScriptsV2",
-            filter=filter,
-            limit=limit,
-            offset=offset,
-            sort=sort,
-            fql_documentation=SEARCH_RTR_ADMIN_SCRIPTS_FQL_DOCUMENTATION,
+        ids = self._base_search_api_call(
+            operation="RTR_ListScripts",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+            },
+            error_message="Failed to search RTR Admin scripts",
         )
 
-    def get_script_details(
-        self,
-        ids: list[str] = Field(description="Custom RTR script IDs to retrieve."),
-    ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Retrieve custom RTR script metadata and content by script ID."""
-        return self._get_details("RTR_GetScriptsV2", ids)
+        if self._is_error(ids):
+            return self._format_fql_error_response(
+                [ids], filter, SEARCH_RTR_ADMIN_SCRIPTS_FQL_DOCUMENTATION
+            )
 
-    def search_falcon_scripts(
+        if not ids:
+            return self._format_fql_error_response(
+                [], filter, SEARCH_RTR_ADMIN_SCRIPTS_FQL_DOCUMENTATION
+            )
+
+        details = self._base_get_by_ids(
+            operation="RTR_GetScriptsV2",
+            ids=ids,
+            use_params=True,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        return details
+
+    def search_rtr_falcon_scripts(
         self,
         filter: str | None = Field(
             default=None,
-            description=EMBEDDED_FALCON_SCRIPT_FQL_SYNTAX,
+            description="FQL filter expression. See `falcon://rtr-admin/falcon-scripts/search/fql-guide` for syntax.",
         ),
         limit: int = Field(
             default=10,
@@ -255,32 +251,49 @@ class RTRAdminModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search CrowdStrike-provided Falcon scripts and return full records.
 
-        Use this to find CrowdStrike-provided RTR scripts by name or platform.
-        Consult falcon://rtr-admin/falcon-scripts/search/fql-guide before
-        constructing filter expressions.
+        Use this to find CrowdStrike-provided RTR scripts by name or platform,
+        or to look up known script IDs with an `id` filter. Consult
+        falcon://rtr-admin/falcon-scripts/search/fql-guide before constructing
+        filter expressions. Returns full script records including name,
+        description, and platform.
         """
-        return self._search_and_get_details(
-            search_operation="RTR_ListFalconScripts",
-            get_operation="RTR_GetFalconScripts",
-            filter=filter,
-            limit=limit,
-            offset=offset,
-            sort=sort,
-            fql_documentation=SEARCH_RTR_FALCON_SCRIPTS_FQL_DOCUMENTATION,
+        ids = self._base_search_api_call(
+            operation="RTR_ListFalconScripts",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+            },
+            error_message="Failed to search RTR Falcon scripts",
         )
 
-    def get_falcon_script_details(
-        self,
-        ids: list[str] = Field(description="Falcon script IDs to retrieve."),
-    ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Retrieve CrowdStrike-provided Falcon script metadata and content by ID."""
-        return self._get_details("RTR_GetFalconScripts", ids)
+        if self._is_error(ids):
+            return self._format_fql_error_response(
+                [ids], filter, SEARCH_RTR_FALCON_SCRIPTS_FQL_DOCUMENTATION
+            )
 
-    def search_put_files(
+        if not ids:
+            return self._format_fql_error_response(
+                [], filter, SEARCH_RTR_FALCON_SCRIPTS_FQL_DOCUMENTATION
+            )
+
+        details = self._base_get_by_ids(
+            operation="RTR_GetFalconScripts",
+            ids=ids,
+            use_params=True,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        return details
+
+    def search_rtr_put_files(
         self,
         filter: str | None = Field(
             default=None,
-            description=EMBEDDED_PUT_FILE_FQL_SYNTAX,
+            description="FQL filter expression. See `falcon://rtr-admin/put-files/search/fql-guide` for syntax.",
         ),
         limit: int = Field(
             default=10,
@@ -300,32 +313,44 @@ class RTRAdminModule(BaseModule):
         """Search RTR put-files and return full metadata records.
 
         Use this to review put-file inventory before considering an admin
-        command that references staged content. Consult
-        falcon://rtr-admin/put-files/search/fql-guide before constructing
-        filter expressions.
+        command that references staged content, or to look up known put-file IDs
+        with an `id` filter. Consult falcon://rtr-admin/put-files/search/fql-guide
+        before constructing filter expressions. Returns full put-file metadata
+        records.
         """
-        return self._search_and_get_details(
-            search_operation="RTR_ListPut_Files",
-            get_operation="RTR_GetPut_FilesV2",
-            filter=filter,
-            limit=limit,
-            offset=offset,
-            sort=sort,
-            fql_documentation=SEARCH_RTR_PUT_FILES_FQL_DOCUMENTATION,
+        ids = self._base_search_api_call(
+            operation="RTR_ListPut_Files",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+            },
+            error_message="Failed to search RTR put-files",
         )
 
-    def get_put_file_details(
-        self,
-        ids: list[str] = Field(description="RTR put-file IDs to retrieve."),
-    ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Retrieve RTR put-file metadata by ID.
+        if self._is_error(ids):
+            return self._format_fql_error_response(
+                [ids], filter, SEARCH_RTR_PUT_FILES_FQL_DOCUMENTATION
+            )
 
-        This tool intentionally returns metadata only. It does not expose
-        put-file content retrieval in the first RTR Admin slice.
-        """
-        return self._get_details("RTR_GetPut_FilesV2", ids)
+        if not ids:
+            return self._format_fql_error_response(
+                [], filter, SEARCH_RTR_PUT_FILES_FQL_DOCUMENTATION
+            )
 
-    def check_admin_command_status(
+        details = self._base_get_by_ids(
+            operation="RTR_GetPut_FilesV2",
+            ids=ids,
+            use_params=True,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        return details
+
+    def check_rtr_admin_command_status(
         self,
         cloud_request_id: str = Field(
             description="Cloud request ID returned from a prior RTR Admin command.",
@@ -338,10 +363,12 @@ class RTRAdminModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Retrieve status and output for a prior RTR Admin command.
 
-        This is a read-only status lookup. It cannot start a new command.
+        Use this to poll for command completion after execution. This is a
+        read-only status lookup that cannot start a new command. Returns
+        completion status, stdout, stderr, and sequence information.
         """
-        cloud_request_id = _normalize_field_value(cloud_request_id)
-        sequence_id = _normalize_field_value(sequence_id)
+        cloud_request_id = unwrap_field_default(cloud_request_id)
+        sequence_id = unwrap_field_default(sequence_id)
 
         if not isinstance(cloud_request_id, str) or not cloud_request_id.strip():
             return _format_error_response(
@@ -363,7 +390,7 @@ class RTRAdminModule(BaseModule):
             error_message="Failed to check RTR Admin command status",
         )
 
-    def classify_admin_command(
+    def classify_rtr_admin_command(
         self,
         base_command: str = Field(
             description="RTR Admin base command to classify, such as `get`, `runscript`, `rm`, or `reg`.",
@@ -377,9 +404,10 @@ class RTRAdminModule(BaseModule):
 
         Use this before designing or approving any RTR Admin execution flow.
         This policy helper is intentionally local and does not call Falcon.
+        Returns category, risk level, approval requirements, and explanation.
         """
-        base_command = _normalize_field_value(base_command)
-        command_string = _normalize_field_value(command_string)
+        base_command = unwrap_field_default(base_command)
+        command_string = unwrap_field_default(command_string)
 
         if not isinstance(base_command, str) or not base_command.strip():
             return _format_error_response(
@@ -444,9 +472,11 @@ class RTRAdminModule(BaseModule):
             return self._classification(
                 normalized,
                 "evidence_collection",
-                "medium",
-                True,
-                "Command can collect files from a chosen host and needs explicit target review.",
+                "high",
+                False,
+                "File exfiltration command requires explicit operator approval before execution.",
+                requires_approval=True,
+                can_execute_with_approval=True,
             )
 
         if normalized == "runscript":
@@ -490,7 +520,7 @@ class RTRAdminModule(BaseModule):
             "Unknown RTR Admin command. It is blocked until reviewed and explicitly allowlisted.",
         )
 
-    def preview_admin_command(
+    def preview_rtr_admin_command(
         self,
         session_id: str = Field(description="RTR session ID that would receive the command."),
         device_id: str | None = Field(
@@ -531,16 +561,16 @@ class RTRAdminModule(BaseModule):
         execution tool would use, plus local policy classification. It never
         calls Falcon and cannot execute the command.
         """
-        session_id = _normalize_field_value(session_id)
-        device_id = _normalize_field_value(device_id)
-        base_command = _normalize_field_value(base_command)
-        command_string = _normalize_field_value(command_string)
-        command_id = _normalize_field_value(command_id)
-        target_hostname = _normalize_field_value(target_hostname)
-        reason = _normalize_field_value(reason)
-        ticket = _normalize_field_value(ticket)
-        expected_effect = _normalize_field_value(expected_effect)
-        persist = _normalize_field_value(persist)
+        session_id = unwrap_field_default(session_id)
+        device_id = unwrap_field_default(device_id)
+        base_command = unwrap_field_default(base_command)
+        command_string = unwrap_field_default(command_string)
+        command_id = unwrap_field_default(command_id)
+        target_hostname = unwrap_field_default(target_hostname)
+        reason = unwrap_field_default(reason)
+        ticket = unwrap_field_default(ticket)
+        expected_effect = unwrap_field_default(expected_effect)
+        persist = unwrap_field_default(persist)
 
         missing_required = []
         if not isinstance(session_id, str) or not session_id.strip():
@@ -557,7 +587,7 @@ class RTRAdminModule(BaseModule):
                 details={"missing_required": missing_required},
             )
 
-        classification = self.classify_admin_command(base_command, command_string)
+        classification = self.classify_rtr_admin_command(base_command, command_string)
         if self._is_error(classification):
             return classification
 
@@ -618,12 +648,11 @@ class RTRAdminModule(BaseModule):
             "approval_gate": approval_gate,
         }
 
-    def execute_admin_command(
+    def execute_rtr_admin_command(
         self,
         base_command: str = Field(description="RTR Admin base command to execute."),
         command_string: str = Field(description="Full RTR Admin command string to execute."),
-        session_id: str | None = Field(
-            default=None,
+        session_id: str = Field(
             description="RTR session ID to execute the command against.",
         ),
         device_id: str | None = Field(
@@ -666,20 +695,22 @@ class RTRAdminModule(BaseModule):
     ) -> dict[str, Any]:
         """Execute an RTR Admin command on a single host.
 
-        High-impact commands are blocked before the Falcon API call unless the
-        exact operator approval phrase for this payload is supplied.
+        Use after previewing and classifying the command. High-impact commands
+        are blocked unless the exact operator approval phrase is supplied.
+        Returns submission status, cloud_request_id for polling, and
+        classification enforcement details.
         """
-        base_command = _normalize_field_value(base_command)
-        command_string = _normalize_field_value(command_string)
-        session_id = _normalize_field_value(session_id)
-        device_id = _normalize_field_value(device_id)
-        command_id = _normalize_field_value(command_id)
-        persist = _normalize_field_value(persist)
-        target_hostname = _normalize_field_value(target_hostname)
-        reason = _normalize_field_value(reason)
-        ticket = _normalize_field_value(ticket)
-        expected_effect = _normalize_field_value(expected_effect)
-        operator_approval = _normalize_field_value(operator_approval)
+        base_command = unwrap_field_default(base_command)
+        command_string = unwrap_field_default(command_string)
+        session_id = unwrap_field_default(session_id)
+        device_id = unwrap_field_default(device_id)
+        command_id = unwrap_field_default(command_id)
+        persist = unwrap_field_default(persist)
+        target_hostname = unwrap_field_default(target_hostname)
+        reason = unwrap_field_default(reason)
+        ticket = unwrap_field_default(ticket)
+        expected_effect = unwrap_field_default(expected_effect)
+        operator_approval = unwrap_field_default(operator_approval)
 
         missing_required = []
         if not isinstance(base_command, str) or not base_command.strip():
@@ -696,7 +727,7 @@ class RTRAdminModule(BaseModule):
                 details={"missing_required": missing_required},
             )
 
-        classification = self.classify_admin_command(base_command, command_string)
+        classification = self.classify_rtr_admin_command(base_command, command_string)
         if self._is_error(classification):
             return classification
 
@@ -745,63 +776,6 @@ class RTRAdminModule(BaseModule):
             missing_context=self._missing_audit_context(reason, ticket, expected_effect),
             payload=payload,
         )
-
-    def _search_and_get_details(
-        self,
-        search_operation: str,
-        get_operation: str,
-        filter: str | None,
-        limit: int,
-        offset: int | None,
-        sort: str | None,
-        fql_documentation: str,
-    ) -> list[dict[str, Any]] | dict[str, Any]:
-        ids = self._base_search_api_call(
-            operation=search_operation,
-            search_params={
-                "filter": filter,
-                "limit": limit,
-                "offset": offset,
-                "sort": sort,
-            },
-            error_message=f"Failed to search RTR Admin resources with {search_operation}",
-        )
-
-        if self._is_error(ids):
-            return self._format_fql_error_response([ids], filter, fql_documentation)
-
-        if not ids:
-            return self._format_fql_error_response([], filter, fql_documentation)
-
-        details = self._base_get_by_ids(
-            operation=get_operation,
-            ids=ids,
-            use_params=True,
-        )
-
-        if self._is_error(details):
-            return [details]
-
-        return details
-
-    def _get_details(
-        self,
-        operation: str,
-        ids: list[str],
-    ) -> list[dict[str, Any]] | dict[str, Any]:
-        if not ids:
-            return []
-
-        details = self._base_get_by_ids(
-            operation=operation,
-            ids=ids,
-            use_params=True,
-        )
-
-        if self._is_error(details):
-            return [details]
-
-        return details
 
     def _classification(
         self,
@@ -964,12 +938,15 @@ class RTRAdminModule(BaseModule):
         payload: dict[str, Any],
         target: dict[str, Any],
     ) -> str:
+        hash_target = {
+            k: v for k, v in target.items() if k in ("session_id", "device_id")
+        }
         material = {
             "operation": operation,
             "base_command": classification.get("base_command"),
             "category": classification.get("category"),
             "risk": classification.get("risk"),
-            "target": prepare_api_parameters(target),
+            "target": prepare_api_parameters(hash_target),
             "payload": payload,
         }
         serialized = json.dumps(material, sort_keys=True, separators=(",", ":"))

--- a/falcon_mcp/modules/rtr_admin.py
+++ b/falcon_mcp/modules/rtr_admin.py
@@ -1,0 +1,1021 @@
+"""
+Real Time Response Admin module for Falcon MCP Server.
+
+This module exposes RTR Admin inventory, command status, command preview, and
+admin command execution helpers. It does not manage script / put-file uploads,
+updates, or deletes.
+"""
+
+import hashlib
+import json
+from typing import Any
+
+from mcp.server import FastMCP
+from mcp.server.fastmcp.resources import TextResource
+from mcp.types import ToolAnnotations
+from pydantic import AnyUrl, Field
+
+from falcon_mcp.common.errors import _format_error_response
+from falcon_mcp.common.utils import prepare_api_parameters, unwrap_field_default
+from falcon_mcp.modules.base import BaseModule
+from falcon_mcp.resources.rtr_admin import (
+    EMBEDDED_FALCON_SCRIPT_FQL_SYNTAX,
+    EMBEDDED_PUT_FILE_FQL_SYNTAX,
+    EMBEDDED_SCRIPT_FQL_SYNTAX,
+    RTR_ADMIN_RUNSCRIPT_RAW_GUIDE,
+    RTR_ADMIN_TOOL_USE_GUIDE,
+    SEARCH_RTR_ADMIN_SCRIPTS_FQL_DOCUMENTATION,
+    SEARCH_RTR_FALCON_SCRIPTS_FQL_DOCUMENTATION,
+    SEARCH_RTR_PUT_FILES_FQL_DOCUMENTATION,
+)
+
+READ_ONLY_ADMIN_COMMANDS = {
+    "cat",
+    "cd",
+    "clear",
+    "env",
+    "eventlog",
+    "filehash",
+    "getsid",
+    "help",
+    "history",
+    "ipconfig",
+    "ls",
+    "mount",
+    "netstat",
+    "ps",
+}
+
+EVIDENCE_COLLECTION_COMMANDS = {"get"}
+SENSITIVE_COLLECTION_COMMANDS = {"memdump", "xmemdump"}
+BLOCKED_ADMIN_COMMANDS = {
+    "cp",
+    "encrypt",
+    "kill",
+    "map",
+    "mkdir",
+    "mv",
+    "put",
+    "put-and-run",
+    "restart",
+    "rm",
+    "run",
+    "shutdown",
+    "unmap",
+    "zip",
+}
+READ_ONLY_UPDATE_SUBCOMMANDS = {"history", "list", "query"}
+
+RTR_ADMIN_SAFETY_DISCLAIMER = (
+    "RTR Admin can affect live endpoints. This module can execute admin "
+    "commands when explicitly invoked, but automated tests must stay mocked, "
+    "smoke-only, or read-only. Any live endpoint-changing test must target "
+    "only a PC chosen by the operator."
+)
+
+RTR_ADMIN_EXECUTION_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=True,
+)
+
+
+def _normalize_field_value(value: Any) -> Any:
+    """Unwrap direct-call Pydantic Field defaults into plain Python values."""
+    return unwrap_field_default(value)
+
+
+class RTRAdminModule(BaseModule):
+    """Module for RTR Admin inventory and pre-execution safety checks."""
+
+    MODULE_NAME = "rtr_admin"
+
+    def register_tools(self, server: FastMCP) -> None:
+        """Register tools with the MCP server."""
+        self._add_tool(
+            server=server,
+            method=self.search_scripts,
+            name="search_rtr_admin_scripts",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_script_details,
+            name="get_rtr_admin_script_details",
+        )
+        self._add_tool(
+            server=server,
+            method=self.search_falcon_scripts,
+            name="search_rtr_falcon_scripts",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_falcon_script_details,
+            name="get_rtr_falcon_script_details",
+        )
+        self._add_tool(
+            server=server,
+            method=self.search_put_files,
+            name="search_rtr_put_files",
+        )
+        self._add_tool(
+            server=server,
+            method=self.get_put_file_details,
+            name="get_rtr_put_file_details",
+        )
+        self._add_tool(
+            server=server,
+            method=self.check_admin_command_status,
+            name="check_rtr_admin_command_status",
+        )
+        self._add_tool(
+            server=server,
+            method=self.classify_admin_command,
+            name="classify_rtr_admin_command",
+        )
+        self._add_tool(
+            server=server,
+            method=self.preview_admin_command,
+            name="preview_rtr_admin_command",
+        )
+        self._add_tool(
+            server=server,
+            method=self.execute_admin_command,
+            name="execute_rtr_admin_command",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+    def register_resources(self, server: FastMCP) -> None:
+        """Register resources with the MCP server."""
+        resources = [
+            TextResource(
+                uri=AnyUrl("falcon://rtr-admin/scripts/search/fql-guide"),
+                name="falcon_search_rtr_admin_scripts_fql_guide",
+                description="Contains the guide for the `filter` param of the custom RTR script search tool.",
+                text=SEARCH_RTR_ADMIN_SCRIPTS_FQL_DOCUMENTATION,
+            ),
+            TextResource(
+                uri=AnyUrl("falcon://rtr-admin/falcon-scripts/search/fql-guide"),
+                name="falcon_search_rtr_falcon_scripts_fql_guide",
+                description="Contains the guide for the `filter` param of the Falcon script search tool.",
+                text=SEARCH_RTR_FALCON_SCRIPTS_FQL_DOCUMENTATION,
+            ),
+            TextResource(
+                uri=AnyUrl("falcon://rtr-admin/put-files/search/fql-guide"),
+                name="falcon_search_rtr_put_files_fql_guide",
+                description="Contains the guide for the `filter` param of the RTR put-file search tool.",
+                text=SEARCH_RTR_PUT_FILES_FQL_DOCUMENTATION,
+            ),
+            TextResource(
+                uri=AnyUrl("falcon://rtr-admin/workflows/admin-guide"),
+                name="falcon_rtr_admin_tool_use_guide",
+                description="Contains RTR Admin inventory, preview, execution, and polling guidance.",
+                text=RTR_ADMIN_TOOL_USE_GUIDE,
+            ),
+            TextResource(
+                uri=AnyUrl("falcon://rtr-admin/commands/runscript-guide"),
+                name="falcon_rtr_admin_runscript_raw_guide",
+                description="Contains RTR Admin runscript raw command construction guidance.",
+                text=RTR_ADMIN_RUNSCRIPT_RAW_GUIDE,
+            ),
+        ]
+
+        for resource in resources:
+            self._add_resource(server, resource)
+
+    def search_scripts(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description=EMBEDDED_SCRIPT_FQL_SYNTAX,
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            le=5000,
+            description="Maximum number of custom script IDs to return. Max: 5000.",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index of overall result set from which to return IDs.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Sort custom scripts by a supported field such as `created_at|desc`.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search RTR custom scripts and return full metadata records.
+
+        Use this to find reusable custom RTR scripts by name, platform, or
+        permission type. Consult falcon://rtr-admin/scripts/search/fql-guide
+        before constructing filter expressions.
+        """
+        return self._search_and_get_details(
+            search_operation="RTR_ListScripts",
+            get_operation="RTR_GetScriptsV2",
+            filter=filter,
+            limit=limit,
+            offset=offset,
+            sort=sort,
+            fql_documentation=SEARCH_RTR_ADMIN_SCRIPTS_FQL_DOCUMENTATION,
+        )
+
+    def get_script_details(
+        self,
+        ids: list[str] = Field(description="Custom RTR script IDs to retrieve."),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve custom RTR script metadata and content by script ID."""
+        return self._get_details("RTR_GetScriptsV2", ids)
+
+    def search_falcon_scripts(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description=EMBEDDED_FALCON_SCRIPT_FQL_SYNTAX,
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            le=100,
+            description="Maximum number of Falcon script IDs to return. Max: 100.",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index of overall result set from which to return IDs.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Sort Falcon scripts by a supported field such as `name|asc`.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search CrowdStrike-provided Falcon scripts and return full records.
+
+        Use this to find CrowdStrike-provided RTR scripts by name or platform.
+        Consult falcon://rtr-admin/falcon-scripts/search/fql-guide before
+        constructing filter expressions.
+        """
+        return self._search_and_get_details(
+            search_operation="RTR_ListFalconScripts",
+            get_operation="RTR_GetFalconScripts",
+            filter=filter,
+            limit=limit,
+            offset=offset,
+            sort=sort,
+            fql_documentation=SEARCH_RTR_FALCON_SCRIPTS_FQL_DOCUMENTATION,
+        )
+
+    def get_falcon_script_details(
+        self,
+        ids: list[str] = Field(description="Falcon script IDs to retrieve."),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve CrowdStrike-provided Falcon script metadata and content by ID."""
+        return self._get_details("RTR_GetFalconScripts", ids)
+
+    def search_put_files(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description=EMBEDDED_PUT_FILE_FQL_SYNTAX,
+        ),
+        limit: int = Field(
+            default=10,
+            ge=1,
+            le=5000,
+            description="Maximum number of put-file IDs to return. Max: 5000.",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="Starting index of overall result set from which to return IDs.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Sort put-files by a supported field such as `created_at|desc`.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search RTR put-files and return full metadata records.
+
+        Use this to review put-file inventory before considering an admin
+        command that references staged content. Consult
+        falcon://rtr-admin/put-files/search/fql-guide before constructing
+        filter expressions.
+        """
+        return self._search_and_get_details(
+            search_operation="RTR_ListPut_Files",
+            get_operation="RTR_GetPut_FilesV2",
+            filter=filter,
+            limit=limit,
+            offset=offset,
+            sort=sort,
+            fql_documentation=SEARCH_RTR_PUT_FILES_FQL_DOCUMENTATION,
+        )
+
+    def get_put_file_details(
+        self,
+        ids: list[str] = Field(description="RTR put-file IDs to retrieve."),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve RTR put-file metadata by ID.
+
+        This tool intentionally returns metadata only. It does not expose
+        put-file content retrieval in the first RTR Admin slice.
+        """
+        return self._get_details("RTR_GetPut_FilesV2", ids)
+
+    def check_admin_command_status(
+        self,
+        cloud_request_id: str = Field(
+            description="Cloud request ID returned from a prior RTR Admin command.",
+        ),
+        sequence_id: int = Field(
+            default=0,
+            ge=0,
+            description="Sequence chunk to retrieve for command output. Starts at 0.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Retrieve status and output for a prior RTR Admin command.
+
+        This is a read-only status lookup. It cannot start a new command.
+        """
+        cloud_request_id = _normalize_field_value(cloud_request_id)
+        sequence_id = _normalize_field_value(sequence_id)
+
+        if not isinstance(cloud_request_id, str) or not cloud_request_id.strip():
+            return _format_error_response(
+                "cloud_request_id is required to check RTR Admin command status. "
+                "No Falcon call was made."
+            )
+
+        if not isinstance(sequence_id, int) or sequence_id < 0:
+            return _format_error_response(
+                "sequence_id must be a non-negative integer. No Falcon call was made."
+            )
+
+        return self._base_query_api_call(
+            operation="RTR_CheckAdminCommandStatus",
+            query_params={
+                "cloud_request_id": cloud_request_id,
+                "sequence_id": sequence_id,
+            },
+            error_message="Failed to check RTR Admin command status",
+        )
+
+    def classify_admin_command(
+        self,
+        base_command: str = Field(
+            description="RTR Admin base command to classify, such as `get`, `runscript`, `rm`, or `reg`.",
+        ),
+        command_string: str | None = Field(
+            default=None,
+            description="Optional full command line for subcommand-sensitive checks, such as `reg query ...`.",
+        ),
+    ) -> dict[str, Any]:
+        """Classify an RTR Admin command without executing it.
+
+        Use this before designing or approving any RTR Admin execution flow.
+        This policy helper is intentionally local and does not call Falcon.
+        """
+        base_command = _normalize_field_value(base_command)
+        command_string = _normalize_field_value(command_string)
+
+        if not isinstance(base_command, str) or not base_command.strip():
+            return _format_error_response(
+                "base_command is required. Provide an RTR Admin base command such "
+                "as `ps`, `get`, `reg`, `runscript`, or `rm`. No Falcon call was made."
+            )
+
+        normalized = base_command.strip().lower()
+        command_text = command_string.strip() if isinstance(command_string, str) else ""
+        command_lower = command_text.lower()
+
+        if normalized in READ_ONLY_ADMIN_COMMANDS:
+            return self._classification(
+                normalized,
+                "read_only",
+                "low",
+                True,
+                "Command is normally read-only in RTR Admin.",
+            )
+
+        if normalized == "reg":
+            if command_lower.split()[:2] == ["reg", "query"]:
+                return self._classification(
+                    normalized,
+                    "read_only",
+                    "low",
+                    True,
+                    "`reg query` is read-only; other registry subcommands are blocked.",
+                )
+            return self._classification(
+                normalized,
+                "high_impact",
+                "critical",
+                False,
+                "Registry writes, loads, unloads, and deletes require explicit operator approval.",
+                requires_approval=True,
+                can_execute_with_approval=True,
+            )
+
+        if normalized == "update":
+            update_tokens = command_lower.split()
+            if len(update_tokens) >= 2 and update_tokens[1] in READ_ONLY_UPDATE_SUBCOMMANDS:
+                return self._classification(
+                    normalized,
+                    "read_only",
+                    "low",
+                    True,
+                    "`update history`, `update list`, and `update query` are read-only; "
+                    "update installs are blocked.",
+                )
+            return self._classification(
+                normalized,
+                "high_impact",
+                "critical",
+                False,
+                "Sensor update install actions require explicit operator approval.",
+                requires_approval=True,
+                can_execute_with_approval=True,
+            )
+
+        if normalized in EVIDENCE_COLLECTION_COMMANDS:
+            return self._classification(
+                normalized,
+                "evidence_collection",
+                "medium",
+                True,
+                "Command can collect files from a chosen host and needs explicit target review.",
+            )
+
+        if normalized == "runscript":
+            return self._classification(
+                normalized,
+                "script_execution",
+                "critical",
+                False,
+                "Script execution is high risk and requires explicit operator approval.",
+                requires_approval=True,
+                can_execute_with_approval=True,
+            )
+
+        if normalized in SENSITIVE_COLLECTION_COMMANDS:
+            return self._classification(
+                normalized,
+                "sensitive_collection",
+                "high",
+                False,
+                "Memory dump commands can collect sensitive data and require explicit operator approval.",
+                requires_approval=True,
+                can_execute_with_approval=True,
+            )
+
+        if normalized in BLOCKED_ADMIN_COMMANDS:
+            return self._classification(
+                normalized,
+                "high_impact",
+                "critical",
+                False,
+                "Command can write, delete, execute, disrupt, or stage material on a host and requires explicit operator approval.",
+                requires_approval=True,
+                can_execute_with_approval=True,
+            )
+
+        return self._classification(
+            normalized,
+            "unknown",
+            "unknown",
+            False,
+            "Unknown RTR Admin command. It is blocked until reviewed and explicitly allowlisted.",
+        )
+
+    def preview_admin_command(
+        self,
+        session_id: str = Field(description="RTR session ID that would receive the command."),
+        device_id: str | None = Field(
+            default=None,
+            description="Optional host agent ID included in the preview target and Falcon body when supplied.",
+        ),
+        base_command: str = Field(description="RTR Admin base command to preview."),
+        command_string: str = Field(description="Full RTR Admin command string to preview."),
+        command_id: int | None = Field(
+            default=None,
+            ge=0,
+            description="Optional command sequence ID that would be sent as `id` in the Falcon body.",
+        ),
+        target_hostname: str | None = Field(
+            default=None,
+            description="Optional hostname for human review of the selected target.",
+        ),
+        reason: str | None = Field(
+            default=None,
+            description="Why this command is being considered.",
+        ),
+        ticket: str | None = Field(
+            default=None,
+            description="Ticket, case, or incident identifier for audit context.",
+        ),
+        expected_effect: str | None = Field(
+            default=None,
+            description="Expected endpoint effect if this command were executed later.",
+        ),
+        persist: bool = Field(
+            default=False,
+            description="Whether the command would be persisted. Defaults false.",
+        ),
+    ) -> dict[str, Any]:
+        """Preview an RTR Admin command payload without executing it.
+
+        This tool returns the exact Falcon operation and body shape that a later
+        execution tool would use, plus local policy classification. It never
+        calls Falcon and cannot execute the command.
+        """
+        session_id = _normalize_field_value(session_id)
+        device_id = _normalize_field_value(device_id)
+        base_command = _normalize_field_value(base_command)
+        command_string = _normalize_field_value(command_string)
+        command_id = _normalize_field_value(command_id)
+        target_hostname = _normalize_field_value(target_hostname)
+        reason = _normalize_field_value(reason)
+        ticket = _normalize_field_value(ticket)
+        expected_effect = _normalize_field_value(expected_effect)
+        persist = _normalize_field_value(persist)
+
+        missing_required = []
+        if not isinstance(session_id, str) or not session_id.strip():
+            missing_required.append("session_id")
+        if not isinstance(base_command, str) or not base_command.strip():
+            missing_required.append("base_command")
+        if not isinstance(command_string, str) or not command_string.strip():
+            missing_required.append("command_string")
+
+        if missing_required:
+            return _format_error_response(
+                "RTR Admin command preview requires non-empty session_id, "
+                "base_command, and command_string. No Falcon call was made.",
+                details={"missing_required": missing_required},
+            )
+
+        classification = self.classify_admin_command(base_command, command_string)
+        if self._is_error(classification):
+            return classification
+
+        body = self._execute_admin_command_body(
+            base_command=base_command,
+            command_string=command_string,
+            session_id=session_id,
+            device_id=device_id,
+            command_id=command_id,
+            persist=bool(persist),
+        )
+        approval_gate = self._approval_gate(
+            operation="RTR_ExecuteAdminCommand",
+            classification=classification,
+            payload={"body": prepare_api_parameters(body)},
+            target={
+                "session_id": session_id,
+                "device_id": device_id,
+                "hostname": target_hostname,
+            },
+        )
+
+        required_context = {
+            "reason": reason,
+            "ticket": ticket,
+            "expected_effect": expected_effect,
+        }
+        missing_context = [key for key, value in required_context.items() if not value]
+
+        return {
+            "execution_available": True,
+            "execution_tool": "falcon_execute_rtr_admin_command",
+            "policy_allows_future_execution": classification["allowed_for_execution"],
+            "policy_note": (
+                "Classification is enforced before Falcon calls. High-impact "
+                "commands require the exact operator approval phrase returned "
+                "by this preview or by a blocked execution attempt."
+            ),
+            "classification_enforced": True,
+            "classification": classification,
+            "safety_disclaimer": RTR_ADMIN_SAFETY_DISCLAIMER,
+            "command_guidance": self._command_guidance(base_command, command_string),
+            "missing_context": missing_context,
+            "required_context": list(required_context.keys()),
+            "target": {
+                "session_id": session_id,
+                "device_id": device_id,
+                "hostname": target_hostname,
+            },
+            "operation": "RTR_ExecuteAdminCommand",
+            "payload_preview": {
+                "body": prepare_api_parameters(body),
+            },
+            "review_note": (
+                "This preview does not call Falcon. Use the execution tool only "
+                "after reviewing the target and expected endpoint effect."
+            ),
+            "approval_gate": approval_gate,
+        }
+
+    def execute_admin_command(
+        self,
+        base_command: str = Field(description="RTR Admin base command to execute."),
+        command_string: str = Field(description="Full RTR Admin command string to execute."),
+        session_id: str | None = Field(
+            default=None,
+            description="RTR session ID to execute the command against.",
+        ),
+        device_id: str | None = Field(
+            default=None,
+            description="Optional device AID for human review. Falcon execution requires session_id.",
+        ),
+        command_id: int | None = Field(
+            default=None,
+            ge=0,
+            description="Optional command sequence ID sent as `id` in the Falcon body.",
+        ),
+        persist: bool = Field(
+            default=False,
+            description="Execute when the host returns to service. Defaults false.",
+        ),
+        target_hostname: str | None = Field(
+            default=None,
+            description="Optional hostname for human review. Not sent to Falcon.",
+        ),
+        reason: str | None = Field(
+            default=None,
+            description="Why this command is being executed.",
+        ),
+        ticket: str | None = Field(
+            default=None,
+            description="Ticket, case, or incident identifier for audit context.",
+        ),
+        expected_effect: str | None = Field(
+            default=None,
+            description="Expected endpoint effect of the command.",
+        ),
+        operator_approval: str | None = Field(
+            default=None,
+            description=(
+                "Exact approval phrase required for high-impact RTR Admin commands. "
+                "Get it from preview or from the approval-required response after "
+                "human review."
+            ),
+        ),
+    ) -> dict[str, Any]:
+        """Execute an RTR Admin command on a single host.
+
+        High-impact commands are blocked before the Falcon API call unless the
+        exact operator approval phrase for this payload is supplied.
+        """
+        base_command = _normalize_field_value(base_command)
+        command_string = _normalize_field_value(command_string)
+        session_id = _normalize_field_value(session_id)
+        device_id = _normalize_field_value(device_id)
+        command_id = _normalize_field_value(command_id)
+        persist = _normalize_field_value(persist)
+        target_hostname = _normalize_field_value(target_hostname)
+        reason = _normalize_field_value(reason)
+        ticket = _normalize_field_value(ticket)
+        expected_effect = _normalize_field_value(expected_effect)
+        operator_approval = _normalize_field_value(operator_approval)
+
+        missing_required = []
+        if not isinstance(base_command, str) or not base_command.strip():
+            missing_required.append("base_command")
+        if not isinstance(command_string, str) or not command_string.strip():
+            missing_required.append("command_string")
+        if not self._has_text(session_id):
+            missing_required.append("session_id")
+
+        if missing_required:
+            return _format_error_response(
+                "RTR Admin command execution requires base_command, command_string, "
+                "and session_id. No Falcon call was made.",
+                details={"missing_required": missing_required},
+            )
+
+        classification = self.classify_admin_command(base_command, command_string)
+        if self._is_error(classification):
+            return classification
+
+        body = self._execute_admin_command_body(
+            base_command=base_command,
+            command_string=command_string,
+            session_id=session_id,
+            device_id=device_id,
+            command_id=command_id,
+            persist=bool(persist),
+        )
+        payload = {"body": prepare_api_parameters(body)}
+        target = {
+            "session_id": session_id,
+            "device_id": device_id,
+            "hostname": target_hostname,
+        }
+        approval_gate = self._approval_gate(
+            operation="RTR_ExecuteAdminCommand",
+            classification=classification,
+            payload=payload,
+            target=target,
+        )
+        policy_error = self._enforce_admin_command_policy(
+            classification=classification,
+            approval_gate=approval_gate,
+            operator_approval=operator_approval,
+            target=target,
+            payload=payload,
+        )
+        if policy_error:
+            return policy_error
+
+        result = self._base_query_api_call(
+            operation="RTR_ExecuteAdminCommand",
+            body_params=body,
+            error_message="Failed to execute RTR Admin command",
+        )
+
+        return self._execution_response(
+            operation="RTR_ExecuteAdminCommand",
+            result=result,
+            classification=classification,
+            approval_gate=approval_gate,
+            target=target,
+            missing_context=self._missing_audit_context(reason, ticket, expected_effect),
+            payload=payload,
+        )
+
+    def _search_and_get_details(
+        self,
+        search_operation: str,
+        get_operation: str,
+        filter: str | None,
+        limit: int,
+        offset: int | None,
+        sort: str | None,
+        fql_documentation: str,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        ids = self._base_search_api_call(
+            operation=search_operation,
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+            },
+            error_message=f"Failed to search RTR Admin resources with {search_operation}",
+        )
+
+        if self._is_error(ids):
+            return self._format_fql_error_response([ids], filter, fql_documentation)
+
+        if not ids:
+            return self._format_fql_error_response([], filter, fql_documentation)
+
+        details = self._base_get_by_ids(
+            operation=get_operation,
+            ids=ids,
+            use_params=True,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        return details
+
+    def _get_details(
+        self,
+        operation: str,
+        ids: list[str],
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        if not ids:
+            return []
+
+        details = self._base_get_by_ids(
+            operation=operation,
+            ids=ids,
+            use_params=True,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        return details
+
+    def _classification(
+        self,
+        base_command: str,
+        category: str,
+        risk: str,
+        allowed_for_execution: bool,
+        explanation: str,
+        requires_approval: bool = False,
+        can_execute_with_approval: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "base_command": base_command,
+            "category": category,
+            "risk": risk,
+            "allowed_for_execution": allowed_for_execution,
+            "requires_approval": requires_approval,
+            "can_execute_with_approval": can_execute_with_approval,
+            "explanation": explanation,
+            "blocked_reason": None if allowed_for_execution else explanation,
+            "requires_explicit_target": allowed_for_execution,
+            "safety_disclaimer": RTR_ADMIN_SAFETY_DISCLAIMER,
+        }
+
+    def _execute_admin_command_body(
+        self,
+        base_command: str,
+        command_string: str,
+        session_id: str | None,
+        device_id: str | None,
+        command_id: int | None,
+        persist: bool,
+    ) -> dict[str, Any]:
+        return {
+            "base_command": base_command,
+            "command_string": command_string,
+            "device_id": device_id,
+            "session_id": session_id,
+            "id": command_id,
+            "persist": persist,
+        }
+
+    def _execution_response(
+        self,
+        operation: str,
+        result: list[dict[str, Any]] | dict[str, Any],
+        classification: dict[str, Any],
+        approval_gate: dict[str, Any],
+        target: dict[str, Any],
+        missing_context: list[str],
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        response: dict[str, Any] = {
+            "operation": operation,
+            "submitted": not self._is_error(result),
+            "result": result,
+            "classification": classification,
+            "classification_enforced": True,
+            "approval_gate": approval_gate | {"approved": True},
+            "safety_disclaimer": RTR_ADMIN_SAFETY_DISCLAIMER,
+            "command_guidance": self._command_guidance(
+                payload.get("body", {}).get("base_command"),
+                payload.get("body", {}).get("command_string"),
+            ),
+            "missing_context": missing_context,
+            "target": target,
+            "payload": payload,
+            "next_step": (
+                "Use `falcon_check_rtr_admin_command_status` with the returned "
+                "cloud_request_id to retrieve command output."
+            ),
+        }
+
+        if payload.get("body", {}).get("persist"):
+            response["persist_warning"] = (
+                "Persisted RTR Admin commands may run when offline hosts return "
+                "to service."
+            )
+
+        if missing_context:
+            response["context_warning"] = (
+                "Audit context is incomplete. Consider providing reason, ticket, "
+                "and expected_effect before live use."
+            )
+
+        return response
+
+    def _enforce_admin_command_policy(
+        self,
+        classification: dict[str, Any],
+        approval_gate: dict[str, Any],
+        operator_approval: str | None,
+        target: dict[str, Any],
+        payload: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        if classification.get("allowed_for_execution"):
+            return None
+
+        if not classification.get("requires_approval"):
+            return _format_error_response(
+                "RTR Admin command is blocked by local policy. No Falcon call was made.",
+                details={
+                    "classification": classification,
+                    "target": prepare_api_parameters(target),
+                    "payload_preview": payload,
+                    "approval_gate": approval_gate,
+                },
+            )
+
+        if operator_approval == approval_gate["approval_phrase"]:
+            return None
+
+        return _format_error_response(
+            "RTR Admin high-impact approval required before Falcon call. No Falcon call was made.",
+            details={
+                "classification": classification,
+                "target": prepare_api_parameters(target),
+                "payload_preview": payload,
+                "approval_gate": approval_gate,
+            },
+        )
+
+    def _approval_gate(
+        self,
+        operation: str,
+        classification: dict[str, Any],
+        payload: dict[str, Any],
+        target: dict[str, Any],
+    ) -> dict[str, Any]:
+        if not classification.get("requires_approval"):
+            return {
+                "approval_required": False,
+                "approved_by_default": True,
+                "reason": "Command classification does not require high-impact approval.",
+            }
+
+        approval_hash = self._approval_hash(
+            operation=operation,
+            classification=classification,
+            payload=payload,
+            target=target,
+        )
+        return {
+            "approval_required": True,
+            "approved_by_default": False,
+            "approval_phrase": f"APPROVE_RTR_ADMIN_{approval_hash}",
+            "approval_hash": approval_hash,
+            "reason": classification.get("blocked_reason") or classification.get("explanation"),
+            "instruction": (
+                "Ask the operator to review the exact target, command, expected effect, "
+                "and payload hash. Re-submit with operator_approval set to the exact "
+                "approval_phrase only after approval."
+            ),
+        }
+
+    def _approval_hash(
+        self,
+        operation: str,
+        classification: dict[str, Any],
+        payload: dict[str, Any],
+        target: dict[str, Any],
+    ) -> str:
+        material = {
+            "operation": operation,
+            "base_command": classification.get("base_command"),
+            "category": classification.get("category"),
+            "risk": classification.get("risk"),
+            "target": prepare_api_parameters(target),
+            "payload": payload,
+        }
+        serialized = json.dumps(material, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16].upper()
+
+    def _missing_audit_context(
+        self,
+        reason: str | None,
+        ticket: str | None,
+        expected_effect: str | None,
+    ) -> list[str]:
+        required_context = {
+            "reason": reason,
+            "ticket": ticket,
+            "expected_effect": expected_effect,
+        }
+        return [key for key, value in required_context.items() if not self._has_text(value)]
+
+    def _has_text(self, value: Any) -> bool:
+        return isinstance(value, str) and bool(value.strip())
+
+    def _command_guidance(
+        self,
+        base_command: Any,
+        command_string: Any,
+    ) -> dict[str, Any] | None:
+        if not isinstance(base_command, str):
+            return None
+
+        if base_command.strip().lower() != "runscript":
+            return None
+
+        warnings = [
+            "`runscript -Raw` is not an interactive terminal; submit one command and poll status.",
+            "Do not place RTR controller commands such as `get`, `put`, or status polling inside raw script bodies.",
+            "Use `falcon_check_rtr_admin_command_status` with the returned cloud_request_id.",
+        ]
+
+        if isinstance(command_string, str) and "-raw" in command_string.lower():
+            warnings.append(
+                "Raw script bodies are quoting-sensitive; avoid unescaped triple backticks."
+            )
+
+        return {
+            "resource": "falcon://rtr-admin/commands/runscript-guide",
+            "shape": "runscript -Raw=```<target-side script>```",
+            "cloud_file_shape": 'runscript -CloudFile="ScriptName" -CommandLine="<arguments>"',
+            "warnings": warnings,
+        }

--- a/falcon_mcp/modules/rtr_admin.py
+++ b/falcon_mcp/modules/rtr_admin.py
@@ -405,17 +405,22 @@ class RTRAdminModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="Sort custom scripts by a supported field such as `created_at|desc`.",
+            description="Sort custom scripts by a supported field such as `created_timestamp|desc`.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search RTR custom scripts and return full metadata records.
 
         Use this to find reusable custom RTR scripts by name, platform, or
-        permission type, or to look up known script IDs with an `id` filter.
-        Consult falcon://rtr-admin/scripts/search/fql-guide before constructing
-        filter expressions. Returns full script records including name, content,
-        platform, and permission details.
+        permission type. Consult falcon://rtr-admin/scripts/search/fql-guide
+        before constructing filter expressions. Returns full script records,
+        including script content; treat the response as sensitive operational
+        material.
         """
+        filter = unwrap_field_default(filter)
+        limit = unwrap_field_default(limit)
+        offset = unwrap_field_default(offset)
+        sort = unwrap_field_default(sort)
+
         ids = self._base_search_api_call(
             operation="RTR_ListScripts",
             search_params={
@@ -446,7 +451,7 @@ class RTRAdminModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        return self._order_details_by_ids(ids, details)
 
     def search_rtr_falcon_scripts(
         self,
@@ -474,9 +479,14 @@ class RTRAdminModule(BaseModule):
         Use this to find CrowdStrike-provided RTR scripts by name or platform,
         or to look up known script IDs with an `id` filter. Consult
         falcon://rtr-admin/falcon-scripts/search/fql-guide before constructing
-        filter expressions. Returns full script records including name,
-        description, and platform.
+        filter expressions. Returns full script records; treat any returned
+        script content as sensitive operational material.
         """
+        filter = unwrap_field_default(filter)
+        limit = unwrap_field_default(limit)
+        offset = unwrap_field_default(offset)
+        sort = unwrap_field_default(sort)
+
         ids = self._base_search_api_call(
             operation="RTR_ListFalconScripts",
             search_params={
@@ -507,7 +517,7 @@ class RTRAdminModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        return self._order_details_by_ids(ids, details)
 
     def search_rtr_put_files(
         self,
@@ -527,17 +537,21 @@ class RTRAdminModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="Sort put-files by a supported field such as `created_at|desc`.",
+            description="Sort put-files by a supported field such as `created_timestamp|desc`.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search RTR put-files and return full metadata records.
 
         Use this to review put-file inventory before considering an admin
-        command that references staged content, or to look up known put-file IDs
-        with an `id` filter. Consult falcon://rtr-admin/put-files/search/fql-guide
-        before constructing filter expressions. Returns full put-file metadata
-        records.
+        command that references staged content. Consult
+        falcon://rtr-admin/put-files/search/fql-guide before constructing
+        filter expressions. Returns full put-file metadata records.
         """
+        filter = unwrap_field_default(filter)
+        limit = unwrap_field_default(limit)
+        offset = unwrap_field_default(offset)
+        sort = unwrap_field_default(sort)
+
         ids = self._base_search_api_call(
             operation="RTR_ListPut_Files",
             search_params={
@@ -568,7 +582,7 @@ class RTRAdminModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        return self._order_details_by_ids(ids, details)
 
     def get_rtr_put_file_contents(
         self,
@@ -583,7 +597,9 @@ class RTRAdminModule(BaseModule):
         returned content can be sensitive because put-files may contain scripts,
         binaries, or operational payloads staged for RTR `put` workflows.
         Text content is returned for model review; binary content returns size
-        metadata and a safe error instead of raw bytes.
+        metadata and a safe error instead of raw bytes. Treat retrieval results
+        as sensitive regardless of inventory `file_type`; live testing showed
+        binary-tagged inventory can still retrieve text content.
         """
         file_id = unwrap_field_default(file_id)
 
@@ -605,6 +621,7 @@ class RTRAdminModule(BaseModule):
                     "id": file_id,
                     "content": response.decode("utf-8"),
                     "content_format": "text",
+                    "sensitivity_warning": self._put_file_content_warning(),
                 }
             except UnicodeDecodeError:
                 return {
@@ -629,9 +646,17 @@ class RTRAdminModule(BaseModule):
 
             body = response.get("body", {})
             if isinstance(body, dict) and "resources" in body:
-                return body.get("resources", [])
+                resources = body.get("resources", [])
+                if isinstance(resources, list):
+                    return [
+                        self._annotate_put_file_content(resource)
+                        if isinstance(resource, dict)
+                        else resource
+                        for resource in resources
+                    ]
+                return resources
             if body:
-                return {"id": file_id, "body": body}
+                return self._annotate_put_file_content({"id": file_id, "body": body})
             return []
 
         return {"error": f"Unexpected response type: {type(response).__name__}"}
@@ -705,6 +730,7 @@ class RTRAdminModule(BaseModule):
         command_text = command_string.strip() if isinstance(command_string, str) else ""
         command_lower = command_text.lower()
         command_base = command_lower.split(maxsplit=1)[0] if command_lower else None
+        command_warnings = self._command_shape_warnings(normalized, command_text)
 
         if command_base and command_base != normalized:
             return _format_error_response(
@@ -723,6 +749,7 @@ class RTRAdminModule(BaseModule):
                 "low",
                 True,
                 "Command is normally read-only in RTR Admin.",
+                command_warnings=command_warnings,
             )
 
         if normalized == "reg":
@@ -733,6 +760,7 @@ class RTRAdminModule(BaseModule):
                     "low",
                     True,
                     "`reg query` is read-only; other registry subcommands are blocked.",
+                    command_warnings=command_warnings,
                 )
             return self._classification(
                 normalized,
@@ -742,6 +770,7 @@ class RTRAdminModule(BaseModule):
                 "Registry writes, loads, unloads, and deletes require explicit operator approval.",
                 requires_approval=True,
                 can_execute_with_approval=True,
+                command_warnings=command_warnings,
             )
 
         if normalized == "update":
@@ -763,6 +792,7 @@ class RTRAdminModule(BaseModule):
                 "Sensor update install actions require explicit operator approval.",
                 requires_approval=True,
                 can_execute_with_approval=True,
+                command_warnings=command_warnings,
             )
 
         if normalized in EVIDENCE_COLLECTION_COMMANDS:
@@ -774,6 +804,7 @@ class RTRAdminModule(BaseModule):
                 "File exfiltration command requires explicit operator approval before execution.",
                 requires_approval=True,
                 can_execute_with_approval=True,
+                command_warnings=command_warnings,
             )
 
         if normalized == "runscript":
@@ -785,6 +816,7 @@ class RTRAdminModule(BaseModule):
                 "Script execution is high risk and requires explicit operator approval.",
                 requires_approval=True,
                 can_execute_with_approval=True,
+                command_warnings=command_warnings,
             )
 
         if normalized in SENSITIVE_COLLECTION_COMMANDS:
@@ -796,6 +828,7 @@ class RTRAdminModule(BaseModule):
                 "Memory dump commands can collect sensitive data and require explicit operator approval.",
                 requires_approval=True,
                 can_execute_with_approval=True,
+                command_warnings=command_warnings,
             )
 
         if normalized in BLOCKED_ADMIN_COMMANDS:
@@ -815,6 +848,7 @@ class RTRAdminModule(BaseModule):
             "unknown",
             False,
             "Unknown RTR Admin command. It is blocked until reviewed and explicitly allowlisted.",
+            command_warnings=command_warnings,
         )
 
     def preview_rtr_admin_command(
@@ -888,6 +922,9 @@ class RTRAdminModule(BaseModule):
         if self._is_error(classification):
             return classification
 
+        audit_context = self._audit_context(reason, ticket, expected_effect)
+        missing_context = self._missing_audit_context(reason, ticket, expected_effect)
+
         body = self._execute_admin_command_body(
             base_command=base_command,
             command_string=command_string,
@@ -905,14 +942,8 @@ class RTRAdminModule(BaseModule):
                 "device_id": device_id,
                 "hostname": target_hostname,
             },
+            audit_context=audit_context,
         )
-
-        required_context = {
-            "reason": reason,
-            "ticket": ticket,
-            "expected_effect": expected_effect,
-        }
-        missing_context = [key for key, value in required_context.items() if not value]
 
         return {
             "execution_available": True,
@@ -928,7 +959,7 @@ class RTRAdminModule(BaseModule):
             "safety_disclaimer": RTR_ADMIN_SAFETY_DISCLAIMER,
             "command_guidance": self._command_guidance(base_command, command_string),
             "missing_context": missing_context,
-            "required_context": list(required_context.keys()),
+            "required_context": list(audit_context.keys()),
             "target": {
                 "session_id": session_id,
                 "device_id": device_id,
@@ -1042,11 +1073,14 @@ class RTRAdminModule(BaseModule):
             "device_id": device_id,
             "hostname": target_hostname,
         }
+        audit_context = self._audit_context(reason, ticket, expected_effect)
+        missing_context = self._missing_audit_context(reason, ticket, expected_effect)
         approval_gate = self._approval_gate(
             operation="RTR_ExecuteAdminCommand",
             classification=classification,
             payload=payload,
             target=target,
+            audit_context=audit_context,
         )
         policy_error = self._enforce_admin_command_policy(
             classification=classification,
@@ -1070,7 +1104,7 @@ class RTRAdminModule(BaseModule):
             classification=classification,
             approval_gate=approval_gate,
             target=target,
-            missing_context=self._missing_audit_context(reason, ticket, expected_effect),
+            missing_context=missing_context,
             payload=payload,
         )
 
@@ -1263,6 +1297,8 @@ class RTRAdminModule(BaseModule):
                 f"Read-only update subcommands: {', '.join(sorted(READ_ONLY_UPDATE_SUBCOMMANDS))}",
                 "",
                 "`reg query` is read-only; other registry subcommands require approval.",
+                "`reg query` accepts only a small argument shape in Falcon RTR; keep key/value arguments minimal and preview warnings before live use.",
+                "Use `rm <directory> -force` for directory cleanup and verify stderr/stdout before assuming deletion succeeded.",
                 "`runscript` is always high impact and requires approval.",
                 "Unknown commands are blocked until reviewed and explicitly allowlisted.",
                 "For execution, `base_command` must match the first token of `command_string`.",
@@ -1278,6 +1314,7 @@ class RTRAdminModule(BaseModule):
         explanation: str,
         requires_approval: bool = False,
         can_execute_with_approval: bool = False,
+        command_warnings: list[str] | None = None,
     ) -> dict[str, Any]:
         return {
             "base_command": base_command,
@@ -1290,6 +1327,7 @@ class RTRAdminModule(BaseModule):
             "blocked_reason": None if allowed_for_execution else explanation,
             "requires_explicit_target": allowed_for_execution or can_execute_with_approval,
             "safety_disclaimer": RTR_ADMIN_SAFETY_DISCLAIMER,
+            "command_warnings": command_warnings or [],
         }
 
     def _execute_admin_command_body(
@@ -1389,6 +1427,11 @@ class RTRAdminModule(BaseModule):
         if timed_out:
             result["warning"] = "Timed out waiting for RTR Admin command completion."
 
+        if execute_response.get("context_warning"):
+            result["context_warning"] = execute_response["context_warning"]
+        if execute_response.get("missing_context"):
+            result["missing_context"] = execute_response["missing_context"]
+
         return result
 
     def _enforce_admin_command_policy(
@@ -1405,6 +1448,17 @@ class RTRAdminModule(BaseModule):
         if not classification.get("requires_approval"):
             return _format_error_response(
                 "RTR Admin command is blocked by local policy. No Falcon call was made.",
+                details={
+                    "classification": classification,
+                    "target": prepare_api_parameters(target),
+                    "payload_preview": payload,
+                    "approval_gate": approval_gate,
+                },
+            )
+
+        if not approval_gate.get("approval_ready", True):
+            return _format_error_response(
+                "RTR Admin approval context is incomplete. No Falcon call was made.",
                 details={
                     "classification": classification,
                     "target": prepare_api_parameters(target),
@@ -1432,6 +1486,7 @@ class RTRAdminModule(BaseModule):
         classification: dict[str, Any],
         payload: dict[str, Any],
         target: dict[str, Any],
+        audit_context: dict[str, Any],
     ) -> dict[str, Any]:
         if not classification.get("requires_approval"):
             return {
@@ -1440,15 +1495,35 @@ class RTRAdminModule(BaseModule):
                 "reason": "Command classification does not require high-impact approval.",
             }
 
+        missing_approval_context = self._missing_approval_context(
+            audit_context=audit_context,
+            target=target,
+        )
+        if missing_approval_context:
+            return {
+                "approval_required": True,
+                "approved_by_default": False,
+                "approval_ready": False,
+                "missing_approval_context": missing_approval_context,
+                "reason": classification.get("blocked_reason") or classification.get("explanation"),
+                "instruction": (
+                    "Provide device_id, reason, ticket, and expected_effect before "
+                    "requesting high-impact approval. No approval phrase is issued "
+                    "until the approval packet can bind target, payload, and audit context."
+                ),
+            }
+
         approval_hash = self._approval_hash(
             operation=operation,
             classification=classification,
             payload=payload,
             target=target,
+            audit_context=audit_context,
         )
         return {
             "approval_required": True,
             "approved_by_default": False,
+            "approval_ready": True,
             "approval_phrase": f"APPROVE_RTR_ADMIN_{approval_hash}",
             "approval_hash": approval_hash,
             "reason": classification.get("blocked_reason") or classification.get("explanation"),
@@ -1465,6 +1540,7 @@ class RTRAdminModule(BaseModule):
         classification: dict[str, Any],
         payload: dict[str, Any],
         target: dict[str, Any],
+        audit_context: dict[str, Any],
     ) -> str:
         hash_target = {
             k: v for k, v in target.items() if k in ("session_id", "device_id")
@@ -1475,10 +1551,27 @@ class RTRAdminModule(BaseModule):
             "category": classification.get("category"),
             "risk": classification.get("risk"),
             "target": prepare_api_parameters(hash_target),
+            "audit_context": prepare_api_parameters(audit_context),
             "payload": payload,
         }
         serialized = json.dumps(material, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16].upper()
+
+    def _audit_context(
+        self,
+        reason: str | None,
+        ticket: str | None,
+        expected_effect: str | None,
+    ) -> dict[str, Any]:
+        return {
+            "reason": reason.strip() if isinstance(reason, str) else reason,
+            "ticket": ticket.strip() if isinstance(ticket, str) else ticket,
+            "expected_effect": (
+                expected_effect.strip()
+                if isinstance(expected_effect, str)
+                else expected_effect
+            ),
+        }
 
     def _missing_audit_context(
         self,
@@ -1496,6 +1589,65 @@ class RTRAdminModule(BaseModule):
     def _has_text(self, value: Any) -> bool:
         return isinstance(value, str) and bool(value.strip())
 
+    def _missing_approval_context(
+        self,
+        audit_context: dict[str, Any],
+        target: dict[str, Any],
+    ) -> list[str]:
+        missing = [
+            key for key, value in audit_context.items() if not self._has_text(value)
+        ]
+        if not self._has_text(target.get("device_id")):
+            missing.append("device_id")
+        return missing
+
+    def _put_file_content_warning(self) -> str:
+        return (
+            "RTR put-file content retrieval is sensitive regardless of inventory "
+            "file_type. Live testing showed put-file metadata can say binary while "
+            "retrieval returns text content."
+        )
+
+    def _annotate_put_file_content(self, item: dict[str, Any]) -> dict[str, Any]:
+        content_format = item.get("content_format")
+        has_text_content = "content" in item or (
+            isinstance(item.get("body"), dict) and "content" in item["body"]
+        )
+        if content_format == "binary":
+            return item
+        if has_text_content:
+            return item | {"sensitivity_warning": self._put_file_content_warning()}
+        return item
+
+    def _order_details_by_ids(
+        self,
+        ids: list[str],
+        details: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Preserve query/list result order after Falcon detail lookups."""
+        order = {entity_id: index for index, entity_id in enumerate(ids)}
+        return sorted(
+            details,
+            key=lambda item: order.get(str(item.get("id")), len(order)),
+        )
+
+    def _command_shape_warnings(
+        self,
+        base_command: str,
+        command_string: str,
+    ) -> list[str]:
+        if base_command != "reg":
+            return []
+
+        tokens = command_string.split()
+        if len(tokens) > 3 and [token.lower() for token in tokens[:2]] == ["reg", "query"]:
+            return [
+                "`reg query` reached Falcon with HTTP 400 during live testing when more "
+                "than two arguments followed `reg`. Keep the query shape to "
+                "`reg query <key>` or quote paths with spaces before live use."
+            ]
+        return []
+
     def _command_guidance(
         self,
         base_command: Any,
@@ -1504,7 +1656,18 @@ class RTRAdminModule(BaseModule):
         if not isinstance(base_command, str):
             return None
 
-        if base_command.strip().lower() != "runscript":
+        normalized = base_command.strip().lower()
+        shape_warnings = self._command_shape_warnings(
+            normalized,
+            command_string if isinstance(command_string, str) else "",
+        )
+
+        if normalized == "reg" and shape_warnings:
+            return {
+                "warnings": shape_warnings,
+            }
+
+        if normalized != "runscript":
             return None
 
         warnings = [
@@ -1517,6 +1680,7 @@ class RTRAdminModule(BaseModule):
             warnings.append(
                 "Raw script bodies are quoting-sensitive; avoid unescaped triple backticks."
             )
+        warnings.extend(shape_warnings)
 
         return {
             "resource": "falcon://rtr-admin/commands/runscript-guide",

--- a/falcon_mcp/registry.py
+++ b/falcon_mcp/registry.py
@@ -39,8 +39,13 @@ def discover_modules() -> None:
                 if attr_name.endswith("Module") and attr_name != "BaseModule":
                     # Get the class
                     module_class = getattr(module, attr_name)
-                    # Register it
-                    module_name = attr_name.lower().replace("module", "")
+                    # Register it. Modules may override the discovered name when
+                    # CamelCase would produce an awkward CLI/module key.
+                    module_name = getattr(
+                        module_class,
+                        "MODULE_NAME",
+                        attr_name.lower().replace("module", ""),
+                    )
                     AVAILABLE_MODULES[module_name] = module_class
                     logger.debug("Discovered module: %s", module_name)
 

--- a/falcon_mcp/resources/quarantine.py
+++ b/falcon_mcp/resources/quarantine.py
@@ -33,7 +33,7 @@ SEARCH_QUARANTINED_FILES_FQL_FILTERS = [
     (
         "hostname",
         "String",
-        "Host name tied to the quarantine event (top-level field). Example: hostname:'BRR-WB-LIB-22'",
+        "Host name tied to the quarantine event (top-level field). Example: hostname:'EXAMPLE-WIN-22'",
     ),
     (
         "behaviors.username",
@@ -81,7 +81,7 @@ field_name:[operator]'value'
 === EXAMPLES ===
 
 # Quarantined files for a host
-hostname:'BRR-WB-LIB-22'
+hostname:'EXAMPLE-WIN-22'
 
 # Records updated recently
 date_updated:>'2026-03-01T00:00:00Z'

--- a/falcon_mcp/resources/rtr.py
+++ b/falcon_mcp/resources/rtr.py
@@ -75,9 +75,9 @@ SEARCH_RTR_SESSIONS_FQL_FILTERS = [
         "id",
         "String",
         """
-        RTR session ID. Live testing showed exact ID filtering can be
-        API-shape dependent; if no rows return, fall back to aid/hostname plus
-        bounded created_at and inspect returned session IDs client-side.
+        RTR session ID. Exact ID filtering can be API-shape dependent; if no
+        rows return, fall back to aid/hostname plus bounded created_at and
+        inspect returned session IDs client-side.
         Ex: 9f3c5e7a-1234-5678-abcd-ef0123456789
         """,
     ),
@@ -142,10 +142,10 @@ SEARCH_RTR_SESSIONS_FQL_FILTERS = [
         "cloud_request_id",
         "String",
         """
-        Cloud request ID associated with a command execution. Live testing
-        showed exact filtering can be API-shape dependent; if no rows return,
-        fall back to aid/hostname plus bounded created_at and inspect returned
-        command logs client-side.
+        Cloud request ID associated with a command execution. Exact filtering
+        can be API-shape dependent; if no rows return, fall back to
+        aid/hostname plus bounded created_at and inspect returned command logs
+        client-side.
         Ex: a1b2c3d4-5678-90ab-cdef-1234567890ab
         """,
     ),
@@ -245,10 +245,9 @@ SEARCH_RTR_AUDIT_SESSIONS_FQL_FILTERS = [
         "String",
         """
         Cloud request ID associated with command execution. This is most
-        useful when with_command_info=true is enabled. Live testing showed
-        exact filtering can be API-shape dependent; if no rows return, fall
-        back to aid/hostname plus bounded created_at and inspect returned
-        command logs client-side.
+        useful when with_command_info=true is enabled. Exact filtering can be
+        API-shape dependent; if no rows return, fall back to aid/hostname plus
+        bounded created_at and inspect returned command logs client-side.
         Ex: a1b2c3d4-5678-90ab-cdef-1234567890ab
         """,
     ),

--- a/falcon_mcp/resources/rtr.py
+++ b/falcon_mcp/resources/rtr.py
@@ -30,8 +30,13 @@ COMMON FIELDS:
 - command_string: Full command line executed
 - offline_queued: Whether session was queued offline (true/false)
 
+LOOKUP NOTES:
+- Direct session id and cloud_request_id filters can be environment/API-shape dependent.
+- For command history, prefer aid or hostname plus a bounded created_at window and optional base_command.
+- Inspect returned session command logs client-side for exact session IDs and cloud request IDs.
+
 EXAMPLES:
-- Sessions for a host: hostname:'BRR-WB-LIB-22'
+- Sessions for a host: hostname:'EXAMPLE-WIN-22'
 - Sessions by agent ID: aid:'2c5c4e7738004deaa9dfcdb86f633f3e'
 - Current user sessions: user_id:'@me'
 - Offline-queued sessions: offline_queued:true+hostname:'DC*'
@@ -50,6 +55,8 @@ COMMON STARTING POINTS:
 - Use created_at or updated_at filters to keep audit searches time-bound.
 - Set with_command_info=true when you need command IDs and command log context.
 - If a field is rejected by Falcon, reduce to a timestamp-bounded search and inspect returned fields.
+- Direct cloud_request_id filters can be environment/API-shape dependent; if they return no rows,
+  search by aid or hostname plus a bounded created_at window and inspect command logs client-side.
 
 EXAMPLES:
 - Recent RTR audit sessions: created_at:>'now-7d'
@@ -68,7 +75,9 @@ SEARCH_RTR_SESSIONS_FQL_FILTERS = [
         "id",
         "String",
         """
-        RTR session ID.
+        RTR session ID. Live testing showed exact ID filtering can be
+        API-shape dependent; if no rows return, fall back to aid/hostname plus
+        bounded created_at and inspect returned session IDs client-side.
         Ex: 9f3c5e7a-1234-5678-abcd-ef0123456789
         """,
     ),
@@ -109,7 +118,7 @@ SEARCH_RTR_SESSIONS_FQL_FILTERS = [
         "String",
         """
         Hostname of the connected host.
-        Ex: BRR-WB-LIB-22
+        Ex: EXAMPLE-WIN-22
         """,
     ),
     (
@@ -133,7 +142,10 @@ SEARCH_RTR_SESSIONS_FQL_FILTERS = [
         "cloud_request_id",
         "String",
         """
-        Cloud request ID associated with a command execution.
+        Cloud request ID associated with a command execution. Live testing
+        showed exact filtering can be API-shape dependent; if no rows return,
+        fall back to aid/hostname plus bounded created_at and inspect returned
+        command logs client-side.
         Ex: a1b2c3d4-5678-90ab-cdef-1234567890ab
         """,
     ),
@@ -159,14 +171,6 @@ SEARCH_RTR_SESSIONS_FQL_FILTERS = [
         "Boolean",
         """
         Whether the session was queued for offline execution.
-        Ex: true
-        """,
-    ),
-    (
-        "commands_queued",
-        "Boolean",
-        """
-        Whether commands are queued in the session.
         Ex: true
         """,
     ),
@@ -216,7 +220,7 @@ SEARCH_RTR_AUDIT_SESSIONS_FQL_FILTERS = [
         "String",
         """
         Hostname associated with the audited RTR activity.
-        Ex: BRR-WB-LIB-22
+        Ex: EXAMPLE-WIN-22
         """,
     ),
     (
@@ -241,7 +245,10 @@ SEARCH_RTR_AUDIT_SESSIONS_FQL_FILTERS = [
         "String",
         """
         Cloud request ID associated with command execution. This is most
-        useful when with_command_info=true is enabled.
+        useful when with_command_info=true is enabled. Live testing showed
+        exact filtering can be API-shape dependent; if no rows return, fall
+        back to aid/hostname plus bounded created_at and inspect returned
+        command logs client-side.
         Ex: a1b2c3d4-5678-90ab-cdef-1234567890ab
         """,
     ),
@@ -250,7 +257,9 @@ SEARCH_RTR_AUDIT_SESSIONS_FQL_FILTERS = [
         "String",
         """
         RTR base command name. This is most useful when with_command_info=true
-        is enabled.
+        is enabled, but exact command filters can be API-shape dependent on the
+        audit endpoint. If no rows return, fall back to aid/hostname plus
+        bounded created_at and inspect returned command logs client-side.
         Ex: ps
         """,
     ),
@@ -259,7 +268,10 @@ SEARCH_RTR_AUDIT_SESSIONS_FQL_FILTERS = [
         "String",
         """
         Full RTR command line string. This is most useful when
-        with_command_info=true is enabled.
+        with_command_info=true is enabled, but exact command filters can be
+        API-shape dependent on the audit endpoint. If no rows return, fall back
+        to aid/hostname plus bounded created_at and inspect returned command
+        logs client-side.
         Ex: cat C:\\Windows\\win.ini
         """,
     ),
@@ -308,7 +320,7 @@ Examples: 'created_at.desc', 'hostname.asc'
 === COMPLEX FILTER EXAMPLES ===
 
 # Sessions for a specific host
-hostname:'BRR-WB-LIB-22'
+hostname:'EXAMPLE-WIN-22'
 
 # Sessions by agent ID
 aid:'2c5c4e7738004deaa9dfcdb86f633f3e'
@@ -331,8 +343,8 @@ origin:'falcon-mcp'+user_id:'@me'
 # Sessions matching multiple commands
 (base_command:'ls',base_command:'cat',base_command:'filehash')+hostname:'WEB*'
 
-# Recent sessions for a host with queued commands
-commands_queued:true+created_at:>'2025-03-10T00:00:00Z'
+# Recent offline-queued sessions
+offline_queued:true+created_at:>'2025-03-10T00:00:00Z'
 
 # Deleted sessions after a timestamp for an agent
 deleted_at:>'2025-03-10T00:00:00Z'+aid:'2c5c4e7738004deaa9dfcdb86f633f3e'
@@ -366,6 +378,9 @@ The RTR audit API uses pipe-style sort examples such as:
 === COMMAND INFO ===
 Set with_command_info=true when the investigation needs cloud request IDs and command log fields.
 Leave it false for lighter timeline searches.
+Direct cloud_request_id filters can be environment/API-shape dependent. If an
+exact lookup returns no rows, search by aid or hostname plus a bounded created_at
+window and inspect returned command logs client-side.
 
 === falcon_search_rtr_audit_sessions FQL filter fields ===
 
@@ -383,10 +398,9 @@ hostname:'DC*'+created_at:>'now-7d'
 user_id:'@me'+created_at:>'now-7d'
 
 # Command-focused audit search
-base_command:'ps'+created_at:>'now-7d'
+aid:'2c5c4e7738004deaa9dfcdb86f633f3e'+created_at:>'now-7d'
 
-# Audit search for a command request
-cloud_request_id:'a1b2c3d4-5678-90ab-cdef-1234567890ab'
+# Then inspect returned command logs for cloud_request_id, base_command, and command_string.
 """
 
 AGGREGATE_RTR_SESSIONS_GUIDE = """RTR Session Aggregation Guide
@@ -407,7 +421,6 @@ Recommended filters:
 - user_id:'@me'
 - hostname:'DC*'
 - offline_queued:true
-- commands_queued:true
 
 Example terms aggregation:
 - aggregate_type: terms

--- a/falcon_mcp/resources/rtr_admin.py
+++ b/falcon_mcp/resources/rtr_admin.py
@@ -9,10 +9,10 @@ SCRIPT_FQL_FILTERS = [
     ("id", "String", "Script ID."),
     ("name", "String", "Script name."),
     ("description", "String", "Script description."),
-    ("platform", "String", "Script platform such as windows, mac, or linux."),
+    ("platform", "String", "Custom script platform such as windows, mac, or linux."),
     ("permission_type", "String", "Script permission level such as private, group, or public."),
-    ("created_at", "Timestamp", "When the script was created."),
-    ("updated_at", "Timestamp", "When the script was last updated."),
+    ("created_timestamp", "Timestamp", "When the script was created."),
+    ("modified_timestamp", "Timestamp", "When the script was last modified."),
 ]
 
 FALCON_SCRIPT_FQL_FILTERS = [
@@ -20,7 +20,7 @@ FALCON_SCRIPT_FQL_FILTERS = [
     ("id", "String", "Falcon script ID."),
     ("name", "String", "Falcon script name."),
     ("description", "String", "Falcon script description."),
-    ("platform", "String", "Script platform such as windows, mac, or linux."),
+    ("platform", "String", "Falcon script platform such as Windows, Mac, or Linux."),
 ]
 
 PUT_FILE_FQL_FILTERS = [
@@ -28,8 +28,8 @@ PUT_FILE_FQL_FILTERS = [
     ("id", "String", "Put-file ID."),
     ("name", "String", "Put-file name."),
     ("description", "String", "Put-file description."),
-    ("created_at", "Timestamp", "When the put-file was created."),
-    ("updated_at", "Timestamp", "When the put-file was last updated."),
+    ("created_timestamp", "Timestamp", "When the put-file was created."),
+    ("modified_timestamp", "Timestamp", "When the put-file was last modified."),
 ]
 
 SEARCH_RTR_ADMIN_SCRIPTS_FQL_DOCUMENTATION = (
@@ -49,8 +49,16 @@ permission_type:'private'
 # Scripts with triage in the name
 name:~'triage'
 
-# Look up known script IDs
-id:['<id1>','<id2>']
+# Scripts created after a date
+created_timestamp:>'2026-01-01T00:00:00Z'
+
+NOTE: Live testing showed custom script ID filters may not return known IDs
+reliably. Use name/platform/time filters and compare returned IDs manually when
+exact lookup matters.
+
+NOTE: Search results can include full script content. Treat responses as
+sensitive operational material and avoid copying script bodies into notes unless
+content review is explicitly required.
 
 === falcon_search_rtr_admin_scripts FQL filter available fields ===
 
@@ -67,13 +75,21 @@ field_name:[operator]'value'
 === COMMON EXAMPLES ===
 
 # Windows Falcon scripts
-platform:'windows'
+platform:'Windows'
 
 # Falcon scripts with collect in the name
 name:~'collect'
 
 # Look up known script IDs
 id:['<id1>','<id2>']
+
+NOTE: Falcon script platform casing differs from custom scripts. Use
+platform:'Windows' for CrowdStrike-provided Falcon scripts, but
+platform:'windows' for custom scripts.
+
+NOTE: Search results can include full script content. Treat responses as
+sensitive operational material and avoid copying script bodies into notes unless
+content review is explicitly required.
 
 === falcon_search_rtr_falcon_scripts FQL filter available fields ===
 
@@ -89,14 +105,19 @@ field_name:[operator]'value'
 
 === COMMON EXAMPLES ===
 
-# Put-files with collector in the name
-name:~'collector'
+# Put-file by exact name
+name:'approved-collector.ps1'
 
 # Put-files created after a date
-created_at:>'2026-01-01T00:00:00Z'
+created_timestamp:>'2026-01-01T00:00:00Z'
 
-# Look up known put-file IDs
-id:['<id1>','<id2>']
+NOTE: Live testing showed put-file ID filters may not return known IDs
+reliably. Use name/time filters and compare returned IDs manually before using
+falcon_get_rtr_put_file_contents with a selected put-file ID.
+
+NOTE: Live testing showed exact put-file name filters can match while
+contains/wildcard name filters may return no rows. If exact name is not known,
+use a time-bounded inventory search and compare returned names client-side.
 
 === falcon_search_rtr_put_files FQL filter available fields ===
 
@@ -117,11 +138,23 @@ needed.
    - Use `falcon_search_rtr_admin_scripts` for custom cloud scripts.
    - Use `falcon_search_rtr_falcon_scripts` for CrowdStrike-provided scripts.
    - Use `falcon_search_rtr_put_files` for put-file inventory.
+   - Treat script inventory responses as sensitive because they can include
+     full custom or Falcon script content.
    - Use `falcon_get_rtr_put_file_contents` only after selecting a specific
      put-file ID. Treat returned content as potentially sensitive operational
      material.
-   - When you already have IDs, filter the matching search tool with the `id`
-     field, such as `id:['<id1>','<id2>']`.
+   - Do not rely on put-file inventory `file_type` to predict content exposure.
+     Live testing showed inventory can report `file_type: binary` while the
+     content retrieval endpoint returns text script content.
+   - Falcon script ID filters are supported by live testing. Custom script and
+     put-file ID filters may be API-dependent; prefer broader filters and
+     compare returned IDs manually before acting on a selected record.
+   - For put-files, prefer exact `name:'...'` filters when the name is known.
+     Contains or wildcard name filters may return no rows; use time-bounded
+     inventory and compare names client-side when exact name is not known.
+   - Platform casing differs: custom scripts use values such as
+     `platform:'windows'`, while Falcon scripts use values such as
+     `platform:'Windows'`.
 
 2. Classify the intended command locally.
    - Use `falcon_classify_rtr_admin_command` before execution planning.
@@ -136,9 +169,14 @@ needed.
      mismatches are rejected locally before any Falcon call.
    - Review `payload_preview`, `classification`, `missing_context`,
      `approval_gate`, and any command-specific guidance.
+   - For `reg query`, keep the query shape minimal. Live testing showed Falcon
+     can reject extra unquoted arguments with HTTP 400.
    - If `approval_gate.approval_required` is true, ask the operator to approve
      the exact target, command, expected effect, and approval hash before
      re-submitting with `operator_approval`.
+   - High-impact approval is only ready when `device_id`, `reason`, `ticket`,
+     and `expected_effect` are present. The approval phrase binds the target,
+     payload, and audit context.
 
 4. Execute only after target and effect review.
    - Use `falcon_execute_rtr_admin_command` for one host/session.
@@ -152,6 +190,8 @@ needed.
      shutdown actions, registry writes, and memory dumps return an
      approval-required response unless `operator_approval` matches the exact
      phrase for that payload.
+   - For directory cleanup, use `rm <directory> -force` and verify stderr/stdout
+     before assuming deletion succeeded.
 
 5. Poll output.
    - Use `falcon_check_rtr_admin_command_status` with the returned
@@ -182,6 +222,9 @@ needed.
 - Keep single-host `persist` false unless the operator explicitly wants offline
   execution when a host returns to service.
 - Batch admin execution is intentionally out of scope for this module slice.
+- If audit/session searches return 403 during an RTR Admin investigation, verify
+  `real-time-response-audit:read`; live testing showed newly added audit scope
+  can take effect without restarting the MCP process.
 - Do not place RTR controller actions such as status polling, `get`, `put`, or
   session cleanup inside raw script bodies. Use the separate MCP tools for those
   steps.

--- a/falcon_mcp/resources/rtr_admin.py
+++ b/falcon_mcp/resources/rtr_admin.py
@@ -1,0 +1,265 @@
+"""
+Contains RTR Admin resources.
+"""
+
+from falcon_mcp.common.utils import generate_md_table
+
+EMBEDDED_SCRIPT_FQL_SYNTAX = """FQL filter string for querying RTR custom scripts.
+
+SYNTAX:
+- Equals: field:'value'
+- Not equals: field:!'value'
+- Contains: field:~'partial'
+- Wildcard: field:'prefix*'
+
+COMMON FIELDS:
+- name: Script name
+- description: Script description
+- platform: Script platform such as windows, mac, or linux
+- permission_type: Script permission level such as private, group, or public
+- created_at: Creation timestamp
+- updated_at: Last update timestamp
+
+EXAMPLES:
+- Windows scripts: platform:'windows'
+- Private scripts: permission_type:'private'
+- Name match: name:~'triage'
+- Sort example: created_at|desc
+"""
+
+EMBEDDED_FALCON_SCRIPT_FQL_SYNTAX = """FQL filter string for querying CrowdStrike Falcon scripts.
+
+SYNTAX:
+- Equals: field:'value'
+- Contains: field:~'partial'
+- Wildcard: field:'prefix*'
+
+COMMON FIELDS:
+- name: Falcon script name
+- description: Falcon script description
+- platform: Script platform such as windows, mac, or linux
+
+EXAMPLES:
+- Windows Falcon scripts: platform:'windows'
+- Name match: name:~'collect'
+- Sort example: name|asc
+"""
+
+EMBEDDED_PUT_FILE_FQL_SYNTAX = """FQL filter string for querying RTR put-files.
+
+SYNTAX:
+- Equals: field:'value'
+- Not equals: field:!'value'
+- Contains: field:~'partial'
+- Wildcard: field:'prefix*'
+
+COMMON FIELDS:
+- name: Put-file name
+- description: Put-file description
+- created_at: Creation timestamp
+- updated_at: Last update timestamp
+
+EXAMPLES:
+- Name match: name:~'collector'
+- Recent files: created_at:>'2026-01-01T00:00:00Z'
+- Sort example: created_at|desc
+"""
+
+SCRIPT_FQL_FILTERS = [
+    ("Name", "Type", "Description"),
+    ("id", "String", "Script ID."),
+    ("name", "String", "Script name."),
+    ("description", "String", "Script description."),
+    ("platform", "String", "Script platform such as windows, mac, or linux."),
+    ("permission_type", "String", "Script permission level such as private, group, or public."),
+    ("created_at", "Timestamp", "When the script was created."),
+    ("updated_at", "Timestamp", "When the script was last updated."),
+]
+
+FALCON_SCRIPT_FQL_FILTERS = [
+    ("Name", "Type", "Description"),
+    ("id", "String", "Falcon script ID."),
+    ("name", "String", "Falcon script name."),
+    ("description", "String", "Falcon script description."),
+    ("platform", "String", "Script platform such as windows, mac, or linux."),
+]
+
+PUT_FILE_FQL_FILTERS = [
+    ("Name", "Type", "Description"),
+    ("id", "String", "Put-file ID."),
+    ("name", "String", "Put-file name."),
+    ("description", "String", "Put-file description."),
+    ("created_at", "Timestamp", "When the put-file was created."),
+    ("updated_at", "Timestamp", "When the put-file was last updated."),
+]
+
+SEARCH_RTR_ADMIN_SCRIPTS_FQL_DOCUMENTATION = (
+    """Falcon Query Language (FQL) - Search RTR Custom Scripts Guide
+
+=== BASIC SYNTAX ===
+field_name:[operator]'value'
+
+=== COMMON EXAMPLES ===
+
+# Windows custom scripts
+platform:'windows'
+
+# Private custom scripts
+permission_type:'private'
+
+# Scripts with triage in the name
+name:~'triage'
+
+=== falcon_search_rtr_admin_scripts FQL filter available fields ===
+
+"""
+    + generate_md_table(SCRIPT_FQL_FILTERS)
+)
+
+SEARCH_RTR_FALCON_SCRIPTS_FQL_DOCUMENTATION = (
+    """Falcon Query Language (FQL) - Search RTR Falcon Scripts Guide
+
+=== BASIC SYNTAX ===
+field_name:[operator]'value'
+
+=== COMMON EXAMPLES ===
+
+# Windows Falcon scripts
+platform:'windows'
+
+# Falcon scripts with collect in the name
+name:~'collect'
+
+=== falcon_search_rtr_falcon_scripts FQL filter available fields ===
+
+"""
+    + generate_md_table(FALCON_SCRIPT_FQL_FILTERS)
+)
+
+SEARCH_RTR_PUT_FILES_FQL_DOCUMENTATION = (
+    """Falcon Query Language (FQL) - Search RTR Put-Files Guide
+
+=== BASIC SYNTAX ===
+field_name:[operator]'value'
+
+=== COMMON EXAMPLES ===
+
+# Put-files with collector in the name
+name:~'collector'
+
+# Put-files created after a date
+created_at:>'2026-01-01T00:00:00Z'
+
+=== falcon_search_rtr_put_files FQL filter available fields ===
+
+"""
+    + generate_md_table(PUT_FILE_FQL_FILTERS)
+)
+
+RTR_ADMIN_TOOL_USE_GUIDE = """RTR Admin Tool Use Guide
+
+This guide explains how to use the RTR Admin module tools. RTR Admin can affect
+live endpoints. Use standard RTR for read-only host triage and use this module
+only when an admin command, script execution, or put-file workflow is actually
+needed.
+
+=== Recommended workflow ===
+
+1. Review available reusable material.
+   - Use `falcon_search_rtr_admin_scripts` for custom cloud scripts.
+   - Use `falcon_search_rtr_falcon_scripts` for CrowdStrike-provided scripts.
+   - Use `falcon_search_rtr_put_files` for put-file inventory.
+   - Use the matching `get_*_details` tool when you already have IDs.
+
+2. Classify the intended command locally.
+   - Use `falcon_classify_rtr_admin_command` before execution planning.
+   - This does not call Falcon.
+   - Classification is enforced before execution. High-impact commands require
+     an explicit operator approval phrase before any Falcon call is made.
+
+3. Preview the exact payload.
+   - Use `falcon_preview_rtr_admin_command` before live execution.
+   - Provide `reason`, `ticket`, and `expected_effect` whenever possible.
+   - Review `payload_preview`, `classification`, `missing_context`,
+     `approval_gate`, and any command-specific guidance.
+   - If `approval_gate.approval_required` is true, ask the operator to approve
+     the exact target, command, expected effect, and approval hash before
+     re-submitting with `operator_approval`.
+
+4. Execute only after target and effect review.
+   - Use `falcon_execute_rtr_admin_command` for one host/session.
+   - This execution tool is marked destructive because submitted commands can
+     change or disrupt endpoints depending on the command string.
+   - High-impact commands such as `runscript`, `rm`, `put`, `kill`, restart or
+     shutdown actions, registry writes, and memory dumps return an
+     approval-required response unless `operator_approval` matches the exact
+     phrase for that payload.
+
+5. Poll output.
+   - Use `falcon_check_rtr_admin_command_status` with the returned
+     `cloud_request_id`.
+   - Start with `sequence_id=0`; if the status response includes a
+     `sequence_id`, use that returned sequence_id on the next poll.
+
+=== Raw runscript workflow ===
+
+- Use `base_command="runscript"`.
+- Use `falcon://rtr-admin/commands/runscript-guide` for quoting and
+  controller notes.
+- Treat `runscript -Raw` as submit-and-poll execution, not an interactive
+  terminal.
+- Prefer `runscript -CloudFile="ScriptName" -CommandLine="<arguments>"` for
+  reusable or multiline scripts.
+
+=== Boundaries and disclaimers ===
+
+- This module does not upload, update, delete, or retrieve contents for scripts
+  or put-files in the first implementation slice.
+- Do not use automated live tests for endpoint-changing commands. Tests should
+  stay mocked, smoke-only, or read-only unless the operator chooses a specific
+  PC for that run.
+- Keep single-host `persist` false unless the operator explicitly wants offline
+  execution when a host returns to service.
+- Batch admin execution is intentionally out of scope for this first module
+  slice.
+- Do not place RTR controller actions such as status polling, `get`, `put`, or
+  session cleanup inside raw script bodies. Use the separate MCP tools for those
+  steps.
+"""
+
+RTR_ADMIN_RUNSCRIPT_RAW_GUIDE = """RTR Admin runscript raw command guide
+
+Use this guide when building command strings for
+`falcon_execute_rtr_admin_command` with `base_command="runscript"`.
+
+CORE SHAPE:
+- base_command: runscript
+- command_string: runscript -Raw=```<target-side script>```
+
+EXAMPLES:
+- Windows process list: runscript -Raw=```Get-Process```
+- Windows command wrapper: runscript -Raw=```cmd /c whoami && hostname```
+- Linux/macOS shell: runscript -Raw=```/bin/sh -c 'id; hostname'```
+
+CLOUD SCRIPT SHAPE:
+- command_string: runscript -CloudFile="ScriptName"
+- with arguments: runscript -CloudFile="ScriptName" -CommandLine="<arguments>"
+
+IMPORTANT CONTROLLER NOTES:
+- `runscript -Raw` is not an interactive terminal. Each tool call submits one
+  RTR Admin command and returns a `cloud_request_id`.
+- Use `falcon_check_rtr_admin_command_status` to poll command output chunks.
+- Do not put RTR controller commands such as `get`, `put`, `cd`, or status
+  polling inside the raw script. Those are RTR commands, not target-side shell
+  commands.
+- If the target-side script needs to coordinate multiple steps, write explicit
+  stdout markers or output files, then use separate RTR commands to retrieve or
+  inspect results.
+- Raw scripts are quoting-sensitive. Prefer short one-liners or approved cloud
+  scripts for long multiline logic.
+- Avoid unescaped triple backticks inside the script body because they delimit
+  the raw payload.
+- Prefer `-CloudFile` plus `-CommandLine` for reusable or complex scripts.
+- Keep single-host `persist` false unless the operator explicitly wants offline
+  execution when the host returns to service.
+"""

--- a/falcon_mcp/resources/rtr_admin.py
+++ b/falcon_mcp/resources/rtr_admin.py
@@ -52,9 +52,9 @@ name:~'triage'
 # Scripts created after a date
 created_timestamp:>'2026-01-01T00:00:00Z'
 
-NOTE: Live testing showed custom script ID filters may not return known IDs
-reliably. Use name/platform/time filters and compare returned IDs manually when
-exact lookup matters.
+NOTE: Custom script ID filters can be API-shape dependent. Use
+name/platform/time filters and compare returned IDs manually when exact lookup
+matters.
 
 NOTE: Search results can include full script content. Treat responses as
 sensitive operational material and avoid copying script bodies into notes unless
@@ -111,13 +111,13 @@ name:'approved-collector.ps1'
 # Put-files created after a date
 created_timestamp:>'2026-01-01T00:00:00Z'
 
-NOTE: Live testing showed put-file ID filters may not return known IDs
-reliably. Use name/time filters and compare returned IDs manually before using
-falcon_get_rtr_put_file_contents with a selected put-file ID.
+NOTE: Put-file ID filters can be API-shape dependent. Use name/time filters and
+compare returned IDs manually before using falcon_get_rtr_put_file_contents
+with a selected put-file ID.
 
-NOTE: Live testing showed exact put-file name filters can match while
-contains/wildcard name filters may return no rows. If exact name is not known,
-use a time-bounded inventory search and compare returned names client-side.
+NOTE: Exact put-file name filters are more reliable than contains or wildcard
+name filters in some Falcon API responses. If exact name is not known, use a
+time-bounded inventory search and compare returned names client-side.
 
 === falcon_search_rtr_put_files FQL filter available fields ===
 
@@ -144,11 +144,11 @@ needed.
      put-file ID. Treat returned content as potentially sensitive operational
      material.
    - Do not rely on put-file inventory `file_type` to predict content exposure.
-     Live testing showed inventory can report `file_type: binary` while the
-     content retrieval endpoint returns text script content.
-   - Falcon script ID filters are supported by live testing. Custom script and
-     put-file ID filters may be API-dependent; prefer broader filters and
-     compare returned IDs manually before acting on a selected record.
+     Inventory can report `file_type: binary` while the content retrieval
+     endpoint returns text script content.
+   - Falcon script ID filters are supported. Custom script and put-file ID
+     filters may be API-dependent; prefer broader filters and compare returned
+     IDs manually before acting on a selected record.
    - For put-files, prefer exact `name:'...'` filters when the name is known.
      Contains or wildcard name filters may return no rows; use time-bounded
      inventory and compare names client-side when exact name is not known.
@@ -169,8 +169,8 @@ needed.
      mismatches are rejected locally before any Falcon call.
    - Review `payload_preview`, `classification`, `missing_context`,
      `approval_gate`, and any command-specific guidance.
-   - For `reg query`, keep the query shape minimal. Live testing showed Falcon
-     can reject extra unquoted arguments with HTTP 400.
+   - For `reg query`, keep the query shape minimal. Falcon can reject extra
+     unquoted arguments with HTTP 400.
    - If `approval_gate.approval_required` is true, ask the operator to approve
      the exact target, command, expected effect, and approval hash before
      re-submitting with `operator_approval`.
@@ -222,9 +222,8 @@ needed.
 - Keep single-host `persist` false unless the operator explicitly wants offline
   execution when a host returns to service.
 - Batch admin execution is intentionally out of scope for this module slice.
-- If audit/session searches return 403 during an RTR Admin investigation, verify
-  `real-time-response-audit:read`; live testing showed newly added audit scope
-  can take effect without restarting the MCP process.
+- If audit/session searches return 403 during an RTR Admin investigation,
+  verify the API client has `real-time-response-audit:read`.
 - Do not place RTR controller actions such as status polling, `get`, `put`, or
   session cleanup inside raw script bodies. Use the separate MCP tools for those
   steps.

--- a/falcon_mcp/resources/rtr_admin.py
+++ b/falcon_mcp/resources/rtr_admin.py
@@ -117,6 +117,9 @@ needed.
    - Use `falcon_search_rtr_admin_scripts` for custom cloud scripts.
    - Use `falcon_search_rtr_falcon_scripts` for CrowdStrike-provided scripts.
    - Use `falcon_search_rtr_put_files` for put-file inventory.
+   - Use `falcon_get_rtr_put_file_contents` only after selecting a specific
+     put-file ID. Treat returned content as potentially sensitive operational
+     material.
    - When you already have IDs, filter the matching search tool with the `id`
      field, such as `id:['<id1>','<id2>']`.
 
@@ -129,6 +132,8 @@ needed.
 3. Preview the exact payload.
    - Use `falcon_preview_rtr_admin_command` before live execution.
    - Provide `reason`, `ticket`, and `expected_effect` whenever possible.
+   - Confirm `base_command` matches the first token of `command_string`;
+     mismatches are rejected locally before any Falcon call.
    - Review `payload_preview`, `classification`, `missing_context`,
      `approval_gate`, and any command-specific guidance.
    - If `approval_gate.approval_required` is true, ask the operator to approve
@@ -137,6 +142,10 @@ needed.
 
 4. Execute only after target and effect review.
    - Use `falcon_execute_rtr_admin_command` for one host/session.
+   - Use `falcon_run_rtr_admin_command_and_wait` when you want a focused
+     single-host command to submit once and return combined stdout/stderr after
+     polling. It uses the same classification and approval gate as the execution
+     tool.
    - This execution tool is marked destructive because submitted commands can
      change or disrupt endpoints depending on the command string.
    - High-impact commands such as `runscript`, `rm`, `put`, `kill`, restart or
@@ -147,6 +156,9 @@ needed.
 5. Poll output.
    - Use `falcon_check_rtr_admin_command_status` with the returned
      `cloud_request_id`.
+   - The wait helper handles this polling for simple workflows; manual polling
+     remains useful for long-running commands or when the caller needs each
+     status chunk.
    - Start with `sequence_id=0`; if the status response includes a
      `sequence_id`, use that returned sequence_id on the next poll.
 
@@ -162,15 +174,14 @@ needed.
 
 === Boundaries and disclaimers ===
 
-- This module does not upload, update, delete, or retrieve contents for scripts
-  or put-files in the first implementation slice.
+- This module retrieves put-file contents by explicit ID but does not upload,
+  update, or delete script / put-file records.
 - Do not use automated live tests for endpoint-changing commands. Tests should
   stay mocked, smoke-only, or read-only unless the operator chooses a specific
   PC for that run.
 - Keep single-host `persist` false unless the operator explicitly wants offline
   execution when a host returns to service.
-- Batch admin execution is intentionally out of scope for this first module
-  slice.
+- Batch admin execution is intentionally out of scope for this module slice.
 - Do not place RTR controller actions such as status polling, `get`, `put`, or
   session cleanup inside raw script bodies. Use the separate MCP tools for those
   steps.
@@ -179,7 +190,8 @@ needed.
 RTR_ADMIN_RUNSCRIPT_RAW_GUIDE = """RTR Admin runscript raw command guide
 
 Use this guide when building command strings for
-`falcon_execute_rtr_admin_command` with `base_command="runscript"`.
+`falcon_execute_rtr_admin_command` or `falcon_run_rtr_admin_command_and_wait`
+with `base_command="runscript"`.
 
 CORE SHAPE:
 - base_command: runscript
@@ -197,7 +209,9 @@ CLOUD SCRIPT SHAPE:
 IMPORTANT CONTROLLER NOTES:
 - `runscript -Raw` is not an interactive terminal. Each tool call submits one
   RTR Admin command and returns a `cloud_request_id`.
-- Use `falcon_check_rtr_admin_command_status` to poll command output chunks.
+- Use `falcon_check_rtr_admin_command_status` to poll command output chunks, or
+  use `falcon_run_rtr_admin_command_and_wait` for focused commands where direct
+  stdout/stderr output is preferred.
 - Do not put RTR controller commands such as `get`, `put`, `cd`, or status
   polling inside the raw script. Those are RTR commands, not target-side shell
   commands.
@@ -211,4 +225,41 @@ IMPORTANT CONTROLLER NOTES:
 - Prefer `-CloudFile` plus `-CommandLine` for reusable or complex scripts.
 - Keep single-host `persist` false unless the operator explicitly wants offline
   execution when the host returns to service.
+"""
+
+RTR_ADMIN_APPROVAL_PACKET_TEMPLATE = """RTR Admin Approval Packet Template
+
+Use this template before running high-impact RTR Admin commands. The operator
+must review the exact target, command, expected endpoint effect, and approval
+hash before the execution tool is called with `operator_approval`.
+
+=== Target ===
+- Hostname:
+- Device ID:
+- Session ID:
+- Ticket / case:
+
+=== Command ===
+- Base command:
+- Command string:
+- Persist when offline: false
+- Classification:
+- Risk:
+
+=== Rationale ===
+- Reason:
+- Expected endpoint effect:
+- Evidence or inventory reviewed:
+
+=== Approval Gate ===
+- Approval required:
+- Approval hash:
+- Exact approval phrase:
+
+=== Execution and Follow-up ===
+- Execution tool: falcon_execute_rtr_admin_command
+- Wait helper: falcon_run_rtr_admin_command_and_wait
+- Status tool: falcon_check_rtr_admin_command_status
+- Cloud request ID:
+- Completion / stdout / stderr summary:
 """

--- a/falcon_mcp/resources/rtr_admin.py
+++ b/falcon_mcp/resources/rtr_admin.py
@@ -4,67 +4,6 @@ Contains RTR Admin resources.
 
 from falcon_mcp.common.utils import generate_md_table
 
-EMBEDDED_SCRIPT_FQL_SYNTAX = """FQL filter string for querying RTR custom scripts.
-
-SYNTAX:
-- Equals: field:'value'
-- Not equals: field:!'value'
-- Contains: field:~'partial'
-- Wildcard: field:'prefix*'
-
-COMMON FIELDS:
-- name: Script name
-- description: Script description
-- platform: Script platform such as windows, mac, or linux
-- permission_type: Script permission level such as private, group, or public
-- created_at: Creation timestamp
-- updated_at: Last update timestamp
-
-EXAMPLES:
-- Windows scripts: platform:'windows'
-- Private scripts: permission_type:'private'
-- Name match: name:~'triage'
-- Sort example: created_at|desc
-"""
-
-EMBEDDED_FALCON_SCRIPT_FQL_SYNTAX = """FQL filter string for querying CrowdStrike Falcon scripts.
-
-SYNTAX:
-- Equals: field:'value'
-- Contains: field:~'partial'
-- Wildcard: field:'prefix*'
-
-COMMON FIELDS:
-- name: Falcon script name
-- description: Falcon script description
-- platform: Script platform such as windows, mac, or linux
-
-EXAMPLES:
-- Windows Falcon scripts: platform:'windows'
-- Name match: name:~'collect'
-- Sort example: name|asc
-"""
-
-EMBEDDED_PUT_FILE_FQL_SYNTAX = """FQL filter string for querying RTR put-files.
-
-SYNTAX:
-- Equals: field:'value'
-- Not equals: field:!'value'
-- Contains: field:~'partial'
-- Wildcard: field:'prefix*'
-
-COMMON FIELDS:
-- name: Put-file name
-- description: Put-file description
-- created_at: Creation timestamp
-- updated_at: Last update timestamp
-
-EXAMPLES:
-- Name match: name:~'collector'
-- Recent files: created_at:>'2026-01-01T00:00:00Z'
-- Sort example: created_at|desc
-"""
-
 SCRIPT_FQL_FILTERS = [
     ("Name", "Type", "Description"),
     ("id", "String", "Script ID."),
@@ -110,6 +49,9 @@ permission_type:'private'
 # Scripts with triage in the name
 name:~'triage'
 
+# Look up known script IDs
+id:['<id1>','<id2>']
+
 === falcon_search_rtr_admin_scripts FQL filter available fields ===
 
 """
@@ -129,6 +71,9 @@ platform:'windows'
 
 # Falcon scripts with collect in the name
 name:~'collect'
+
+# Look up known script IDs
+id:['<id1>','<id2>']
 
 === falcon_search_rtr_falcon_scripts FQL filter available fields ===
 
@@ -150,6 +95,9 @@ name:~'collector'
 # Put-files created after a date
 created_at:>'2026-01-01T00:00:00Z'
 
+# Look up known put-file IDs
+id:['<id1>','<id2>']
+
 === falcon_search_rtr_put_files FQL filter available fields ===
 
 """
@@ -169,7 +117,8 @@ needed.
    - Use `falcon_search_rtr_admin_scripts` for custom cloud scripts.
    - Use `falcon_search_rtr_falcon_scripts` for CrowdStrike-provided scripts.
    - Use `falcon_search_rtr_put_files` for put-file inventory.
-   - Use the matching `get_*_details` tool when you already have IDs.
+   - When you already have IDs, filter the matching search tool with the `id`
+     field, such as `id:['<id1>','<id2>']`.
 
 2. Classify the intended command locally.
    - Use `falcon_classify_rtr_admin_command` before execution planning.

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -127,12 +127,15 @@ class FalconMCPServer:
         resource_count = self._register_resources()
         resource_word = "resource" if resource_count == 1 else "resources"
 
+        prompt_count = self._register_prompts()
+        prompt_word = "prompt" if prompt_count == 1 else "prompts"
+
         # Count modules and tools with proper grammar
         module_count = len(self.modules)
         module_word = "module" if module_count == 1 else "modules"
 
         logger.info(
-            "Falcon MCP v%s — %d %s, %d %s, %d %s",
+            "Falcon MCP v%s — %d %s, %d %s, %d %s, %d %s",
             get_version(),
             module_count,
             module_word,
@@ -140,6 +143,8 @@ class FalconMCPServer:
             tool_word,
             resource_count,
             resource_word,
+            prompt_count,
+            prompt_word,
         )
 
     def _register_tools(self) -> int:
@@ -193,6 +198,18 @@ class FalconMCPServer:
                 module.register_resources(self.server)
 
         return sum(len(getattr(m, "resources", [])) for m in self.modules.values())
+
+    def _register_prompts(self) -> int:
+        """Register prompts from all modules.
+
+        Returns:
+            int: Number of prompts registered
+        """
+        for module in self.modules.values():
+            if hasattr(module, "register_prompts") and callable(module.register_prompts):
+                module.register_prompts(self.server)
+
+        return sum(len(getattr(m, "prompts", [])) for m in self.modules.values())
 
     def falcon_check_connectivity(self) -> dict[str, bool]:
         """Check connectivity to the Falcon API."""

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -362,7 +362,7 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     ],
     "falcon_search_rtr_audit_sessions": [
         "Show me RTR audit activity from the last 7 days",
-        "Who used RTR against host BRR-WB-LIB-22?",
+        "Who used RTR against host EXAMPLE-WIN-22?",
     ],
     "falcon_aggregate_rtr_sessions": [
         "Summarize RTR sessions by command for the last 30 days",

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -398,21 +398,18 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     "falcon_search_rtr_admin_scripts": [
         "Find Windows RTR Admin scripts with triage in the name",
         "Show me private custom RTR scripts I could review for this host",
-    ],
-    "falcon_get_rtr_admin_script_details": [
-        "Pull the details for that RTR Admin script ID",
+        "Look up RTR Admin script ID abc123 with an id filter",
     ],
     "falcon_search_rtr_falcon_scripts": [
         "Find CrowdStrike-provided Falcon scripts for Windows collection",
-    ],
-    "falcon_get_rtr_falcon_script_details": [
-        "Show me the details for that Falcon script",
+        "Look up Falcon script ID abc123 with an id filter",
     ],
     "falcon_search_rtr_put_files": [
         "Search RTR put-files with collector in the name",
+        "Look up RTR put-file ID abc123 with an id filter",
     ],
-    "falcon_get_rtr_put_file_details": [
-        "Get metadata for this RTR put-file ID",
+    "falcon_get_rtr_put_file_contents": [
+        "Retrieve the contents for RTR put-file ID abc123",
     ],
     "falcon_check_rtr_admin_command_status": [
         "Check the output for this RTR Admin cloud request ID",
@@ -425,6 +422,9 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     ],
     "falcon_execute_rtr_admin_command": [
         "Run this approved RTR Admin command against the existing RTR session",
+    ],
+    "falcon_run_rtr_admin_command_and_wait": [
+        "Run this approved RTR Admin command and wait for stdout and stderr",
     ],
 }
 
@@ -592,7 +592,7 @@ def extract_registered_tool_names(module_cls: type) -> dict[str, str]:
     """
     try:
         source = inspect.getsource(module_cls.register_tools)  # type: ignore[attr-defined]
-    except (AttributeError, TypeError):
+    except (AttributeError, TypeError, OSError):
         return {}
 
     registered: dict[str, str] = {}
@@ -622,7 +622,7 @@ def extract_resource_info(module_cls: type) -> list[dict[str, str]]:
     """Extract resource URIs and descriptions by inspecting register_resources."""
     try:
         source = inspect.getsource(module_cls.register_resources)  # type: ignore[attr-defined]
-    except (AttributeError, TypeError):
+    except (AttributeError, TypeError, OSError):
         return []
 
     resources = []
@@ -656,9 +656,50 @@ def extract_resource_info(module_cls: type) -> list[dict[str, str]]:
     return resources
 
 
+def extract_prompt_info(module_cls: type) -> list[dict[str, str]]:
+    """Extract prompt names, titles, and descriptions by inspecting register_prompts."""
+    try:
+        source = inspect.getsource(module_cls.register_prompts)  # type: ignore[attr-defined]
+    except (AttributeError, TypeError, OSError):
+        return []
+
+    prompts = []
+
+    for match in re.finditer(r"self\._add_prompt\(", source):
+        start = match.end()
+        depth = 1
+        pos = start
+        while pos < len(source) and depth > 0:
+            if source[pos] == "(":
+                depth += 1
+            elif source[pos] == ")":
+                depth -= 1
+            pos += 1
+        block = source[start : pos - 1]
+
+        name_m = re.search(r'name=["\']([^"\']+)["\']', block)
+        title_m = re.search(r'title=["\']([^"\']+)["\']', block)
+        desc_m = re.search(r'description=["\']([^"\']+)["\']', block)
+
+        if name_m:
+            raw_name = name_m.group(1)
+            prompts.append(
+                {
+                    "name": f"falcon_{raw_name}",
+                    "title": title_m.group(1) if title_m else "",
+                    "description": desc_m.group(1) if desc_m else "",
+                }
+            )
+
+    return prompts
+
+
 def extract_tool_annotations(module_cls: type) -> dict[str, dict[str, bool]]:
     """Extract tool annotations from register_tools source."""
-    source = inspect.getsource(module_cls.register_tools)  # type: ignore[attr-defined]
+    try:
+        source = inspect.getsource(module_cls.register_tools)  # type: ignore[attr-defined]
+    except (AttributeError, TypeError, OSError):
+        return {}
     annotations = {}
 
     # Find _add_tool calls with explicit annotations
@@ -678,7 +719,13 @@ def extract_tool_annotations(module_cls: type) -> dict[str, dict[str, bool]]:
     return annotations
 
 
-def generate_module_page(module_key: str, module_cls: type, auto_title: str, auto_description: str) -> str:
+def generate_module_page(
+    module_key: str,
+    module_cls: type,
+    auto_title: str,
+    auto_description: str,
+    sidebar_order: int,
+) -> str:
     """Generate a complete markdown page for a module."""
     meta = MODULE_METADATA.get(module_key, {})
     title = meta.get("title", auto_title)
@@ -726,13 +773,16 @@ def generate_module_page(module_key: str, module_cls: type, auto_title: str, aut
     # Extract resources
     resources = extract_resource_info(module_cls)
 
+    # Extract prompts
+    prompts = extract_prompt_info(module_cls)
+
     # Build markdown
     lines = []
     lines.append("---")
     lines.append(f"title: {title}")
     lines.append(f"description: {description}")
     lines.append("sidebar:")
-    lines.append("  order: 10")
+    lines.append(f"  order: {sidebar_order}")
     lines.append("---")
     lines.append("")
     lines.append(description)
@@ -798,6 +848,20 @@ def generate_module_page(module_key: str, module_cls: type, auto_title: str, aut
             lines.append(f"- **`{r['uri']}`**: {r['description']}")
         lines.append("")
 
+    # Prompts
+    if prompts:
+        lines.append("## Prompts")
+        lines.append("")
+        for prompt in prompts:
+            lines.append(f"### `{prompt['name']}`")
+            lines.append("")
+            if prompt["title"]:
+                lines.append(f"**Title:** {prompt['title']}")
+                lines.append("")
+            if prompt["description"]:
+                lines.append(prompt["description"])
+                lines.append("")
+
     return "\n".join(lines)
 
 
@@ -842,19 +906,26 @@ def main() -> None:
 
     # Generate overview page
     overview = generate_overview_page(modules)
-    (OUTPUT_DIR / "overview.md").write_text(overview)
+    (OUTPUT_DIR / "overview.md").write_text(overview, encoding="utf-8")
     print("  Generated: modules/overview.md")
 
     # Generate per-module pages
     expected_files = {"overview.md"}
-    for key, mod_info in sorted(modules.items()):
+    for sidebar_order, key in enumerate(sorted(modules.keys()), start=10):
+        mod_info = modules[key]
         meta = MODULE_METADATA.get(key, {})
         slug = meta.get("slug", key)
         filename = f"{slug}.md"
         expected_files.add(filename)
 
-        page = generate_module_page(key, mod_info["cls"], mod_info["auto_title"], mod_info["auto_description"])
-        (OUTPUT_DIR / filename).write_text(page)
+        page = generate_module_page(
+            key,
+            mod_info["cls"],
+            mod_info["auto_title"],
+            mod_info["auto_description"],
+            sidebar_order,
+        )
+        (OUTPUT_DIR / filename).write_text(page, encoding="utf-8")
         print(f"  Generated: modules/{filename}")
 
     # Clean up stale module files

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -45,6 +45,11 @@ MODULE_METADATA: dict[str, dict[str, Any]] = {
     "idp": {
         "title": "Identity Protection",
     },
+    "rtr_admin": {
+        "title": "Real Time Response Admin",
+        "slug": "rtr-admin",
+        "description": "Inspect RTR Admin assets, classify command risk, preview payloads, and execute approved single-host admin workflows.",
+    },
     "scheduledreports": {
         "slug": "scheduled-reports",
     },
@@ -389,6 +394,38 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     "falcon_delete_rtr_session": [
         "End the RTR session abc123",
     ],
+    # Real Time Response Admin
+    "falcon_search_rtr_admin_scripts": [
+        "Find Windows RTR Admin scripts with triage in the name",
+        "Show me private custom RTR scripts I could review for this host",
+    ],
+    "falcon_get_rtr_admin_script_details": [
+        "Pull the details for that RTR Admin script ID",
+    ],
+    "falcon_search_rtr_falcon_scripts": [
+        "Find CrowdStrike-provided Falcon scripts for Windows collection",
+    ],
+    "falcon_get_rtr_falcon_script_details": [
+        "Show me the details for that Falcon script",
+    ],
+    "falcon_search_rtr_put_files": [
+        "Search RTR put-files with collector in the name",
+    ],
+    "falcon_get_rtr_put_file_details": [
+        "Get metadata for this RTR put-file ID",
+    ],
+    "falcon_check_rtr_admin_command_status": [
+        "Check the output for this RTR Admin cloud request ID",
+    ],
+    "falcon_classify_rtr_admin_command": [
+        "Classify this RTR Admin command before I decide whether to run it",
+    ],
+    "falcon_preview_rtr_admin_command": [
+        "Preview the exact RTR Admin payload for this command before running it",
+    ],
+    "falcon_execute_rtr_admin_command": [
+        "Run this approved RTR Admin command against the existing RTR session",
+    ],
 }
 
 # Lines matching these patterns are stripped from docstrings
@@ -471,7 +508,11 @@ def discover_module_classes() -> dict[str, dict[str, Any]]:
         for attr_name in dir(mod):
             if attr_name.endswith("Module") and attr_name != "BaseModule":
                 cls = getattr(mod, attr_name)
-                module_key = attr_name.lower().replace("module", "")
+                module_key = getattr(
+                    cls,
+                    "MODULE_NAME",
+                    attr_name.lower().replace("module", ""),
+                )
                 result[module_key] = {
                     "cls": cls,
                     "auto_title": auto_title or module_key.title(),

--- a/tests/integration/test_rtr.py
+++ b/tests/integration/test_rtr.py
@@ -222,7 +222,7 @@ class TestRTRIntegration(BaseIntegrationTest):
 
     def test_fql_boolean_fields_are_accepted(self):
         """Validate that all documented boolean FQL fields are accepted."""
-        boolean_fields = ["offline_queued", "commands_queued"]
+        boolean_fields = ["offline_queued"]
         for field in boolean_fields:
             self._assert_fql_field_accepted(
                 f"{field}:true",

--- a/tests/integration/test_rtr_admin.py
+++ b/tests/integration/test_rtr_admin.py
@@ -1,0 +1,121 @@
+"""Integration tests for the RTR Admin module."""
+
+import pytest
+
+from falcon_mcp.modules.rtr_admin import RTRAdminModule
+from tests.integration.utils.base_integration_test import BaseIntegrationTest
+
+
+@pytest.mark.integration
+class TestRTRAdminIntegration(BaseIntegrationTest):
+    """Integration tests for RTR Admin inventory and local policy helpers.
+
+    Validates:
+    - Correct FalconPy operation names for RTR Admin inventory APIs
+    - GET query parameter usage for script and put-file detail lookups
+    - Sort expressions accepted by the current API contract
+    - Preview and classification helpers stay local and do not require a live endpoint
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_module(self, falcon_client):
+        """Set up the RTR Admin module with a real client."""
+        self.module = RTRAdminModule(falcon_client)
+
+    def _skip_if_admin_scope_error(self, result, context: str) -> None:
+        """Skip gracefully when the API client lacks RTR Admin scope."""
+        error_text = ""
+        if isinstance(result, dict) and "error" in result:
+            error_text = str(result)
+        elif isinstance(result, list) and result and isinstance(result[0], dict):
+            if "error" in result[0]:
+                error_text = str(result[0])
+
+        if not error_text:
+            return
+
+        scope_markers = ["403", "permission", "scope", "authorization", "access denied"]
+        if any(marker in error_text.lower() for marker in scope_markers):
+            self.skip_with_warning(
+                f"{context} requires Real time response (admin):write; API returned {error_text}",
+                context=context,
+            )
+
+    def test_search_custom_scripts_operation_name(self):
+        """Validate RTR_ListScripts and RTR_GetScriptsV2 operation usage."""
+        result = self.call_method(self.module.search_scripts, limit=1)
+
+        self._skip_if_admin_scope_error(result, "search_rtr_admin_scripts")
+        self.assert_no_error(result, context="search_rtr_admin_scripts")
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result,
+                min_length=0,
+                context="search_rtr_admin_scripts",
+            )
+
+    def test_search_custom_scripts_with_sort(self):
+        """Validate custom script search accepts documented pipe sort syntax."""
+        result = self.call_method(
+            self.module.search_scripts,
+            sort="created_at|desc",
+            limit=1,
+        )
+
+        self._skip_if_admin_scope_error(result, "search_rtr_admin_scripts sort")
+        self.assert_no_error(result, context="search_rtr_admin_scripts sort")
+
+    def test_search_falcon_scripts_operation_name(self):
+        """Validate RTR_ListFalconScripts and RTR_GetFalconScripts operation usage."""
+        result = self.call_method(self.module.search_falcon_scripts, limit=1)
+
+        self._skip_if_admin_scope_error(result, "search_rtr_falcon_scripts")
+        self.assert_no_error(result, context="search_rtr_falcon_scripts")
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result,
+                min_length=0,
+                context="search_rtr_falcon_scripts",
+            )
+
+    def test_search_falcon_scripts_with_sort(self):
+        """Validate Falcon script search accepts a documented sort field."""
+        result = self.call_method(
+            self.module.search_falcon_scripts,
+            sort="name|asc",
+            limit=1,
+        )
+
+        self._skip_if_admin_scope_error(result, "search_rtr_falcon_scripts sort")
+        self.assert_no_error(result, context="search_rtr_falcon_scripts sort")
+
+    def test_search_put_files_operation_name(self):
+        """Validate RTR_ListPut_Files and RTR_GetPut_FilesV2 operation usage."""
+        result = self.call_method(self.module.search_put_files, limit=1)
+
+        self._skip_if_admin_scope_error(result, "search_rtr_put_files")
+        self.assert_no_error(result, context="search_rtr_put_files")
+        if isinstance(result, list):
+            self.assert_valid_list_response(
+                result,
+                min_length=0,
+                context="search_rtr_put_files",
+            )
+
+    def test_preview_high_impact_command_is_local(self):
+        """Validate high-impact preview returns approval guidance without a Falcon call."""
+        result = self.module.preview_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="runscript",
+            command_string="runscript -Raw=```Get-Process```",
+            target_hostname="HOST-1",
+            reason="integration local policy check",
+            ticket="TEST-LOCAL",
+            expected_effect="no live Falcon call",
+        )
+
+        assert result["operation"] == "RTR_ExecuteAdminCommand"
+        assert result["approval_gate"]["approval_required"] is True
+        assert result["payload_preview"]["body"]["device_id"] == "aid-1"
+        assert result["target"]["device_id"] == "aid-1"

--- a/tests/integration/test_rtr_admin.py
+++ b/tests/integration/test_rtr_admin.py
@@ -59,7 +59,7 @@ class TestRTRAdminIntegration(BaseIntegrationTest):
         """Validate custom script search accepts documented pipe sort syntax."""
         result = self.call_method(
             self.module.search_rtr_admin_scripts,
-            sort="created_at|desc",
+            sort="created_timestamp|desc",
             limit=1,
         )
 

--- a/tests/integration/test_rtr_admin.py
+++ b/tests/integration/test_rtr_admin.py
@@ -13,6 +13,7 @@ class TestRTRAdminIntegration(BaseIntegrationTest):
     Validates:
     - Correct FalconPy operation names for RTR Admin inventory APIs
     - GET query parameter usage for script and put-file detail lookups
+    - Put-file content and command-and-wait helpers fail closed locally when unsafe
     - Sort expressions accepted by the current API contract
     - Preview and classification helpers stay local and do not require a live endpoint
     """
@@ -43,7 +44,7 @@ class TestRTRAdminIntegration(BaseIntegrationTest):
 
     def test_search_custom_scripts_operation_name(self):
         """Validate RTR_ListScripts and RTR_GetScriptsV2 operation usage."""
-        result = self.call_method(self.module.search_scripts, limit=1)
+        result = self.call_method(self.module.search_rtr_admin_scripts, limit=1)
 
         self._skip_if_admin_scope_error(result, "search_rtr_admin_scripts")
         self.assert_no_error(result, context="search_rtr_admin_scripts")
@@ -57,7 +58,7 @@ class TestRTRAdminIntegration(BaseIntegrationTest):
     def test_search_custom_scripts_with_sort(self):
         """Validate custom script search accepts documented pipe sort syntax."""
         result = self.call_method(
-            self.module.search_scripts,
+            self.module.search_rtr_admin_scripts,
             sort="created_at|desc",
             limit=1,
         )
@@ -67,7 +68,7 @@ class TestRTRAdminIntegration(BaseIntegrationTest):
 
     def test_search_falcon_scripts_operation_name(self):
         """Validate RTR_ListFalconScripts and RTR_GetFalconScripts operation usage."""
-        result = self.call_method(self.module.search_falcon_scripts, limit=1)
+        result = self.call_method(self.module.search_rtr_falcon_scripts, limit=1)
 
         self._skip_if_admin_scope_error(result, "search_rtr_falcon_scripts")
         self.assert_no_error(result, context="search_rtr_falcon_scripts")
@@ -81,7 +82,7 @@ class TestRTRAdminIntegration(BaseIntegrationTest):
     def test_search_falcon_scripts_with_sort(self):
         """Validate Falcon script search accepts a documented sort field."""
         result = self.call_method(
-            self.module.search_falcon_scripts,
+            self.module.search_rtr_falcon_scripts,
             sort="name|asc",
             limit=1,
         )
@@ -91,7 +92,7 @@ class TestRTRAdminIntegration(BaseIntegrationTest):
 
     def test_search_put_files_operation_name(self):
         """Validate RTR_ListPut_Files and RTR_GetPut_FilesV2 operation usage."""
-        result = self.call_method(self.module.search_put_files, limit=1)
+        result = self.call_method(self.module.search_rtr_put_files, limit=1)
 
         self._skip_if_admin_scope_error(result, "search_rtr_put_files")
         self.assert_no_error(result, context="search_rtr_put_files")
@@ -104,7 +105,7 @@ class TestRTRAdminIntegration(BaseIntegrationTest):
 
     def test_preview_high_impact_command_is_local(self):
         """Validate high-impact preview returns approval guidance without a Falcon call."""
-        result = self.module.preview_admin_command(
+        result = self.module.preview_rtr_admin_command(
             session_id="session-1",
             device_id="aid-1",
             base_command="runscript",
@@ -119,3 +120,27 @@ class TestRTRAdminIntegration(BaseIntegrationTest):
         assert result["approval_gate"]["approval_required"] is True
         assert result["payload_preview"]["body"]["device_id"] == "aid-1"
         assert result["target"]["device_id"] == "aid-1"
+
+    def test_put_file_contents_requires_id_locally(self):
+        """Validate put-file content retrieval fails closed without a file ID."""
+        result = self.module.get_rtr_put_file_contents(file_id=" ")
+
+        assert "error" in result
+
+    def test_run_admin_command_and_wait_requires_approval_locally(self):
+        """Validate command-and-wait does not bypass high-impact approval."""
+        result = self.module.run_rtr_admin_command_and_wait(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            target_hostname="HOST-1",
+            reason="integration local policy check",
+            ticket="TEST-LOCAL",
+            expected_effect="no live Falcon call",
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+        assert "error" in result
+        assert result["phase"] == "execute"

--- a/tests/modules/test_quarantine.py
+++ b/tests/modules/test_quarantine.py
@@ -78,7 +78,7 @@ class TestQuarantineModule(TestModules):
         self.mock_client.command.side_effect = [query_response, get_response]
 
         result = self.module.search_quarantined_files(
-            filter="hostname:'BRR-WB-LIB-22'",
+            filter="hostname:'EXAMPLE-WIN-22'",
             limit=25,
             offset="0",
             sort="date_updated|desc",
@@ -92,7 +92,7 @@ class TestQuarantineModule(TestModules):
         self.assertEqual(
             first_call[1]["parameters"],
             {
-                "filter": "hostname:'BRR-WB-LIB-22'",
+                "filter": "hostname:'EXAMPLE-WIN-22'",
                 "limit": 25,
                 "offset": "0",
                 "sort": "date_updated|desc",

--- a/tests/modules/test_rtr.py
+++ b/tests/modules/test_rtr.py
@@ -117,7 +117,7 @@ class TestRTRModule(TestModules):
         self.mock_client.command.side_effect = [search_response, details_response]
 
         result = self.module.search_sessions(
-            filter="hostname:'BRR-WB-LIB-22'",
+            filter="hostname:'EXAMPLE-WIN-22'",
             limit=25,
             offset=0,
             sort="created_at.desc",
@@ -128,7 +128,7 @@ class TestRTRModule(TestModules):
         second_call = self.mock_client.command.call_args_list[1]
 
         self.assertEqual(first_call[0][0], "RTR_ListAllSessions")
-        self.assertEqual(first_call[1]["parameters"]["filter"], "hostname:'BRR-WB-LIB-22'")
+        self.assertEqual(first_call[1]["parameters"]["filter"], "hostname:'EXAMPLE-WIN-22'")
         self.assertEqual(first_call[1]["parameters"]["limit"], 25)
         self.assertEqual(first_call[1]["parameters"]["offset"], 0)
         self.assertEqual(first_call[1]["parameters"]["sort"], "created_at.desc")
@@ -147,7 +147,7 @@ class TestRTRModule(TestModules):
                 "resources": [
                     {
                         "id": "audit-session-1",
-                        "hostname": "BRR-WB-LIB-22",
+                        "hostname": "EXAMPLE-WIN-22",
                         "user_id": "user@example.com",
                     }
                 ]

--- a/tests/modules/test_rtr_admin.py
+++ b/tests/modules/test_rtr_admin.py
@@ -1,0 +1,676 @@
+"""
+Tests for the RTR Admin module.
+"""
+
+import inspect
+
+from falcon_mcp.common.api_scopes import get_required_scopes
+from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
+from falcon_mcp.modules.rtr_admin import RTR_ADMIN_EXECUTION_ANNOTATIONS, RTRAdminModule
+from tests.modules.utils.test_modules import TestModules
+
+
+class TestRTRAdminModule(TestModules):
+    """Test cases for the RTR Admin module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(RTRAdminModule)
+
+    def test_register_tools(self):
+        """Test registering tools with the server."""
+        expected_tools = [
+            "falcon_search_rtr_admin_scripts",
+            "falcon_get_rtr_admin_script_details",
+            "falcon_search_rtr_falcon_scripts",
+            "falcon_get_rtr_falcon_script_details",
+            "falcon_search_rtr_put_files",
+            "falcon_get_rtr_put_file_details",
+            "falcon_check_rtr_admin_command_status",
+            "falcon_classify_rtr_admin_command",
+            "falcon_preview_rtr_admin_command",
+            "falcon_execute_rtr_admin_command",
+        ]
+        self.assert_tools_registered(expected_tools)
+        self.assertFalse(hasattr(self.module, "batch_execute_admin_command"))
+
+    def test_tool_annotations(self):
+        """Test tool annotations are correctly set."""
+        self.module.register_tools(self.mock_server)
+
+        for tool_name in [
+            "falcon_search_rtr_admin_scripts",
+            "falcon_get_rtr_admin_script_details",
+            "falcon_search_rtr_falcon_scripts",
+            "falcon_get_rtr_falcon_script_details",
+            "falcon_search_rtr_put_files",
+            "falcon_get_rtr_put_file_details",
+            "falcon_check_rtr_admin_command_status",
+            "falcon_classify_rtr_admin_command",
+            "falcon_preview_rtr_admin_command",
+        ]:
+            self.assert_tool_annotations(tool_name, READ_ONLY_ANNOTATIONS)
+
+        self.assert_tool_annotations(
+            "falcon_execute_rtr_admin_command",
+            RTR_ADMIN_EXECUTION_ANNOTATIONS,
+        )
+
+    def test_register_resources(self):
+        """Test registering resources with the server."""
+        expected_resources = [
+            "falcon_search_rtr_admin_scripts_fql_guide",
+            "falcon_search_rtr_falcon_scripts_fql_guide",
+            "falcon_search_rtr_put_files_fql_guide",
+            "falcon_rtr_admin_tool_use_guide",
+            "falcon_rtr_admin_runscript_raw_guide",
+        ]
+        self.assert_resources_registered(expected_resources)
+
+    def test_register_resources_includes_admin_tool_use_guide(self):
+        """Test RTR Admin workflow guidance is exposed as a resource."""
+        self.module.register_resources(self.mock_server)
+
+        resources = {
+            call.kwargs["resource"].name: call.kwargs["resource"]
+            for call in self.mock_server.add_resource.call_args_list
+        }
+
+        guide = resources["falcon_rtr_admin_tool_use_guide"]
+        self.assertEqual(str(guide.uri), "falcon://rtr-admin/workflows/admin-guide")
+        self.assertIn("Recommended workflow", guide.text)
+        self.assertIn("falcon_preview_rtr_admin_command", guide.text)
+        self.assertIn("classification is enforced", guide.text.lower())
+        self.assertIn("returned sequence_id", guide.text)
+        self.assertNotIn("then increment", guide.text)
+
+    def test_api_scope_mappings(self):
+        """Test RTR Admin operations have explicit scope mappings."""
+        for operation in [
+            "RTR_ListScripts",
+            "RTR_GetScriptsV2",
+            "RTR_ListFalconScripts",
+            "RTR_GetFalconScripts",
+            "RTR_ListPut_Files",
+            "RTR_GetPut_FilesV2",
+            "RTR_CheckAdminCommandStatus",
+            "RTR_ExecuteAdminCommand",
+        ]:
+            self.assertEqual(
+                get_required_scopes(operation),
+                ["Real time response (admin):write"],
+            )
+
+    def test_inventory_limits_match_falconpy_contract(self):
+        """Test search tool limits match the pinned FalconPy endpoint metadata."""
+        self.assertEqual(self._limit_le("search_scripts"), 5000)
+        self.assertEqual(self._limit_le("search_falcon_scripts"), 100)
+        self.assertEqual(self._limit_le("search_put_files"), 5000)
+
+    def test_search_scripts_returns_full_details(self):
+        """Test custom script search fetches details after IDs are returned."""
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"resources": ["script-1", "script-2"]}},
+            {
+                "status_code": 200,
+                "body": {
+                    "resources": [
+                        {"id": "script-1", "name": "collect-a"},
+                        {"id": "script-2", "name": "collect-b"},
+                    ]
+                },
+            },
+        ]
+
+        result = self.module.search_scripts(
+            filter="platform:'windows'",
+            limit=25,
+            offset=5,
+            sort="created_at|desc",
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+        first_call = self.mock_client.command.call_args_list[0]
+        second_call = self.mock_client.command.call_args_list[1]
+
+        self.assertEqual(first_call[0][0], "RTR_ListScripts")
+        self.assertEqual(first_call[1]["parameters"]["filter"], "platform:'windows'")
+        self.assertEqual(first_call[1]["parameters"]["limit"], 25)
+        self.assertEqual(first_call[1]["parameters"]["offset"], 5)
+        self.assertEqual(first_call[1]["parameters"]["sort"], "created_at|desc")
+
+        self.assertEqual(second_call[0][0], "RTR_GetScriptsV2")
+        self.assertEqual(second_call[1]["parameters"]["ids"], ["script-1", "script-2"])
+        self.assertEqual(result[0]["name"], "collect-a")
+
+    def test_search_falcon_scripts_returns_full_details(self):
+        """Test Falcon script search fetches details after IDs are returned."""
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"resources": ["falcon-script-1"]}},
+            {
+                "status_code": 200,
+                "body": {"resources": [{"id": "falcon-script-1", "name": "triage"}]},
+            },
+        ]
+
+        result = self.module.search_falcon_scripts(
+            filter="name:~'triage'",
+            limit=10,
+            offset=None,
+            sort="name|asc",
+        )
+
+        first_call = self.mock_client.command.call_args_list[0]
+        second_call = self.mock_client.command.call_args_list[1]
+
+        self.assertEqual(first_call[0][0], "RTR_ListFalconScripts")
+        self.assertEqual(first_call[1]["parameters"]["filter"], "name:~'triage'")
+        self.assertNotIn("offset", first_call[1]["parameters"])
+        self.assertEqual(second_call[0][0], "RTR_GetFalconScripts")
+        self.assertEqual(second_call[1]["parameters"]["ids"], ["falcon-script-1"])
+        self.assertEqual(result[0]["id"], "falcon-script-1")
+
+    def test_search_put_files_returns_full_details(self):
+        """Test put-file search fetches details after IDs are returned."""
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"resources": ["file-1"]}},
+            {
+                "status_code": 200,
+                "body": {"resources": [{"id": "file-1", "name": "collector.exe"}]},
+            },
+        ]
+
+        result = self.module.search_put_files(
+            filter="name:~'collector'",
+            limit=50,
+            offset=0,
+            sort="created_at|desc",
+        )
+
+        first_call = self.mock_client.command.call_args_list[0]
+        second_call = self.mock_client.command.call_args_list[1]
+
+        self.assertEqual(first_call[0][0], "RTR_ListPut_Files")
+        self.assertEqual(first_call[1]["parameters"]["limit"], 50)
+        self.assertEqual(first_call[1]["parameters"]["offset"], 0)
+        self.assertEqual(second_call[0][0], "RTR_GetPut_FilesV2")
+        self.assertEqual(second_call[1]["parameters"]["ids"], ["file-1"])
+        self.assertEqual(result[0]["name"], "collector.exe")
+
+    def test_get_details_empty_ids_return_without_api_call(self):
+        """Test detail helpers return early for empty ID lists."""
+        self.assertEqual(self.module.get_script_details(ids=[]), [])
+        self.assertEqual(self.module.get_falcon_script_details(ids=[]), [])
+        self.assertEqual(self.module.get_put_file_details(ids=[]), [])
+        self.mock_client.command.assert_not_called()
+
+    def test_get_script_details_uses_query_parameters(self):
+        """Test custom script details use query parameters for IDs."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "script-1"}]},
+        }
+
+        result = self.module.get_script_details(ids=["script-1"])
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_GetScriptsV2",
+            parameters={"ids": ["script-1"]},
+        )
+        self.assertEqual(result[0]["id"], "script-1")
+
+    def test_search_error_returns_fql_guide(self):
+        """Test search errors include the relevant FQL guide."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid filter"}]},
+        }
+
+        result = self.module.search_scripts(
+            filter="invalid:::filter",
+            limit=10,
+            offset=None,
+            sort=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("fql_guide", result)
+        self.assertIn("Filter error occurred", result["hint"])
+
+    def test_empty_search_returns_fql_guide(self):
+        """Test empty search results include the relevant FQL guide."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.search_put_files(
+            filter="name:'not-real'",
+            limit=10,
+            offset=None,
+            sort=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("fql_guide", result)
+        self.assertIn("No results matched", result["hint"])
+
+    def test_check_admin_command_status(self):
+        """Test retrieving RTR Admin command status."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"complete": True, "stdout": "ok"}]},
+        }
+
+        result = self.module.check_admin_command_status(
+            cloud_request_id="req-123",
+            sequence_id=1,
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_CheckAdminCommandStatus",
+            parameters={"cloud_request_id": "req-123", "sequence_id": 1},
+        )
+        self.assertTrue(result[0]["complete"])
+
+    def test_check_admin_command_status_validates_required_fields(self):
+        """Test command status lookup fails locally for invalid inputs."""
+        missing_request = self.module.check_admin_command_status(
+            cloud_request_id=" ",
+            sequence_id=0,
+        )
+        invalid_sequence = self.module.check_admin_command_status(
+            cloud_request_id="req-123",
+            sequence_id=-1,
+        )
+
+        self.assertIn("error", missing_request)
+        self.assertIn("error", invalid_sequence)
+        self.mock_client.command.assert_not_called()
+
+    def test_classify_read_only_command(self):
+        """Test read-only commands are classified as low risk."""
+        result = self.module.classify_admin_command(base_command="ps")
+
+        self.assertEqual(result["category"], "read_only")
+        self.assertEqual(result["risk"], "low")
+        self.assertTrue(result["allowed_for_execution"])
+        self.assertIn("safety_disclaimer", result)
+        self.assertIsNone(result["blocked_reason"])
+        self.mock_client.command.assert_not_called()
+
+    def test_classify_registry_query_only(self):
+        """Test only read-only registry queries are allowed."""
+        allowed = self.module.classify_admin_command(
+            base_command="reg",
+            command_string=r"reg query HKLM\Software\Microsoft",
+        )
+        blocked = self.module.classify_admin_command(
+            base_command="reg",
+            command_string=r"reg delete HKLM\Software\Test",
+        )
+
+        self.assertEqual(allowed["category"], "read_only")
+        self.assertTrue(allowed["allowed_for_execution"])
+        self.assertEqual(blocked["category"], "high_impact")
+        self.assertFalse(blocked["allowed_for_execution"])
+        self.assertTrue(blocked["requires_approval"])
+        self.mock_client.command.assert_not_called()
+
+    def test_classify_update_read_only_subcommands(self):
+        """Test documented read-only update subcommands are not blocked as installs."""
+        for command_string in [
+            "update history",
+            "update list",
+            "update query",
+        ]:
+            with self.subTest(command_string=command_string):
+                result = self.module.classify_admin_command(
+                    base_command="update",
+                    command_string=command_string,
+                )
+
+                self.assertEqual(result["category"], "read_only")
+                self.assertEqual(result["risk"], "low")
+                self.assertTrue(result["allowed_for_execution"])
+
+        install = self.module.classify_admin_command(
+            base_command="update",
+            command_string="update install",
+        )
+        self.assertEqual(install["category"], "high_impact")
+        self.assertFalse(install["allowed_for_execution"])
+        self.assertTrue(install["requires_approval"])
+        self.mock_client.command.assert_not_called()
+
+    def test_classify_unsupported_rtr_commands_as_unknown(self):
+        """Test non-documented RTR Admin commands are not treated as low risk."""
+        for base_command in ["csrutil", "ifconfig", "users"]:
+            with self.subTest(base_command=base_command):
+                result = self.module.classify_admin_command(base_command=base_command)
+
+                self.assertEqual(result["category"], "unknown")
+                self.assertFalse(result["allowed_for_execution"])
+                self.assertFalse(result["requires_approval"])
+        self.mock_client.command.assert_not_called()
+
+    def test_classify_destructive_and_unknown_commands_are_blocked(self):
+        """Test destructive and unknown commands are blocked."""
+        destructive = self.module.classify_admin_command(base_command="rm")
+        unknown = self.module.classify_admin_command(base_command="not-a-command")
+
+        self.assertEqual(destructive["risk"], "critical")
+        self.assertFalse(destructive["allowed_for_execution"])
+        self.assertTrue(destructive["requires_approval"])
+        self.assertIsNotNone(destructive["blocked_reason"])
+        self.assertEqual(unknown["category"], "unknown")
+        self.assertFalse(unknown["allowed_for_execution"])
+        self.assertFalse(unknown["requires_approval"])
+        self.mock_client.command.assert_not_called()
+
+    def test_classify_empty_base_command_returns_error(self):
+        """Test empty base command validation."""
+        result = self.module.classify_admin_command(base_command=" ")
+
+        self.assertIn("error", result)
+        self.mock_client.command.assert_not_called()
+
+    def test_preview_admin_command_does_not_call_falcon(self):
+        """Test command preview returns a payload shape without executing."""
+        result = self.module.preview_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="get",
+            command_string=r"get C:\Temp\sample.bin",
+            command_id=7,
+            target_hostname="HOST-1",
+            reason="collect sample",
+            ticket="INC-123",
+            expected_effect="retrieve one file for analysis",
+            persist=False,
+        )
+
+        self.assertTrue(result["execution_available"])
+        self.assertEqual(result["execution_tool"], "falcon_execute_rtr_admin_command")
+        self.assertTrue(result["policy_allows_future_execution"])
+        self.assertTrue(result["classification_enforced"])
+        self.assertFalse(result["approval_gate"]["approval_required"])
+        self.assertIn("safety_disclaimer", result)
+        self.assertEqual(result["operation"], "RTR_ExecuteAdminCommand")
+        self.assertEqual(result["missing_context"], [])
+        self.assertEqual(result["required_context"], ["reason", "ticket", "expected_effect"])
+        self.assertEqual(result["target"]["device_id"], "aid-1")
+        self.assertEqual(result["target"]["hostname"], "HOST-1")
+        self.assertEqual(result["payload_preview"]["body"]["device_id"], "aid-1")
+        self.assertEqual(result["payload_preview"]["body"]["session_id"], "session-1")
+        self.assertEqual(result["payload_preview"]["body"]["id"], 7)
+        self.mock_client.command.assert_not_called()
+
+    def test_preview_approval_phrase_matches_execution_payload_with_device_id(self):
+        """Test preview and execution approval use the same target and payload material."""
+        preview = self.module.preview_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            command_id=7,
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+            persist=True,
+        )
+        approval_phrase = preview["approval_gate"]["approval_phrase"]
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-123"}]},
+        }
+
+        result = self.module.execute_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            command_id=7,
+            persist=True,
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+            operator_approval=approval_phrase,
+        )
+
+        self.assertTrue(result["submitted"])
+        self.assertTrue(result["approval_gate"]["approved"])
+        self.mock_client.command.assert_called_once()
+
+    def test_preview_admin_command_reports_missing_context(self):
+        """Test command preview calls out missing audit context."""
+        result = self.module.preview_admin_command(
+            session_id="session-1",
+            base_command="runscript",
+            command_string="runscript -Raw=```Get-Process```",
+            target_hostname=None,
+            reason=None,
+            ticket=None,
+            expected_effect=None,
+            persist=False,
+        )
+
+        self.assertTrue(result["execution_available"])
+        self.assertEqual(result["missing_context"], ["reason", "ticket", "expected_effect"])
+        self.assertTrue(result["approval_gate"]["approval_required"])
+        self.assertRegex(result["approval_gate"]["approval_phrase"], r"^APPROVE_RTR_ADMIN_[0-9A-F]{16}$")
+        self.assertEqual(
+            result["command_guidance"]["resource"],
+            "falcon://rtr-admin/commands/runscript-guide",
+        )
+        self.mock_client.command.assert_not_called()
+
+    def test_preview_admin_command_missing_required_fields_returns_error(self):
+        """Test command preview rejects missing required command fields."""
+        result = self.module.preview_admin_command(
+            session_id=" ",
+            base_command="ps",
+            command_string=" ",
+        )
+
+        self.assertIn("error", result)
+        self.assertEqual(result["details"]["missing_required"], ["session_id", "command_string"])
+        self.mock_client.command.assert_not_called()
+
+    def test_execute_admin_command_submits_low_risk_single_host_body(self):
+        """Test low-risk single-host RTR Admin execution submits the expected body."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-123"}]},
+        }
+
+        result = self.module.execute_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="ps",
+            command_string="ps",
+            command_id=7,
+            persist=False,
+            target_hostname="HOST-1",
+            reason="process review",
+            ticket="INC-123",
+            expected_effect="list processes",
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_ExecuteAdminCommand",
+            body={
+                "base_command": "ps",
+                "command_string": "ps",
+                "device_id": "aid-1",
+                "session_id": "session-1",
+                "id": 7,
+                "persist": False,
+            },
+        )
+        self.assertTrue(result["submitted"])
+        self.assertTrue(result["classification_enforced"])
+        self.assertFalse(result["approval_gate"]["approval_required"])
+        self.assertTrue(result["approval_gate"]["approved"])
+        self.assertEqual(result["operation"], "RTR_ExecuteAdminCommand")
+        self.assertEqual(result["result"][0]["cloud_request_id"], "req-123")
+        self.assertNotIn("persist_warning", result)
+
+    def test_execute_admin_command_requires_approval_for_high_impact_command(self):
+        """Test high-impact single-host execution stops before the Falcon call."""
+        result = self.module.execute_admin_command(
+            session_id="session-1",
+            device_id=None,
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            command_id=7,
+            persist=True,
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("approval required", result["error"].lower())
+        self.assertTrue(result["details"]["approval_gate"]["approval_required"])
+        self.assertRegex(
+            result["details"]["approval_gate"]["approval_phrase"],
+            r"^APPROVE_RTR_ADMIN_[0-9A-F]{16}$",
+        )
+        self.mock_client.command.assert_not_called()
+
+    def test_execute_admin_command_submits_high_impact_after_exact_approval(self):
+        """Test high-impact single-host execution submits only after exact approval."""
+        blocked = self.module.execute_admin_command(
+            session_id="session-1",
+            device_id=None,
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            command_id=7,
+            persist=True,
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+        )
+        approval_phrase = blocked["details"]["approval_gate"]["approval_phrase"]
+        self.mock_client.command.assert_not_called()
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-123"}]},
+        }
+
+        result = self.module.execute_admin_command(
+            session_id="session-1",
+            device_id=None,
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            command_id=7,
+            persist=True,
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+            operator_approval=approval_phrase,
+        )
+
+        self.assertTrue(result["submitted"])
+        self.assertTrue(result["classification_enforced"])
+        self.assertTrue(result["approval_gate"]["approval_required"])
+        self.assertTrue(result["approval_gate"]["approved"])
+        self.assertIn("persist_warning", result)
+        self.mock_client.command.assert_called_once()
+
+    def test_execute_admin_command_returns_runscript_raw_guidance(self):
+        """Test raw runscript execution includes controller guidance."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-raw"}]},
+        }
+
+        result = self.module.execute_admin_command(
+            session_id="session-1",
+            base_command="runscript",
+            command_string="runscript -Raw=```Get-Process```",
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("approval required", result["error"].lower())
+        self.assertTrue(result["details"]["approval_gate"]["approval_required"])
+        self.mock_client.command.assert_not_called()
+        self.assertTrue(
+            result["details"]["approval_gate"]["approval_phrase"].startswith(
+                "APPROVE_RTR_ADMIN_"
+            )
+        )
+        self.assertEqual(
+            result["details"]["payload_preview"]["body"]["command_string"],
+            "runscript -Raw=```Get-Process```",
+        )
+        self.assertEqual(
+            self.module._command_guidance("runscript", "runscript -Raw=```Get-Process```")[
+                "shape"
+            ],
+            "runscript -Raw=```<target-side script>```",
+        )
+
+    def test_execute_admin_command_requires_target_and_command(self):
+        """Test single-host RTR Admin execution validates minimum fields locally."""
+        result = self.module.execute_admin_command(
+            session_id=None,
+            device_id=None,
+            base_command=" ",
+            command_string=" ",
+        )
+
+        self.assertIn("error", result)
+        self.assertEqual(
+            result["details"]["missing_required"],
+            ["base_command", "command_string", "session_id"],
+        )
+        self.mock_client.command.assert_not_called()
+
+    def test_execute_admin_command_rejects_device_only_target(self):
+        """Test single-host RTR Admin execution requires an existing RTR session."""
+        result = self.module.execute_admin_command(
+            device_id="aid-1",
+            base_command="ps",
+            command_string="ps",
+        )
+
+        self.assertIn("error", result)
+        self.assertEqual(result["details"]["missing_required"], ["session_id"])
+        self.mock_client.command.assert_not_called()
+
+    def test_execute_admin_command_wraps_api_error(self):
+        """Test single-host RTR Admin execution includes context on API errors."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied"}]},
+        }
+
+        result = self.module.execute_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="ps",
+            command_string="ps",
+        )
+
+        self.assertFalse(result["submitted"])
+        self.assertIn("error", result["result"])
+        self.assertEqual(result["missing_context"], ["reason", "ticket", "expected_effect"])
+
+    def _limit_le(self, method_name: str) -> int:
+        """Return the Pydantic upper-bound metadata for a search limit parameter."""
+        signature = inspect.signature(getattr(self.module, method_name))
+        limit_field = signature.parameters["limit"].default
+        for item in limit_field.metadata:
+            le = getattr(item, "le", None)
+            if le is not None:
+                return le
+        raise AssertionError(f"No upper limit metadata found for {method_name}")

--- a/tests/modules/test_rtr_admin.py
+++ b/tests/modules/test_rtr_admin.py
@@ -232,7 +232,7 @@ class TestRTRAdminModule(TestModules):
             filter="platform:'windows'",
             limit=25,
             offset=5,
-            sort="created_at|desc",
+            sort="created_timestamp|desc",
         )
 
         self.assertEqual(self.mock_client.command.call_count, 2)
@@ -243,11 +243,54 @@ class TestRTRAdminModule(TestModules):
         self.assertEqual(first_call[1]["parameters"]["filter"], "platform:'windows'")
         self.assertEqual(first_call[1]["parameters"]["limit"], 25)
         self.assertEqual(first_call[1]["parameters"]["offset"], 5)
-        self.assertEqual(first_call[1]["parameters"]["sort"], "created_at|desc")
+        self.assertEqual(first_call[1]["parameters"]["sort"], "created_timestamp|desc")
 
         self.assertEqual(second_call[0][0], "RTR_GetScriptsV2")
         self.assertEqual(second_call[1]["parameters"]["ids"], ["script-1", "script-2"])
         self.assertEqual(result[0]["name"], "collect-a")
+
+    def test_search_scripts_preserves_query_id_order_after_detail_fetch(self):
+        """Test detail responses are returned in the original search ID order."""
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"resources": ["script-2", "script-1"]}},
+            {
+                "status_code": 200,
+                "body": {
+                    "resources": [
+                        {"id": "script-1", "name": "older"},
+                        {"id": "script-2", "name": "newer"},
+                    ]
+                },
+            },
+        ]
+
+        result = self.module.search_rtr_admin_scripts(sort="created_timestamp|desc")
+
+        first_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(
+            first_call[1]["parameters"],
+            {"limit": 10, "sort": "created_timestamp|desc"},
+        )
+        self.assertEqual([item["id"] for item in result], ["script-2", "script-1"])
+
+    def test_search_put_files_defaults_do_not_send_fieldinfo_values(self):
+        """Test omitted optional search params are not sent as FieldInfo objects."""
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"resources": ["file-1"]}},
+            {
+                "status_code": 200,
+                "body": {"resources": [{"id": "file-1", "name": "collector.exe"}]},
+            },
+        ]
+
+        result = self.module.search_rtr_put_files(sort="created_timestamp|desc")
+
+        first_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(
+            first_call[1]["parameters"],
+            {"limit": 10, "sort": "created_timestamp|desc"},
+        )
+        self.assertEqual(result[0]["id"], "file-1")
 
     def test_search_falcon_scripts_returns_full_details(self):
         """Test Falcon script search fetches details after IDs are returned."""
@@ -290,7 +333,7 @@ class TestRTRAdminModule(TestModules):
             filter="name:~'collector'",
             limit=50,
             offset=0,
-            sort="created_at|desc",
+            sort="created_timestamp|desc",
         )
 
         first_call = self.mock_client.command.call_args_list[0]
@@ -333,6 +376,28 @@ class TestRTRAdminModule(TestModules):
         )
         self.assertEqual(result["id"], "file-1")
         self.assertEqual(result["body"]["content"], "payload")
+
+    def test_get_put_file_contents_warns_when_binary_metadata_returns_text(self):
+        """Test text retrieval is sensitive even when inventory metadata says binary."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "id": "file-1",
+                        "file_type": "binary",
+                        "content_format": "text",
+                        "content": "script payload",
+                    }
+                ]
+            },
+        }
+
+        result = self.module.get_rtr_put_file_contents(file_id="file-1")
+
+        self.assertEqual(result[0]["content_format"], "text")
+        self.assertEqual(result[0]["file_type"], "binary")
+        self.assertIn("sensitivity_warning", result[0])
 
     def test_get_put_file_contents_decodes_text_bytes(self):
         """Test text byte content is decoded into a model-safe response."""
@@ -489,6 +554,10 @@ class TestRTRAdminModule(TestModules):
             base_command="reg",
             command_string=r"reg query HKLM\Software\Microsoft",
         )
+        warned = self.module.classify_rtr_admin_command(
+            base_command="reg",
+            command_string=r"reg query HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion ProductName",
+        )
         blocked = self.module.classify_rtr_admin_command(
             base_command="reg",
             command_string=r"reg delete HKLM\Software\Test",
@@ -496,6 +565,9 @@ class TestRTRAdminModule(TestModules):
 
         self.assertEqual(allowed["category"], "read_only")
         self.assertTrue(allowed["allowed_for_execution"])
+        self.assertEqual(allowed["command_warnings"], [])
+        self.assertEqual(warned["category"], "read_only")
+        self.assertTrue(warned["command_warnings"])
         self.assertEqual(blocked["category"], "high_impact")
         self.assertFalse(blocked["allowed_for_execution"])
         self.assertTrue(blocked["requires_approval"])
@@ -673,6 +745,34 @@ class TestRTRAdminModule(TestModules):
         self.assertTrue(result["approval_gate"]["approved"])
         self.mock_client.command.assert_called_once()
 
+    def test_approval_hash_binds_expected_effect(self):
+        """Test changed audit context changes the high-impact approval phrase."""
+        first = self.module.preview_rtr_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+        )
+        second = self.module.preview_rtr_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected directory",
+        )
+
+        self.assertNotEqual(
+            first["approval_gate"]["approval_phrase"],
+            second["approval_gate"]["approval_phrase"],
+        )
+
     def test_approval_hash_independent_of_hostname(self):
         """Test that hostname differences do not break approval phrase matching."""
         preview = self.module.preview_rtr_admin_command(
@@ -727,7 +827,12 @@ class TestRTRAdminModule(TestModules):
         self.assertTrue(result["execution_available"])
         self.assertEqual(result["missing_context"], ["reason", "ticket", "expected_effect"])
         self.assertTrue(result["approval_gate"]["approval_required"])
-        self.assertRegex(result["approval_gate"]["approval_phrase"], r"^APPROVE_RTR_ADMIN_[0-9A-F]{16}$")
+        self.assertFalse(result["approval_gate"]["approval_ready"])
+        self.assertNotIn("approval_phrase", result["approval_gate"])
+        self.assertEqual(
+            result["approval_gate"]["missing_approval_context"],
+            ["reason", "ticket", "expected_effect", "device_id"],
+        )
         self.assertEqual(
             result["command_guidance"]["resource"],
             "falcon://rtr-admin/commands/runscript-guide",
@@ -802,7 +907,7 @@ class TestRTRAdminModule(TestModules):
         """Test high-impact single-host execution stops before the Falcon call."""
         result = self.module.execute_rtr_admin_command(
             session_id="session-1",
-            device_id=None,
+            device_id="aid-1",
             base_command="rm",
             command_string=r"rm C:\Temp\old.bin",
             command_id=7,
@@ -816,17 +921,43 @@ class TestRTRAdminModule(TestModules):
         self.assertIn("error", result)
         self.assertIn("approval required", result["error"].lower())
         self.assertTrue(result["details"]["approval_gate"]["approval_required"])
+        self.assertTrue(result["details"]["approval_gate"]["approval_ready"])
         self.assertRegex(
             result["details"]["approval_gate"]["approval_phrase"],
             r"^APPROVE_RTR_ADMIN_[0-9A-F]{16}$",
         )
         self.mock_client.command.assert_not_called()
 
+    def test_execute_admin_command_requires_device_id_for_high_impact_approval(self):
+        """Test high-impact approval is not issued without a device ID."""
+        result = self.module.execute_rtr_admin_command(
+            session_id="session-1",
+            device_id=None,
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            command_id=7,
+            persist=True,
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("approval context is incomplete", result["error"])
+        self.assertFalse(result["details"]["approval_gate"]["approval_ready"])
+        self.assertEqual(
+            result["details"]["approval_gate"]["missing_approval_context"],
+            ["device_id"],
+        )
+        self.assertNotIn("approval_phrase", result["details"]["approval_gate"])
+        self.mock_client.command.assert_not_called()
+
     def test_execute_admin_command_submits_high_impact_after_exact_approval(self):
         """Test high-impact single-host execution submits only after exact approval."""
         blocked = self.module.execute_rtr_admin_command(
             session_id="session-1",
-            device_id=None,
+            device_id="aid-1",
             base_command="rm",
             command_string=r"rm C:\Temp\old.bin",
             command_id=7,
@@ -845,7 +976,7 @@ class TestRTRAdminModule(TestModules):
 
         result = self.module.execute_rtr_admin_command(
             session_id="session-1",
-            device_id=None,
+            device_id="aid-1",
             base_command="rm",
             command_string=r"rm C:\Temp\old.bin",
             command_id=7,
@@ -878,14 +1009,11 @@ class TestRTRAdminModule(TestModules):
         )
 
         self.assertIn("error", result)
-        self.assertIn("approval required", result["error"].lower())
+        self.assertIn("approval context is incomplete", result["error"])
         self.assertTrue(result["details"]["approval_gate"]["approval_required"])
+        self.assertFalse(result["details"]["approval_gate"]["approval_ready"])
         self.mock_client.command.assert_not_called()
-        self.assertTrue(
-            result["details"]["approval_gate"]["approval_phrase"].startswith(
-                "APPROVE_RTR_ADMIN_"
-            )
-        )
+        self.assertNotIn("approval_phrase", result["details"]["approval_gate"])
         self.assertEqual(
             result["details"]["payload_preview"]["body"]["command_string"],
             "runscript -Raw=```Get-Process```",
@@ -1046,6 +1174,8 @@ class TestRTRAdminModule(TestModules):
         )
         self.assertEqual(result["stdout"], "part1part2")
         self.assertTrue(result["complete"])
+        self.assertIn("context_warning", result)
+        self.assertEqual(result["missing_context"], ["reason", "ticket", "expected_effect"])
 
     def test_run_admin_command_and_wait_requires_approval_before_falcon_call(self):
         """Test RTR Admin command-and-wait does not bypass high-impact approval."""

--- a/tests/modules/test_rtr_admin.py
+++ b/tests/modules/test_rtr_admin.py
@@ -4,9 +4,11 @@ Tests for the RTR Admin module.
 
 import inspect
 
+from mcp.types import ToolAnnotations
+
 from falcon_mcp.common.api_scopes import get_required_scopes
 from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
-from falcon_mcp.modules.rtr_admin import RTR_ADMIN_EXECUTION_ANNOTATIONS, RTRAdminModule
+from falcon_mcp.modules.rtr_admin import RTRAdminModule
 from tests.modules.utils.test_modules import TestModules
 
 
@@ -21,11 +23,8 @@ class TestRTRAdminModule(TestModules):
         """Test registering tools with the server."""
         expected_tools = [
             "falcon_search_rtr_admin_scripts",
-            "falcon_get_rtr_admin_script_details",
             "falcon_search_rtr_falcon_scripts",
-            "falcon_get_rtr_falcon_script_details",
             "falcon_search_rtr_put_files",
-            "falcon_get_rtr_put_file_details",
             "falcon_check_rtr_admin_command_status",
             "falcon_classify_rtr_admin_command",
             "falcon_preview_rtr_admin_command",
@@ -40,11 +39,8 @@ class TestRTRAdminModule(TestModules):
 
         for tool_name in [
             "falcon_search_rtr_admin_scripts",
-            "falcon_get_rtr_admin_script_details",
             "falcon_search_rtr_falcon_scripts",
-            "falcon_get_rtr_falcon_script_details",
             "falcon_search_rtr_put_files",
-            "falcon_get_rtr_put_file_details",
             "falcon_check_rtr_admin_command_status",
             "falcon_classify_rtr_admin_command",
             "falcon_preview_rtr_admin_command",
@@ -53,7 +49,12 @@ class TestRTRAdminModule(TestModules):
 
         self.assert_tool_annotations(
             "falcon_execute_rtr_admin_command",
-            RTR_ADMIN_EXECUTION_ANNOTATIONS,
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
         )
 
     def test_register_resources(self):
@@ -103,9 +104,9 @@ class TestRTRAdminModule(TestModules):
 
     def test_inventory_limits_match_falconpy_contract(self):
         """Test search tool limits match the pinned FalconPy endpoint metadata."""
-        self.assertEqual(self._limit_le("search_scripts"), 5000)
-        self.assertEqual(self._limit_le("search_falcon_scripts"), 100)
-        self.assertEqual(self._limit_le("search_put_files"), 5000)
+        self.assertEqual(self._limit_le("search_rtr_admin_scripts"), 5000)
+        self.assertEqual(self._limit_le("search_rtr_falcon_scripts"), 100)
+        self.assertEqual(self._limit_le("search_rtr_put_files"), 5000)
 
     def test_search_scripts_returns_full_details(self):
         """Test custom script search fetches details after IDs are returned."""
@@ -122,7 +123,7 @@ class TestRTRAdminModule(TestModules):
             },
         ]
 
-        result = self.module.search_scripts(
+        result = self.module.search_rtr_admin_scripts(
             filter="platform:'windows'",
             limit=25,
             offset=5,
@@ -153,7 +154,7 @@ class TestRTRAdminModule(TestModules):
             },
         ]
 
-        result = self.module.search_falcon_scripts(
+        result = self.module.search_rtr_falcon_scripts(
             filter="name:~'triage'",
             limit=10,
             offset=None,
@@ -180,7 +181,7 @@ class TestRTRAdminModule(TestModules):
             },
         ]
 
-        result = self.module.search_put_files(
+        result = self.module.search_rtr_put_files(
             filter="name:~'collector'",
             limit=50,
             offset=0,
@@ -197,27 +198,32 @@ class TestRTRAdminModule(TestModules):
         self.assertEqual(second_call[1]["parameters"]["ids"], ["file-1"])
         self.assertEqual(result[0]["name"], "collector.exe")
 
-    def test_get_details_empty_ids_return_without_api_call(self):
-        """Test detail helpers return early for empty ID lists."""
-        self.assertEqual(self.module.get_script_details(ids=[]), [])
-        self.assertEqual(self.module.get_falcon_script_details(ids=[]), [])
-        self.assertEqual(self.module.get_put_file_details(ids=[]), [])
-        self.mock_client.command.assert_not_called()
+    def test_search_by_id_filter_round_trips_query_and_get(self):
+        """Test ID lookups go through the search query→get round-trip."""
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"resources": ["script-1"]}},
+            {
+                "status_code": 200,
+                "body": {"resources": [{"id": "script-1", "name": "collect-a"}]},
+            },
+        ]
 
-    def test_get_script_details_uses_query_parameters(self):
-        """Test custom script details use query parameters for IDs."""
-        self.mock_client.command.return_value = {
-            "status_code": 200,
-            "body": {"resources": [{"id": "script-1"}]},
-        }
-
-        result = self.module.get_script_details(ids=["script-1"])
-
-        self.mock_client.command.assert_called_once_with(
-            "RTR_GetScriptsV2",
-            parameters={"ids": ["script-1"]},
+        result = self.module.search_rtr_admin_scripts(
+            filter="id:'script-1'",
+            limit=10,
+            offset=None,
+            sort=None,
         )
-        self.assertEqual(result[0]["id"], "script-1")
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+        first_call = self.mock_client.command.call_args_list[0]
+        second_call = self.mock_client.command.call_args_list[1]
+
+        self.assertEqual(first_call[0][0], "RTR_ListScripts")
+        self.assertEqual(first_call[1]["parameters"]["filter"], "id:'script-1'")
+        self.assertEqual(second_call[0][0], "RTR_GetScriptsV2")
+        self.assertEqual(second_call[1]["parameters"]["ids"], ["script-1"])
+        self.assertEqual(result[0]["name"], "collect-a")
 
     def test_search_error_returns_fql_guide(self):
         """Test search errors include the relevant FQL guide."""
@@ -226,7 +232,7 @@ class TestRTRAdminModule(TestModules):
             "body": {"errors": [{"message": "Invalid filter"}]},
         }
 
-        result = self.module.search_scripts(
+        result = self.module.search_rtr_admin_scripts(
             filter="invalid:::filter",
             limit=10,
             offset=None,
@@ -245,7 +251,7 @@ class TestRTRAdminModule(TestModules):
             "body": {"resources": []},
         }
 
-        result = self.module.search_put_files(
+        result = self.module.search_rtr_put_files(
             filter="name:'not-real'",
             limit=10,
             offset=None,
@@ -264,7 +270,7 @@ class TestRTRAdminModule(TestModules):
             "body": {"resources": [{"complete": True, "stdout": "ok"}]},
         }
 
-        result = self.module.check_admin_command_status(
+        result = self.module.check_rtr_admin_command_status(
             cloud_request_id="req-123",
             sequence_id=1,
         )
@@ -277,11 +283,11 @@ class TestRTRAdminModule(TestModules):
 
     def test_check_admin_command_status_validates_required_fields(self):
         """Test command status lookup fails locally for invalid inputs."""
-        missing_request = self.module.check_admin_command_status(
+        missing_request = self.module.check_rtr_admin_command_status(
             cloud_request_id=" ",
             sequence_id=0,
         )
-        invalid_sequence = self.module.check_admin_command_status(
+        invalid_sequence = self.module.check_rtr_admin_command_status(
             cloud_request_id="req-123",
             sequence_id=-1,
         )
@@ -292,7 +298,7 @@ class TestRTRAdminModule(TestModules):
 
     def test_classify_read_only_command(self):
         """Test read-only commands are classified as low risk."""
-        result = self.module.classify_admin_command(base_command="ps")
+        result = self.module.classify_rtr_admin_command(base_command="ps")
 
         self.assertEqual(result["category"], "read_only")
         self.assertEqual(result["risk"], "low")
@@ -303,11 +309,11 @@ class TestRTRAdminModule(TestModules):
 
     def test_classify_registry_query_only(self):
         """Test only read-only registry queries are allowed."""
-        allowed = self.module.classify_admin_command(
+        allowed = self.module.classify_rtr_admin_command(
             base_command="reg",
             command_string=r"reg query HKLM\Software\Microsoft",
         )
-        blocked = self.module.classify_admin_command(
+        blocked = self.module.classify_rtr_admin_command(
             base_command="reg",
             command_string=r"reg delete HKLM\Software\Test",
         )
@@ -327,7 +333,7 @@ class TestRTRAdminModule(TestModules):
             "update query",
         ]:
             with self.subTest(command_string=command_string):
-                result = self.module.classify_admin_command(
+                result = self.module.classify_rtr_admin_command(
                     base_command="update",
                     command_string=command_string,
                 )
@@ -336,7 +342,7 @@ class TestRTRAdminModule(TestModules):
                 self.assertEqual(result["risk"], "low")
                 self.assertTrue(result["allowed_for_execution"])
 
-        install = self.module.classify_admin_command(
+        install = self.module.classify_rtr_admin_command(
             base_command="update",
             command_string="update install",
         )
@@ -347,19 +353,43 @@ class TestRTRAdminModule(TestModules):
 
     def test_classify_unsupported_rtr_commands_as_unknown(self):
         """Test non-documented RTR Admin commands are not treated as low risk."""
-        for base_command in ["csrutil", "ifconfig", "users"]:
+        for base_command in ["totally-fake", "notacommand"]:
             with self.subTest(base_command=base_command):
-                result = self.module.classify_admin_command(base_command=base_command)
+                result = self.module.classify_rtr_admin_command(base_command=base_command)
 
                 self.assertEqual(result["category"], "unknown")
                 self.assertFalse(result["allowed_for_execution"])
                 self.assertFalse(result["requires_approval"])
         self.mock_client.command.assert_not_called()
 
+    def test_classify_newly_added_read_only_commands(self):
+        """Test csrutil, ifconfig, users, pwd are classified as read-only."""
+        for base_command in ["csrutil", "ifconfig", "users", "pwd"]:
+            with self.subTest(base_command=base_command):
+                result = self.module.classify_rtr_admin_command(base_command=base_command)
+
+                self.assertEqual(result["category"], "read_only")
+                self.assertEqual(result["risk"], "low")
+                self.assertTrue(result["allowed_for_execution"])
+        self.mock_client.command.assert_not_called()
+
+    def test_classify_newly_added_blocked_commands(self):
+        """Test tar, umount, rmdir, cswindiag, falconscript are blocked with approval."""
+        for base_command in ["tar", "umount", "rmdir", "cswindiag", "falconscript"]:
+            with self.subTest(base_command=base_command):
+                result = self.module.classify_rtr_admin_command(base_command=base_command)
+
+                self.assertEqual(result["category"], "high_impact")
+                self.assertEqual(result["risk"], "critical")
+                self.assertFalse(result["allowed_for_execution"])
+                self.assertTrue(result["requires_approval"])
+                self.assertTrue(result["can_execute_with_approval"])
+        self.mock_client.command.assert_not_called()
+
     def test_classify_destructive_and_unknown_commands_are_blocked(self):
         """Test destructive and unknown commands are blocked."""
-        destructive = self.module.classify_admin_command(base_command="rm")
-        unknown = self.module.classify_admin_command(base_command="not-a-command")
+        destructive = self.module.classify_rtr_admin_command(base_command="rm")
+        unknown = self.module.classify_rtr_admin_command(base_command="not-a-command")
 
         self.assertEqual(destructive["risk"], "critical")
         self.assertFalse(destructive["allowed_for_execution"])
@@ -372,14 +402,14 @@ class TestRTRAdminModule(TestModules):
 
     def test_classify_empty_base_command_returns_error(self):
         """Test empty base command validation."""
-        result = self.module.classify_admin_command(base_command=" ")
+        result = self.module.classify_rtr_admin_command(base_command=" ")
 
         self.assertIn("error", result)
         self.mock_client.command.assert_not_called()
 
     def test_preview_admin_command_does_not_call_falcon(self):
         """Test command preview returns a payload shape without executing."""
-        result = self.module.preview_admin_command(
+        result = self.module.preview_rtr_admin_command(
             session_id="session-1",
             device_id="aid-1",
             base_command="get",
@@ -394,9 +424,9 @@ class TestRTRAdminModule(TestModules):
 
         self.assertTrue(result["execution_available"])
         self.assertEqual(result["execution_tool"], "falcon_execute_rtr_admin_command")
-        self.assertTrue(result["policy_allows_future_execution"])
+        self.assertFalse(result["policy_allows_future_execution"])
         self.assertTrue(result["classification_enforced"])
-        self.assertFalse(result["approval_gate"]["approval_required"])
+        self.assertTrue(result["approval_gate"]["approval_required"])
         self.assertIn("safety_disclaimer", result)
         self.assertEqual(result["operation"], "RTR_ExecuteAdminCommand")
         self.assertEqual(result["missing_context"], [])
@@ -410,7 +440,7 @@ class TestRTRAdminModule(TestModules):
 
     def test_preview_approval_phrase_matches_execution_payload_with_device_id(self):
         """Test preview and execution approval use the same target and payload material."""
-        preview = self.module.preview_admin_command(
+        preview = self.module.preview_rtr_admin_command(
             session_id="session-1",
             device_id="aid-1",
             base_command="rm",
@@ -428,7 +458,7 @@ class TestRTRAdminModule(TestModules):
             "body": {"resources": [{"cloud_request_id": "req-123"}]},
         }
 
-        result = self.module.execute_admin_command(
+        result = self.module.execute_rtr_admin_command(
             session_id="session-1",
             device_id="aid-1",
             base_command="rm",
@@ -446,9 +476,47 @@ class TestRTRAdminModule(TestModules):
         self.assertTrue(result["approval_gate"]["approved"])
         self.mock_client.command.assert_called_once()
 
+    def test_approval_hash_independent_of_hostname(self):
+        """Test that hostname differences do not break approval phrase matching."""
+        preview = self.module.preview_rtr_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            command_id=7,
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+            persist=True,
+        )
+        approval_phrase = preview["approval_gate"]["approval_phrase"]
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-123"}]},
+        }
+
+        result = self.module.execute_rtr_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            command_id=7,
+            persist=True,
+            target_hostname="DIFFERENT-HOST",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+            operator_approval=approval_phrase,
+        )
+
+        self.assertTrue(result["submitted"])
+        self.assertTrue(result["approval_gate"]["approved"])
+        self.mock_client.command.assert_called_once()
+
     def test_preview_admin_command_reports_missing_context(self):
         """Test command preview calls out missing audit context."""
-        result = self.module.preview_admin_command(
+        result = self.module.preview_rtr_admin_command(
             session_id="session-1",
             base_command="runscript",
             command_string="runscript -Raw=```Get-Process```",
@@ -471,7 +539,7 @@ class TestRTRAdminModule(TestModules):
 
     def test_preview_admin_command_missing_required_fields_returns_error(self):
         """Test command preview rejects missing required command fields."""
-        result = self.module.preview_admin_command(
+        result = self.module.preview_rtr_admin_command(
             session_id=" ",
             base_command="ps",
             command_string=" ",
@@ -488,7 +556,7 @@ class TestRTRAdminModule(TestModules):
             "body": {"resources": [{"cloud_request_id": "req-123"}]},
         }
 
-        result = self.module.execute_admin_command(
+        result = self.module.execute_rtr_admin_command(
             session_id="session-1",
             device_id="aid-1",
             base_command="ps",
@@ -522,7 +590,7 @@ class TestRTRAdminModule(TestModules):
 
     def test_execute_admin_command_requires_approval_for_high_impact_command(self):
         """Test high-impact single-host execution stops before the Falcon call."""
-        result = self.module.execute_admin_command(
+        result = self.module.execute_rtr_admin_command(
             session_id="session-1",
             device_id=None,
             base_command="rm",
@@ -546,7 +614,7 @@ class TestRTRAdminModule(TestModules):
 
     def test_execute_admin_command_submits_high_impact_after_exact_approval(self):
         """Test high-impact single-host execution submits only after exact approval."""
-        blocked = self.module.execute_admin_command(
+        blocked = self.module.execute_rtr_admin_command(
             session_id="session-1",
             device_id=None,
             base_command="rm",
@@ -565,7 +633,7 @@ class TestRTRAdminModule(TestModules):
             "body": {"resources": [{"cloud_request_id": "req-123"}]},
         }
 
-        result = self.module.execute_admin_command(
+        result = self.module.execute_rtr_admin_command(
             session_id="session-1",
             device_id=None,
             base_command="rm",
@@ -593,7 +661,7 @@ class TestRTRAdminModule(TestModules):
             "body": {"resources": [{"cloud_request_id": "req-raw"}]},
         }
 
-        result = self.module.execute_admin_command(
+        result = self.module.execute_rtr_admin_command(
             session_id="session-1",
             base_command="runscript",
             command_string="runscript -Raw=```Get-Process```",
@@ -621,7 +689,7 @@ class TestRTRAdminModule(TestModules):
 
     def test_execute_admin_command_requires_target_and_command(self):
         """Test single-host RTR Admin execution validates minimum fields locally."""
-        result = self.module.execute_admin_command(
+        result = self.module.execute_rtr_admin_command(
             session_id=None,
             device_id=None,
             base_command=" ",
@@ -637,7 +705,8 @@ class TestRTRAdminModule(TestModules):
 
     def test_execute_admin_command_rejects_device_only_target(self):
         """Test single-host RTR Admin execution requires an existing RTR session."""
-        result = self.module.execute_admin_command(
+        result = self.module.execute_rtr_admin_command(
+            session_id=" ",
             device_id="aid-1",
             base_command="ps",
             command_string="ps",
@@ -654,7 +723,7 @@ class TestRTRAdminModule(TestModules):
             "body": {"errors": [{"message": "Access denied"}]},
         }
 
-        result = self.module.execute_admin_command(
+        result = self.module.execute_rtr_admin_command(
             session_id="session-1",
             device_id="aid-1",
             base_command="ps",

--- a/tests/modules/test_rtr_admin.py
+++ b/tests/modules/test_rtr_admin.py
@@ -2,6 +2,7 @@
 Tests for the RTR Admin module.
 """
 
+import asyncio
 import inspect
 
 from mcp.types import ToolAnnotations
@@ -25,10 +26,12 @@ class TestRTRAdminModule(TestModules):
             "falcon_search_rtr_admin_scripts",
             "falcon_search_rtr_falcon_scripts",
             "falcon_search_rtr_put_files",
+            "falcon_get_rtr_put_file_contents",
             "falcon_check_rtr_admin_command_status",
             "falcon_classify_rtr_admin_command",
             "falcon_preview_rtr_admin_command",
             "falcon_execute_rtr_admin_command",
+            "falcon_run_rtr_admin_command_and_wait",
         ]
         self.assert_tools_registered(expected_tools)
         self.assertFalse(hasattr(self.module, "batch_execute_admin_command"))
@@ -41,6 +44,7 @@ class TestRTRAdminModule(TestModules):
             "falcon_search_rtr_admin_scripts",
             "falcon_search_rtr_falcon_scripts",
             "falcon_search_rtr_put_files",
+            "falcon_get_rtr_put_file_contents",
             "falcon_check_rtr_admin_command_status",
             "falcon_classify_rtr_admin_command",
             "falcon_preview_rtr_admin_command",
@@ -49,6 +53,15 @@ class TestRTRAdminModule(TestModules):
 
         self.assert_tool_annotations(
             "falcon_execute_rtr_admin_command",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+        self.assert_tool_annotations(
+            "falcon_run_rtr_admin_command_and_wait",
             ToolAnnotations(
                 readOnlyHint=False,
                 destructiveHint=True,
@@ -65,8 +78,20 @@ class TestRTRAdminModule(TestModules):
             "falcon_search_rtr_put_files_fql_guide",
             "falcon_rtr_admin_tool_use_guide",
             "falcon_rtr_admin_runscript_raw_guide",
+            "falcon_rtr_admin_command_policy_guide",
+            "falcon_rtr_admin_approval_packet_template",
         ]
         self.assert_resources_registered(expected_resources)
+
+    def test_register_prompts(self):
+        """Test registering RTR Admin workflow prompts with the server."""
+        expected_prompts = [
+            "falcon_plan_rtr_admin_action",
+            "falcon_build_rtr_admin_approval_packet",
+            "falcon_review_rtr_admin_runscript",
+            "falcon_interpret_rtr_admin_status",
+        ]
+        self.assert_prompts_registered(expected_prompts)
 
     def test_register_resources_includes_admin_tool_use_guide(self):
         """Test RTR Admin workflow guidance is exposed as a resource."""
@@ -85,6 +110,85 @@ class TestRTRAdminModule(TestModules):
         self.assertIn("returned sequence_id", guide.text)
         self.assertNotIn("then increment", guide.text)
 
+    def test_register_resources_include_policy_and_approval_guides(self):
+        """Test RTR Admin policy and approval context are exposed as resources."""
+        self.module.register_resources(self.mock_server)
+
+        resources = {
+            call.kwargs["resource"].name: call.kwargs["resource"]
+            for call in self.mock_server.add_resource.call_args_list
+        }
+
+        policy = resources["falcon_rtr_admin_command_policy_guide"]
+        approval = resources["falcon_rtr_admin_approval_packet_template"]
+
+        self.assertEqual(str(policy.uri), "falcon://rtr-admin/policy/command-guide")
+        self.assertIn("Read-only commands", policy.text)
+        self.assertIn("ps", policy.text)
+        self.assertIn("rm", policy.text)
+        self.assertIn("runscript", policy.text)
+        self.assertIn("Unknown commands", policy.text)
+
+        self.assertEqual(str(approval.uri), "falcon://rtr-admin/approval/packet-guide")
+        self.assertIn("Approval Packet", approval.text)
+        self.assertIn("approval phrase", approval.text.lower())
+
+    def test_prompt_methods_are_local_workflow_guides(self):
+        """Test RTR Admin prompts render workflow text without Falcon calls."""
+        plan = self.module.plan_rtr_admin_action(
+            objective="collect triage evidence",
+            target_hostname="HOST-1",
+            ticket="INC-123",
+        )
+        packet = self.module.build_rtr_admin_approval_packet(
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            session_id="session-1",
+            reason="cleanup selected test file",
+            ticket="INC-123",
+            expected_effect="remove one file",
+        )
+        runscript = self.module.review_rtr_admin_runscript(
+            command_string="runscript -Raw=```Get-Process```",
+            target_platform="windows",
+        )
+        status = self.module.interpret_rtr_admin_status(
+            command_status="complete=true stdout=ok stderr=",
+            base_command="ps",
+        )
+
+        self.assertIn("falcon_classify_rtr_admin_command", plan)
+        self.assertIn("falcon_preview_rtr_admin_command", packet)
+        self.assertIn("approval_gate.approval_phrase", packet)
+        self.assertIn("triple backticks", runscript)
+        self.assertIn("falcon_check_rtr_admin_command_status", status)
+        self.mock_client.command.assert_not_called()
+
+    def test_registered_prompt_renders_workflow_text(self):
+        """Test registered MCP prompt renders with runtime arguments."""
+        self.module.register_prompts(self.mock_server)
+        prompts = {
+            call.args[0].name: call.args[0]
+            for call in self.mock_server.add_prompt.call_args_list
+        }
+
+        messages = asyncio.run(
+            prompts["falcon_plan_rtr_admin_action"].render(
+                {
+                    "objective": "collect triage evidence",
+                    "target_hostname": "HOST-1",
+                }
+            )
+        )
+
+        self.assertEqual(len(messages), 1)
+        rendered = messages[0].content.text
+        self.assertIn("collect triage evidence", rendered)
+        self.assertIn("HOST-1", rendered)
+        self.assertIn("falcon_classify_rtr_admin_command", rendered)
+        self.assertIn("falcon_preview_rtr_admin_command", rendered)
+        self.mock_client.command.assert_not_called()
+
     def test_api_scope_mappings(self):
         """Test RTR Admin operations have explicit scope mappings."""
         for operation in [
@@ -94,6 +198,7 @@ class TestRTRAdminModule(TestModules):
             "RTR_GetFalconScripts",
             "RTR_ListPut_Files",
             "RTR_GetPut_FilesV2",
+            "RTR_GetPutFileContents",
             "RTR_CheckAdminCommandStatus",
             "RTR_ExecuteAdminCommand",
         ]:
@@ -197,6 +302,77 @@ class TestRTRAdminModule(TestModules):
         self.assertEqual(second_call[0][0], "RTR_GetPut_FilesV2")
         self.assertEqual(second_call[1]["parameters"]["ids"], ["file-1"])
         self.assertEqual(result[0]["name"], "collector.exe")
+
+    def test_get_put_file_contents_uses_id_query_parameter(self):
+        """Test retrieving put-file contents uses FalconPy's id query shape."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "file-1", "content": "payload"}]},
+        }
+
+        result = self.module.get_rtr_put_file_contents(file_id="file-1")
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_GetPutFileContents",
+            parameters={"id": "file-1"},
+        )
+        self.assertEqual(result[0]["content"], "payload")
+
+    def test_get_put_file_contents_returns_direct_body_payload(self):
+        """Test put-file contents can return a direct body payload."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"content": "payload", "encoding": "utf-8"},
+        }
+
+        result = self.module.get_rtr_put_file_contents(file_id="file-1")
+
+        self.mock_client.command.assert_called_once_with(
+            "RTR_GetPutFileContents",
+            parameters={"id": "file-1"},
+        )
+        self.assertEqual(result["id"], "file-1")
+        self.assertEqual(result["body"]["content"], "payload")
+
+    def test_get_put_file_contents_decodes_text_bytes(self):
+        """Test text byte content is decoded into a model-safe response."""
+        self.mock_client.command.return_value = b"echo hello"
+
+        result = self.module.get_rtr_put_file_contents(file_id="file-1")
+
+        self.assertEqual(result["id"], "file-1")
+        self.assertEqual(result["content"], "echo hello")
+        self.assertEqual(result["content_format"], "text")
+
+    def test_get_put_file_contents_rejects_binary_bytes(self):
+        """Test binary put-file bytes return a safe error with size metadata."""
+        self.mock_client.command.return_value = b"\xff\xfe\x00\x00"
+
+        result = self.module.get_rtr_put_file_contents(file_id="file-1")
+
+        self.assertIn("error", result)
+        self.assertEqual(result["content_format"], "binary")
+        self.assertEqual(result["size_bytes"], 4)
+
+    def test_get_put_file_contents_wraps_api_error(self):
+        """Test put-file content API errors include operation scope context."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied"}]},
+        }
+
+        result = self.module.get_rtr_put_file_contents(file_id="file-1")
+
+        self.assertIn("error", result)
+        self.assertEqual(result["details"]["status_code"], 403)
+        self.assertEqual(result["required_scopes"], ["Real time response (admin):write"])
+
+    def test_get_put_file_contents_validates_file_id(self):
+        """Test put-file content retrieval fails locally without an ID."""
+        result = self.module.get_rtr_put_file_contents(file_id=" ")
+
+        self.assertIn("error", result)
+        self.mock_client.command.assert_not_called()
 
     def test_search_by_id_filter_round_trips_query_and_get(self):
         """Test ID lookups go through the search query→get round-trip."""
@@ -374,8 +550,15 @@ class TestRTRAdminModule(TestModules):
         self.mock_client.command.assert_not_called()
 
     def test_classify_newly_added_blocked_commands(self):
-        """Test tar, umount, rmdir, cswindiag, falconscript are blocked with approval."""
-        for base_command in ["tar", "umount", "rmdir", "cswindiag", "falconscript"]:
+        """Test documented high-impact commands are blocked with approval."""
+        for base_command in [
+            "tar",
+            "umount",
+            "unmount",
+            "rmdir",
+            "cswindiag",
+            "falconscript",
+        ]:
             with self.subTest(base_command=base_command):
                 result = self.module.classify_rtr_admin_command(base_command=base_command)
 
@@ -394,10 +577,12 @@ class TestRTRAdminModule(TestModules):
         self.assertEqual(destructive["risk"], "critical")
         self.assertFalse(destructive["allowed_for_execution"])
         self.assertTrue(destructive["requires_approval"])
+        self.assertTrue(destructive["requires_explicit_target"])
         self.assertIsNotNone(destructive["blocked_reason"])
         self.assertEqual(unknown["category"], "unknown")
         self.assertFalse(unknown["allowed_for_execution"])
         self.assertFalse(unknown["requires_approval"])
+        self.assertFalse(unknown["requires_explicit_target"])
         self.mock_client.command.assert_not_called()
 
     def test_classify_empty_base_command_returns_error(self):
@@ -405,6 +590,18 @@ class TestRTRAdminModule(TestModules):
         result = self.module.classify_rtr_admin_command(base_command=" ")
 
         self.assertIn("error", result)
+        self.mock_client.command.assert_not_called()
+
+    def test_classify_rejects_base_command_mismatch(self):
+        """Test command strings cannot hide a different base command."""
+        result = self.module.classify_rtr_admin_command(
+            base_command="ps",
+            command_string=r"rm C:\Temp\old.bin",
+        )
+
+        self.assertIn("error", result)
+        self.assertEqual(result["details"]["base_command"], "ps")
+        self.assertEqual(result["details"]["command_string_base"], "rm")
         self.mock_client.command.assert_not_called()
 
     def test_preview_admin_command_does_not_call_falcon(self):
@@ -547,6 +744,19 @@ class TestRTRAdminModule(TestModules):
 
         self.assertIn("error", result)
         self.assertEqual(result["details"]["missing_required"], ["session_id", "command_string"])
+        self.mock_client.command.assert_not_called()
+
+    def test_preview_admin_command_rejects_base_command_mismatch(self):
+        """Test preview stops locally when command string and base command disagree."""
+        result = self.module.preview_rtr_admin_command(
+            session_id="session-1",
+            base_command="ps",
+            command_string=r"rm C:\Temp\old.bin",
+        )
+
+        self.assertIn("error", result)
+        self.assertEqual(result["details"]["base_command"], "ps")
+        self.assertEqual(result["details"]["command_string_base"], "rm")
         self.mock_client.command.assert_not_called()
 
     def test_execute_admin_command_submits_low_risk_single_host_body(self):
@@ -716,6 +926,20 @@ class TestRTRAdminModule(TestModules):
         self.assertEqual(result["details"]["missing_required"], ["session_id"])
         self.mock_client.command.assert_not_called()
 
+    def test_execute_admin_command_rejects_base_command_mismatch(self):
+        """Test execution stops locally when command string and base command disagree."""
+        result = self.module.execute_rtr_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="ps",
+            command_string=r"rm C:\Temp\old.bin",
+        )
+
+        self.assertIn("error", result)
+        self.assertEqual(result["details"]["base_command"], "ps")
+        self.assertEqual(result["details"]["command_string_base"], "rm")
+        self.mock_client.command.assert_not_called()
+
     def test_execute_admin_command_wraps_api_error(self):
         """Test single-host RTR Admin execution includes context on API errors."""
         self.mock_client.command.return_value = {
@@ -733,6 +957,188 @@ class TestRTRAdminModule(TestModules):
         self.assertFalse(result["submitted"])
         self.assertIn("error", result["result"])
         self.assertEqual(result["missing_context"], ["reason", "ticket", "expected_effect"])
+
+    def test_run_admin_command_and_wait_submits_and_polls(self):
+        """Test RTR Admin command-and-wait submits once and polls status."""
+        execute_response = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-123", "session_id": "session-1"}]},
+        }
+        status_response = {
+            "status_code": 200,
+            "body": {"resources": [{"complete": True, "stdout": "ok"}]},
+        }
+        self.mock_client.command.side_effect = [execute_response, status_response]
+
+        result = self.module.run_rtr_admin_command_and_wait(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="ps",
+            command_string="ps",
+            command_id=7,
+            persist=False,
+            target_hostname="HOST-1",
+            reason="process review",
+            ticket="INC-123",
+            expected_effect="list processes",
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+        self.mock_client.command.assert_any_call(
+            "RTR_ExecuteAdminCommand",
+            body={
+                "base_command": "ps",
+                "command_string": "ps",
+                "device_id": "aid-1",
+                "session_id": "session-1",
+                "id": 7,
+                "persist": False,
+            },
+        )
+        self.mock_client.command.assert_any_call(
+            "RTR_CheckAdminCommandStatus",
+            parameters={"cloud_request_id": "req-123", "sequence_id": 0},
+        )
+        self.assertEqual(result["cloud_request_id"], "req-123")
+        self.assertTrue(result["complete"])
+        self.assertFalse(result["timed_out"])
+        self.assertEqual(result["stdout"], "ok")
+        self.assertEqual(result["classification"]["category"], "read_only")
+        self.assertFalse(result["approval_gate"]["approval_required"])
+
+    def test_run_admin_command_and_wait_advances_sequence_chunks(self):
+        """Test RTR Admin command-and-wait reads sequence_id from status chunks."""
+        execute_response = {
+            "status_code": 200,
+            "body": {"resources": [{"cloud_request_id": "req-123", "session_id": "session-1"}]},
+        }
+        first_chunk_response = {
+            "status_code": 200,
+            "body": {"resources": [{"complete": False, "stdout": "part1", "sequence_id": 3}]},
+        }
+        second_chunk_response = {
+            "status_code": 200,
+            "body": {"resources": [{"complete": True, "stdout": "part2"}]},
+        }
+        self.mock_client.command.side_effect = [
+            execute_response,
+            first_chunk_response,
+            second_chunk_response,
+        ]
+
+        result = self.module.run_rtr_admin_command_and_wait(
+            session_id="session-1",
+            base_command="ps",
+            command_string="ps",
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+        self.mock_client.command.assert_any_call(
+            "RTR_CheckAdminCommandStatus",
+            parameters={"cloud_request_id": "req-123", "sequence_id": 0},
+        )
+        self.mock_client.command.assert_any_call(
+            "RTR_CheckAdminCommandStatus",
+            parameters={"cloud_request_id": "req-123", "sequence_id": 3},
+        )
+        self.assertEqual(result["stdout"], "part1part2")
+        self.assertTrue(result["complete"])
+
+    def test_run_admin_command_and_wait_requires_approval_before_falcon_call(self):
+        """Test RTR Admin command-and-wait does not bypass high-impact approval."""
+        result = self.module.run_rtr_admin_command_and_wait(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+        self.assertIn("error", result)
+        self.assertEqual(result["phase"], "execute")
+        self.assertIn("approval required", result["error"].lower())
+        self.mock_client.command.assert_not_called()
+
+    def test_run_admin_command_and_wait_high_impact_after_exact_approval(self):
+        """Test high-impact command-and-wait runs only after exact approval."""
+        preview = self.module.preview_rtr_admin_command(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+            persist=True,
+        )
+        approval_phrase = preview["approval_gate"]["approval_phrase"]
+        self.mock_client.command.side_effect = [
+            {
+                "status_code": 200,
+                "body": {"resources": [{"cloud_request_id": "req-123"}]},
+            },
+            {
+                "status_code": 200,
+                "body": {"resources": [{"complete": True, "stderr": ""}]},
+            },
+        ]
+
+        result = self.module.run_rtr_admin_command_and_wait(
+            session_id="session-1",
+            device_id="aid-1",
+            base_command="rm",
+            command_string=r"rm C:\Temp\old.bin",
+            target_hostname="HOST-1",
+            reason="cleanup test file",
+            ticket="INC-123",
+            expected_effect="remove selected file",
+            persist=True,
+            operator_approval=approval_phrase,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+        self.assertTrue(result["complete"])
+        self.assertTrue(result["approval_gate"]["approval_required"])
+        self.assertTrue(result["approval_gate"]["approved"])
+        self.assertEqual(result["classification"]["category"], "high_impact")
+        self.assertEqual(self.mock_client.command.call_count, 2)
+
+    def test_run_admin_command_and_wait_timeout(self):
+        """Test RTR Admin command-and-wait returns partial status on timeout."""
+        self.mock_client.command.side_effect = [
+            {
+                "status_code": 200,
+                "body": {"resources": [{"cloud_request_id": "req-123"}]},
+            },
+            {
+                "status_code": 200,
+                "body": {"resources": [{"complete": False, "stdout": "partial"}]},
+            },
+        ]
+
+        result = self.module.run_rtr_admin_command_and_wait(
+            session_id="session-1",
+            base_command="ps",
+            command_string="ps",
+            timeout_seconds=0,
+            poll_interval_seconds=0,
+        )
+
+        self.assertEqual(result["cloud_request_id"], "req-123")
+        self.assertFalse(result["complete"])
+        self.assertTrue(result["timed_out"])
+        self.assertEqual(result["stdout"], "partial")
+        self.assertIn("warning", result)
 
     def _limit_le(self, method_name: str) -> int:
         """Return the Pydantic upper-bound metadata for a search limit parameter."""

--- a/tests/modules/utils/test_modules.py
+++ b/tests/modules/utils/test_modules.py
@@ -71,6 +71,25 @@ class TestModules(unittest.TestCase):
         for tool in expected_resources:
             self.assertIn(tool, registered_resources)
 
+    def assert_prompts_registered(self, expected_prompts):
+        """
+        Helper method to verify that a module correctly registers its prompts.
+
+        Args:
+            expected_prompts: List of prompt names that should be registered
+        """
+        self.module.register_prompts(self.mock_server)
+
+        self.assertEqual(self.mock_server.add_prompt.call_count, len(expected_prompts))
+
+        registered_prompts = [
+            call.args[0].name if call.args else call.kwargs["prompt"].name
+            for call in self.mock_server.add_prompt.call_args_list
+        ]
+
+        for prompt in expected_prompts:
+            self.assertIn(prompt, registered_prompts)
+
     def assert_tool_annotations(self, tool_name: str, expected_annotations: ToolAnnotations):
         """Verify that a tool was registered with the expected annotations.
 

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -48,6 +48,8 @@ MUTATING_TOOL_ALLOWLIST: set[str] = {
     "falcon_execute_rtr_read_only_command",
     "falcon_run_rtr_read_only_command_and_wait",
     "falcon_delete_rtr_session",
+    # rtr_admin module
+    "falcon_execute_rtr_admin_command",
     # shield module
     "falcon_dismiss_shield_check",
     # scheduled_reports module

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -50,6 +50,7 @@ MUTATING_TOOL_ALLOWLIST: set[str] = {
     "falcon_delete_rtr_session",
     # rtr_admin module
     "falcon_execute_rtr_admin_command",
+    "falcon_run_rtr_admin_command_and_wait",
     # shield module
     "falcon_dismiss_shield_check",
     # scheduled_reports module

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -87,6 +87,13 @@ class TestRegistry(unittest.TestCase):
         for module_class in registry.AVAILABLE_MODULES.values():
             self.assertTrue(issubclass(module_class, BaseModule))
 
+    def test_module_name_override(self):
+        """Test modules can override the discovered registry key."""
+        registry.discover_modules()
+
+        self.assertIn("rtr_admin", registry.AVAILABLE_MODULES)
+        self.assertNotIn("rtradmin", registry.AVAILABLE_MODULES)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a focused RTR Admin module for Falcon MCP. The module covers RTR Admin inventory, command classification, payload preview, single-host admin command execution, and admin command status polling.

## What changed

- Added RTR Admin script, Falcon script, and put-file inventory tools using the pinned FalconPy operation names and query/body shapes.
- Added local command classification and preview helpers so high-impact admin commands are reviewed before any Falcon call.
- Added single-host `falcon_execute_rtr_admin_command` with explicit destructive annotations and exact approval phrase enforcement for high-impact commands.
- Added RTR Admin resources, generated docs, examples, API scope mappings, registry support for the `rtr_admin` module key, and unit/integration coverage.
- Kept uploads, updates, deletes, batch admin execution, and put-file content retrieval out of this first slice.

## Validation

- `python -m ruff check . --select I`
- `python -m ruff check .`
- `python -m mypy .`
- `python -m pytest` (`596 passed, 215 skipped`)
- `python scripts/generate_module_docs.py`
- `corepack pnpm run build`
- CodeRabbit committed-diff review: 0 issues

Note: live RTR Admin integration tests are present but skipped in my local shell because no Falcon API credentials/scope were loaded there.