### PR TITLE
chore: switch dependabot to monthly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,42 +4,43 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "deps(python):"
     labels:
       - "dependencies"
       - "python"
-
-  # Backup configuration (pip ecosystem)
-  # - package-ecosystem: "pip"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "daily"
-  #   commit-message:
-  #     prefix: "deps(python):"
-  #   labels:
-  #     - "dependencies"
-  #     - "python"
+    groups:
+      python-all:
+        patterns:
+          - "*"
 
   # GitHub Actions configuration
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "deps(actions):"
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      actions-all:
+        patterns:
+          - "*"
 
   # Docker configuration
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "deps(docker):"
     labels:
       - "dependencies"
       - "docker"
+    groups:
+      docker-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Reduces dependabot PR noise from ~12 individual PRs to a maximum of 3 per month — one grouped PR per ecosystem (python, actions, docker). Removed the dead commented-out pip ecosystem config. Closed the 12 existing open dependabot PRs (#412–#423) since they'll be superseded by grouped PRs next cycle.