### PR TITLE
fix(modules/intel): parse JSON format in get_mitre_report

### DIFF
--- a/falcon_mcp/modules/intel.py
+++ b/falcon_mcp/modules/intel.py
@@ -4,6 +4,7 @@ Intel module for Falcon MCP Server
 This module provides tools for accessing and analyzing CrowdStrike Falcon intelligence data.
 """
 
+import json
 from typing import Any
 
 from mcp.server import FastMCP
@@ -274,7 +275,7 @@ class IntelModule(BaseModule):
 
         Accepts an actor name (e.g., 'WARP PANDA') or numeric ID. Returns MITRE ATT&CK
         tactics, techniques, and procedures (TTPs) for the actor. JSON format returns a
-        decoded string; CSV format returns CSV text.
+        parsed list of dicts; CSV format returns raw CSV text.
         """
 
         # Check if the actor parameter looks like an ID (numeric) or a name
@@ -334,6 +335,16 @@ class IntelModule(BaseModule):
         if self._is_error(api_response):
             logger.debug("API response is an error, wrapping in list")
             return [api_response]
+
+        # Parse JSON format into Python objects; keep CSV as raw string
+        if format.lower() == "json" and isinstance(api_response, str):
+            stripped = api_response.strip()
+            if not stripped or stripped == "null":
+                return []
+            try:
+                return json.loads(stripped)
+            except json.JSONDecodeError as e:
+                return [{"error": "JSON parse failure", "message": str(e)}]
 
         return api_response
 

--- a/tests/integration/test_intel.py
+++ b/tests/integration/test_intel.py
@@ -120,7 +120,7 @@ class TestIntelIntegration(BaseIntegrationTest):
         self.assert_valid_list_response(result, min_length=0, context="query_report_entities with filter")
 
     def test_get_mitre_report_with_actor_name(self):
-        """Test get_mitre_report with an actor name.
+        """Test get_mitre_report JSON format returns parsed list of dicts.
 
         First searches for an actor, then gets their MITRE report.
         Validates both QueryIntelActorEntities and GetMitreReport operations.
@@ -141,10 +141,10 @@ class TestIntelIntegration(BaseIntegrationTest):
                 context="test_get_mitre_report_with_actor_name",
             )
 
-        # Now get MITRE report for that actor
+        # Now get MITRE report for that actor in JSON format
         result = self.call_method(self.module.get_mitre_report, actor=actor_name, format="json")
 
-        # Result can be a list (data) or string (error message)
+        # JSON format must return a list (possibly empty for actors without MITRE mappings)
         if isinstance(result, list) and len(result) > 0:
             first_item = result[0]
             if isinstance(first_item, dict) and "error" in first_item:
@@ -153,6 +153,58 @@ class TestIntelIntegration(BaseIntegrationTest):
                     f"MITRE report not available for actor: {actor_name}",
                     context="test_get_mitre_report_with_actor_name",
                 )
+
+        assert isinstance(result, list), (
+            f"Expected list for JSON format, got {type(result).__name__}: {repr(result)[:200]}"
+        )
+
+        # If we got results, validate the structure
+        if result:
+            assert isinstance(result[0], dict), (
+                f"Expected list of dicts, got list of {type(result[0]).__name__}"
+            )
+            expected_fields = {"id", "tactic_id", "tactic_name", "technique_id", "technique_name"}
+            actual_fields = set(result[0].keys())
+            missing = expected_fields - actual_fields
+            assert not missing, f"Missing expected MITRE fields: {missing}"
+
+    def test_get_mitre_report_csv_format(self):
+        """Test get_mitre_report CSV format returns raw string.
+
+        Validates that CSV format is not parsed and remains a string.
+        """
+        # First, search for an actor to get a valid name
+        search_result = self.call_method(self.module.query_actor_entities, limit=1)
+
+        if not search_result or len(search_result) == 0:
+            self.skip_with_warning(
+                "No actors available to test get_mitre_report CSV",
+                context="test_get_mitre_report_csv_format",
+            )
+
+        actor_name = search_result[0].get("name")
+        if not actor_name:
+            self.skip_with_warning(
+                "Could not extract actor name from search results",
+                context="test_get_mitre_report_csv_format",
+            )
+
+        # Get MITRE report in CSV format
+        result = self.call_method(self.module.get_mitre_report, actor=actor_name, format="csv")
+
+        # Handle error response (actor may not have MITRE data)
+        if isinstance(result, list) and len(result) > 0:
+            first_item = result[0]
+            if isinstance(first_item, dict) and "error" in first_item:
+                self.skip_with_warning(
+                    f"MITRE report not available for actor: {actor_name}",
+                    context="test_get_mitre_report_csv_format",
+                )
+
+        # CSV format must return a string
+        assert isinstance(result, str), (
+            f"Expected str for CSV format, got {type(result).__name__}: {repr(result)[:200]}"
+        )
 
     def test_operation_names_are_correct(self):
         """Validate that FalconPy operation names are correct.

--- a/tests/modules/test_intel.py
+++ b/tests/modules/test_intel.py
@@ -324,13 +324,13 @@ class TestIntelModule(TestModules):
             },
         )
 
-        # Verify result is decoded string content
-        self.assertIsInstance(result, str)
-        self.assertIn("my_id", result)
-        self.assertIn("Fake Tactic", result)
-        self.assertIn("Fake Technique", result)
-        self.assertIn("FAKE001", result)
-        self.assertIn("technique_id2", result)
+        # Verify result is parsed JSON list
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "my_id")
+        self.assertEqual(result[0]["tactic_name"], "Fake Tactic")
+        self.assertEqual(result[1]["id"], "my_id2")
+        self.assertEqual(result[1]["technique_name"], "Another Fake Technique")
 
     def test_get_mitre_report_csv_format(self):
         """Test getting MITRE report with CSV format.
@@ -400,30 +400,42 @@ class TestIntelModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetMitreReport")
 
-        # Verify result is empty string
-        self.assertEqual(result, "")
+        # Verify result is empty list (empty bytes → empty string → empty list)
+        self.assertEqual(result, [])
 
-    def test_get_mitre_report_default_format(self):
-        """Test that default format is JSON when not specified.
+    def test_get_mitre_report_null_response(self):
+        """Test getting MITRE report when API returns null (no MITRE mappings).
 
-        FalconPy returns raw bytes directly for binary endpoints like GetMitreReport.
+        FalconPy returns b'null' for actors with no MITRE ATT&CK mappings.
         """
-        # Setup mock response with binary content
-        fake_json_content = '{"actor_id": "123456", "format": "JSON"}'
-        # FalconPy returns raw bytes directly for binary endpoints
-        self.mock_client.command.return_value = fake_json_content.encode('utf-8')
+        self.mock_client.command.return_value = b"null"
 
-        # Call get_mitre_report without format parameter - should use default json
-        self.module.get_mitre_report(actor="123456", format="json")
+        result = self.module.get_mitre_report(actor="123456", format="json")
 
-        # Verify the API call was made with json as the default format
         self.mock_client.command.assert_called_once_with(
             "GetMitreReport",
             parameters={
                 "actor_id": "123456",
-                "format": "json",  # Should default to json
+                "format": "json",
             },
         )
+
+        # null should return empty list
+        self.assertEqual(result, [])
+
+    def test_get_mitre_report_default_format(self):
+        """Test that the format parameter defaults to 'json'.
+
+        Unit tests call the method directly, which does not resolve Pydantic
+        Field defaults, so the declared default is verified via the signature.
+        """
+        import inspect
+
+        sig = inspect.signature(self.module.get_mitre_report)
+        format_default = sig.parameters["format"].default
+
+        # The declared default should be the FieldInfo carrying default='json'
+        self.assertEqual(format_default.default, "json")
 
     def test_get_mitre_report_by_actor_name(self):
         """Test getting MITRE report using actor name (automatically resolves to ID).
@@ -488,11 +500,12 @@ class TestIntelModule(TestModules):
         self.assertEqual(second_call[1]["parameters"]["actor_id"], "789012")
         self.assertEqual(second_call[1]["parameters"]["format"], "json")
 
-        # Verify result is decoded JSON string content
-        self.assertIsInstance(result, str)
-        self.assertIn("fake_id_1", result)
-        self.assertIn("Fake Tactic", result)
-        self.assertIn("fake_technique_001", result)
+        # Verify result is parsed JSON list
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "fake_id_1")
+        self.assertEqual(result[0]["tactic_name"], "Fake Tactic")
+        self.assertEqual(result[0]["technique_id"], "fake_technique_001")
 
     def test_get_mitre_report_actor_name_not_found(self):
         """Test getting MITRE report when actor name is not found."""


### PR DESCRIPTION
`get_mitre_report` with `format='json'` was handing back a raw JSON string instead of the parsed objects its return type claims. FalconPy returns bytes for both CSV and JSON, and the JSON case got decoded but never parsed, so callers had to run `json.loads` themselves.

Now the JSON path parses into a list of dicts. Actors with no MITRE mappings come back as `b'null'` from the live API, which becomes an empty list, and a malformed payload returns a structured error instead of throwing. CSV is left alone and still returns raw text.

I checked the `b'null'` behavior and the field shapes against the live API, and the unit and integration tests now assert the parsed list rather than a string.

Closes #383