### PR TITLE
feat(modules/host-groups): add Host Groups module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Full docs are available at **[developer.crowdstrike.com/falcon-mcp](https://deve
 | [Discover](https://developer.crowdstrike.com/falcon-mcp/modules/discover/) | Search application inventory and discover unmanaged assets |
 | [Firewall Management](https://developer.crowdstrike.com/falcon-mcp/modules/firewall/) | Search and manage firewall rules and rule groups |
 | [Hosts](https://developer.crowdstrike.com/falcon-mcp/modules/hosts/) | Manage and query host/device information |
+| [Host Groups](https://developer.crowdstrike.com/falcon-mcp/modules/host-groups/) | Search, create, update, and delete host groups; manage group membership |
 | [Identity Protection](https://developer.crowdstrike.com/falcon-mcp/modules/idp/) | Entity investigation and identity protection analysis |
 | [Intel](https://developer.crowdstrike.com/falcon-mcp/modules/intel/) | Research threat actors, IOCs, and intelligence reports |
 | [IOC](https://developer.crowdstrike.com/falcon-mcp/modules/ioc/) | Search, create, and remove custom indicators of compromise |

--- a/docs/modules/host-groups.md
+++ b/docs/modules/host-groups.md
@@ -1,0 +1,121 @@
+<!-- meta:title Host Groups -->
+<!-- meta:description Searching, creating, updating, and deleting CrowdStrike Falcon host groups, as well as managing group membership -->
+<!-- meta:section modules -->
+<!-- meta:link-base /falcon-mcp/ -->
+<!-- frontmatter:sidebar order:10 -->
+
+Searching, creating, updating, and deleting CrowdStrike Falcon host groups, as well as managing group membership
+
+## API Scopes
+
+- `Host Groups:read`
+- `Host Groups:write`
+
+## Tools
+
+### `falcon_create_host_group`
+
+> [!NOTE]
+> This tool modifies data.
+
+**Required scopes:** `Host Groups:write`
+
+Create a host group.
+
+Provide a name and group_type. 'dynamic' groups take an assignment_rule (host
+FQL) that automatically includes matching hosts. 'static' and 'staticByID' groups
+are created empty (no assignment_rule) and populated afterwards via
+falcon_perform_host_group_action. Returns the created host group record on success.
+
+**Example prompts:**
+
+- "Create a static host group called 'Critical Servers'"
+- "Create a dynamic host group for all Windows hosts"
+
+### `falcon_delete_host_groups`
+
+> [!CAUTION]
+> This tool performs destructive operations.
+
+**Required scopes:** `Host Groups:write`
+
+Delete one or more host groups.
+
+Provide the host group `ids` to delete. This permanently removes the groups.
+Returns an empty list on success.
+
+**Example prompts:**
+
+- "Delete host group abc123"
+
+### `falcon_perform_host_group_action`
+
+> [!NOTE]
+> This tool modifies data.
+
+**Required scopes:** `Host Groups:write`
+
+Add or remove hosts from one or more host groups.
+
+Set action_name to 'add-hosts' or 'remove-hosts', provide the target group
+`ids`, and a host FQL filter selecting which hosts to act on. Applies only to
+static groups. Returns the updated host group records on success.
+
+**Example prompts:**
+
+- "Add the hosts matching platform_name Windows to group abc123"
+- "Remove host device xyz from host group abc123"
+
+### `falcon_search_host_group_members`
+
+**Required scopes:** `Host Groups:read`
+
+Search for the host members of a specific host group.
+
+Use this to list the devices that belong to a host group. Requires the group
+`id` and filters on HOST attributes (platform, hostname, etc.) — consult
+falcon://hosts/search/fql-guide for the filter syntax. Returns full host device
+entities including device_id, hostname, platform, and network context.
+
+**Example prompts:**
+
+- "List the Windows hosts in host group abc123"
+- "Show me the members of the Production Servers group"
+
+### `falcon_search_host_groups`
+
+**Required scopes:** `Host Groups:read`
+
+Search for host groups in your CrowdStrike environment.
+
+Use this to find host groups by name, type, creator, or timestamps. Consult
+falcon://host-groups/search/fql-guide before constructing filter expressions.
+Returns full host group details including id, name, group_type, description,
+and audit metadata in a single call.
+
+**Example prompts:**
+
+- "Show me all static host groups"
+- "Find host groups created in the last 30 days"
+
+### `falcon_update_host_group`
+
+> [!NOTE]
+> This tool modifies data.
+
+**Required scopes:** `Host Groups:write`
+
+Update an existing host group.
+
+Provide the group `id` and any fields to change. name and description are safe
+for any group type; only set assignment_rule on 'dynamic' groups. Unspecified
+fields are left unchanged. Returns the updated host group record on success.
+
+**Example prompts:**
+
+- "Rename host group abc123 to 'Decommissioned'"
+- "Update the assignment rule for the dynamic Windows group"
+
+## Resources
+
+- **`falcon://host-groups/search/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_host_groups` tool.

--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -16,6 +16,7 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 | [Detections](/falcon-mcp/modules/detections/) | `Alerts:read` | Accessing and analyzing CrowdStrike Falcon detections |
 | [Discover](/falcon-mcp/modules/discover/) | `Assets:read` | Accessing and managing CrowdStrike Falcon Discover applications and unmanaged assets |
 | [Firewall Management](/falcon-mcp/modules/firewall/) | `Firewall Management:read`, `Firewall Management:write` | Searching and managing firewall rules and rule groups |
+| [Host Groups](/falcon-mcp/modules/host-groups/) | `Host Groups:read`, `Host Groups:write` | Searching, creating, updating, and deleting CrowdStrike Falcon host groups, as well as managing group membership |
 | [Hosts](/falcon-mcp/modules/hosts/) | `Hosts:read` | Accessing and managing CrowdStrike Falcon hosts/devices |
 | [Identity Protection](/falcon-mcp/modules/idp/) | `Identity Protection Assessment:read`, `Identity Protection Detections:read`, `Identity Protection Entities:read`, `Identity Protection Timeline:read`, `Identity Protection GraphQL:write` | Accessing and managing CrowdStrike Falcon Identity Protection capabilities |
 | [Intel](/falcon-mcp/modules/intel/) | `Actors (Falcon Intelligence):read`, `Indicators (Falcon Intelligence):read`, `Reports (Falcon Intelligence):read` | Accessing and analyzing CrowdStrike Falcon intelligence data |

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -17,6 +17,13 @@ API_SCOPE_REQUIREMENTS = {
     # Hosts operations
     "QueryDevicesByFilter": ["Hosts:read"],
     "PostDeviceDetailsV2": ["Hosts:read"],
+    # Host Groups operations
+    "queryCombinedHostGroups": ["Host Groups:read"],
+    "queryCombinedGroupMembers": ["Host Groups:read"],
+    "createHostGroups": ["Host Groups:write"],
+    "updateHostGroups": ["Host Groups:write"],
+    "deleteHostGroups": ["Host Groups:write"],
+    "performGroupAction": ["Host Groups:write"],
     # Intel operations
     "QueryIntelActorEntities": ["Actors (Falcon Intelligence):read"],
     "QueryIntelIndicatorEntities": ["Indicators (Falcon Intelligence):read"],

--- a/falcon_mcp/modules/host_groups.py
+++ b/falcon_mcp/modules/host_groups.py
@@ -1,0 +1,380 @@
+"""
+Host Groups module for Falcon MCP Server
+
+This module provides tools for searching, creating, updating, and deleting
+CrowdStrike Falcon host groups, as well as managing group membership.
+"""
+
+from textwrap import dedent
+from typing import Any
+
+from mcp.server import FastMCP
+from mcp.server.fastmcp.resources import TextResource
+from mcp.types import ToolAnnotations
+from pydantic import AnyUrl, Field
+
+from falcon_mcp.common.errors import _format_error_response
+from falcon_mcp.common.logging import get_logger
+from falcon_mcp.modules.base import BaseModule
+from falcon_mcp.resources.host_groups import SEARCH_HOST_GROUPS_FQL_DOCUMENTATION
+
+logger = get_logger(__name__)
+
+
+class HostGroupsModule(BaseModule):
+    """Module for managing CrowdStrike Falcon host groups and their membership."""
+
+    def register_tools(self, server: FastMCP) -> None:
+        """Register tools with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        self._add_tool(
+            server=server,
+            method=self.search_host_groups,
+            name="search_host_groups",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.search_host_group_members,
+            name="search_host_group_members",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.create_host_group,
+            name="create_host_group",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.update_host_group,
+            name="update_host_group",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.delete_host_groups,
+            name="delete_host_groups",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.perform_host_group_action,
+            name="perform_host_group_action",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
+
+    def register_resources(self, server: FastMCP) -> None:
+        """Register resources with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        search_host_groups_fql_resource = TextResource(
+            uri=AnyUrl("falcon://host-groups/search/fql-guide"),
+            name="falcon_search_host_groups_fql_guide",
+            description="Contains the guide for the `filter` param of the `falcon_search_host_groups` tool.",
+            text=SEARCH_HOST_GROUPS_FQL_DOCUMENTATION,
+        )
+
+        self._add_resource(
+            server,
+            search_host_groups_fql_resource,
+        )
+
+    def search_host_groups(
+        self,
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter expression. See `falcon://host-groups/search/fql-guide` for syntax.",
+            examples={"group_type:'static'", "name:'Production Servers'"},
+        ),
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=5000,
+            description="The maximum records to return. [1-5000]",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="The offset to start retrieving records from.",
+        ),
+        sort: str = Field(
+            default="name.asc",
+            description=dedent("""
+                Sort host groups using these options:
+
+                name: Host group name
+                group_type: Host group type (static/dynamic)
+                created_by: User who created the group
+                created_timestamp: When the group was created
+                modified_by: User who last modified the group
+                modified_timestamp: When the group was last modified
+
+                Sort either asc (ascending) or desc (descending).
+                Both formats are supported: 'name.desc' or 'name|desc'
+
+                Examples: 'name.asc', 'created_timestamp.desc'
+            """).strip(),
+            examples={"name.asc", "created_timestamp.desc"},
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search for host groups in your CrowdStrike environment.
+
+        Use this to find host groups by name, type, creator, or timestamps. Consult
+        falcon://host-groups/search/fql-guide before constructing filter expressions.
+        Returns full host group details including id, name, group_type, description,
+        and audit metadata in a single call.
+        """
+        host_groups = self._base_search_api_call(
+            operation="queryCombinedHostGroups",
+            search_params={
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+            },
+            error_message="Failed to search host groups",
+        )
+
+        if self._is_error(host_groups):
+            return self._format_fql_error_response(
+                [host_groups], filter, SEARCH_HOST_GROUPS_FQL_DOCUMENTATION
+            )
+
+        if not host_groups:
+            return self._format_fql_error_response(
+                [], filter, SEARCH_HOST_GROUPS_FQL_DOCUMENTATION
+            )
+
+        return host_groups
+
+    def search_host_group_members(
+        self,
+        id: str = Field(
+            description="The host group ID whose members should be retrieved. If you don't already have it, use falcon_search_host_groups to look it up.",
+        ),
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter expression on HOST attributes. See `falcon://hosts/search/fql-guide` for syntax.",
+            examples={"platform_name:'Windows'", "hostname:'PC*'"},
+        ),
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=5000,
+            description="The maximum records to return. [1-5000]",
+        ),
+        offset: int | None = Field(
+            default=None,
+            description="The offset to start retrieving records from.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Sort members using host FQL sort syntax (e.g. 'hostname.asc', 'last_seen.desc').",
+            examples={"hostname.asc", "last_seen.desc"},
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search for the host members of a specific host group.
+
+        Use this to list the devices that belong to a host group. Requires the group
+        `id` and filters on HOST attributes (platform, hostname, etc.) — consult
+        falcon://hosts/search/fql-guide for the filter syntax. Returns full host device
+        entities including device_id, hostname, platform, and network context.
+        """
+        members = self._base_search_api_call(
+            operation="queryCombinedGroupMembers",
+            search_params={
+                "id": id,
+                "filter": filter,
+                "limit": limit,
+                "offset": offset,
+                "sort": sort,
+            },
+            error_message="Failed to search host group members",
+        )
+
+        if self._is_error(members):
+            return [members]
+
+        return members
+
+    def create_host_group(
+        self,
+        name: str = Field(
+            description="Name for the new host group.",
+        ),
+        group_type: str = Field(
+            description="Type of host group. One of: 'static' (hosts added manually by ID via falcon_perform_host_group_action), 'staticByID' (same, populated after creation), or 'dynamic' (hosts matched automatically by an assignment_rule).",
+        ),
+        description: str | None = Field(
+            default=None,
+            description="Description for the host group.",
+        ),
+        assignment_rule: str | None = Field(
+            default=None,
+            description="FQL assignment rule for dynamic groups (e.g. \"platform_name:'Windows'\"). Required for 'dynamic' groups; the API rejects it for 'static'/'staticByID' groups.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Create a host group.
+
+        Provide a name and group_type. 'dynamic' groups take an assignment_rule (host
+        FQL) that automatically includes matching hosts. 'static' and 'staticByID' groups
+        are created empty (no assignment_rule) and populated afterwards via
+        falcon_perform_host_group_action. Returns the created host group record on success.
+        """
+        resource: dict[str, Any] = {
+            "name": name,
+            "group_type": group_type,
+        }
+        if description is not None:
+            resource["description"] = description
+        if assignment_rule is not None:
+            resource["assignment_rule"] = assignment_rule
+
+        result = self._base_query_api_call(
+            operation="createHostGroups",
+            body_params={"resources": [resource]},
+            error_message="Failed to create host group",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def update_host_group(
+        self,
+        id: str = Field(
+            description="The host group ID to update. If you don't already have it, use falcon_search_host_groups to look it up.",
+        ),
+        name: str | None = Field(
+            default=None,
+            description="New name for the host group.",
+        ),
+        description: str | None = Field(
+            default=None,
+            description="New description for the host group.",
+        ),
+        assignment_rule: str | None = Field(
+            default=None,
+            description="New FQL assignment rule (e.g. \"platform_name:'Windows'\"). Only set this for 'dynamic' groups. The API does not block setting it on 'static'/'staticByID' groups, but doing so leaves the group in an inconsistent state and should be avoided.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Update an existing host group.
+
+        Provide the group `id` and any fields to change. name and description are safe
+        for any group type; only set assignment_rule on 'dynamic' groups. Unspecified
+        fields are left unchanged. Returns the updated host group record on success.
+        """
+        resource: dict[str, Any] = {"id": id}
+        if name is not None:
+            resource["name"] = name
+        if description is not None:
+            resource["description"] = description
+        if assignment_rule is not None:
+            resource["assignment_rule"] = assignment_rule
+
+        result = self._base_query_api_call(
+            operation="updateHostGroups",
+            body_params={"resources": [resource]},
+            error_message="Failed to update host group",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def delete_host_groups(
+        self,
+        ids: list[str] = Field(
+            description="Host group IDs to delete. If you don't already have them, use falcon_search_host_groups to look them up.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Delete one or more host groups.
+
+        Provide the host group `ids` to delete. This permanently removes the groups.
+        Returns an empty list on success.
+        """
+        if not ids:
+            return [
+                _format_error_response(
+                    "`ids` must be provided to delete host groups.",
+                    operation="deleteHostGroups",
+                )
+            ]
+
+        result = self._base_query_api_call(
+            operation="deleteHostGroups",
+            query_params={"ids": ids},
+            error_message="Failed to delete host groups",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result
+
+    def perform_host_group_action(
+        self,
+        action_name: str = Field(
+            description="The membership action to perform. Either 'add-hosts' or 'remove-hosts'.",
+        ),
+        ids: list[str] = Field(
+            description="Host group IDs to add hosts to or remove hosts from. If you don't already have them, use falcon_search_host_groups to look them up.",
+        ),
+        filter: str = Field(
+            description="Host FQL expression selecting which hosts to add or remove (e.g. \"device_id:['id1','id2']\" or \"platform_name:'Windows'\"). See `falcon://hosts/search/fql-guide` for syntax.",
+        ),
+    ) -> list[dict[str, Any]]:
+        """Add or remove hosts from one or more host groups.
+
+        Set action_name to 'add-hosts' or 'remove-hosts', provide the target group
+        `ids`, and a host FQL filter selecting which hosts to act on. Applies only to
+        static groups. Returns the updated host group records on success.
+        """
+        result = self._base_query_api_call(
+            operation="performGroupAction",
+            query_params={"action_name": action_name},
+            body_params={
+                "ids": ids,
+                "action_parameters": [{"name": "filter", "value": filter}],
+            },
+            error_message="Failed to perform host group action",
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result

--- a/falcon_mcp/resources/host_groups.py
+++ b/falcon_mcp/resources/host_groups.py
@@ -1,0 +1,143 @@
+"""
+Contains Host Groups resources.
+"""
+
+from falcon_mcp.common.utils import generate_md_table
+
+# List of tuples containing filter options data: (name, type, description)
+SEARCH_HOST_GROUPS_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Description",
+    ),
+    (
+        "name",
+        "String",
+        """
+        The name of the host group.
+
+        Ex: name:'Production Servers'
+        """,
+    ),
+    (
+        "group_type",
+        "String",
+        """
+        The type of host group.
+
+        Possible values:
+        - static (members assigned by hostname)
+        - staticByID (members assigned by device ID)
+        - dynamic (members matched by an FQL assignment rule)
+
+        Ex: group_type:'static'
+        """,
+    ),
+    (
+        "created_by",
+        "String",
+        """
+        The user who created the host group.
+
+        Ex: created_by:'user@example.com'
+        """,
+    ),
+    (
+        "created_timestamp",
+        "Timestamp",
+        """
+        The timestamp when the host group was created (UTC).
+
+        Ex: created_timestamp:>'2024-01-01T00:00:00Z'
+        Ex: created_timestamp:>'now-30d'
+        """,
+    ),
+    (
+        "modified_by",
+        "String",
+        """
+        The user who last modified the host group.
+
+        Ex: modified_by:'user@example.com'
+        """,
+    ),
+    (
+        "modified_timestamp",
+        "Timestamp",
+        """
+        The timestamp when the host group was last modified (UTC).
+
+        Ex: modified_timestamp:>'2024-01-01T00:00:00Z'
+        Ex: modified_timestamp:>'now-7d'
+        """,
+    ),
+]
+
+SEARCH_HOST_GROUPS_FQL_DOCUMENTATION = (
+    """Falcon Query Language (FQL) - Search Host Groups Guide
+
+=== BASIC SYNTAX ===
+property_name:[operator]'value'
+
+=== AVAILABLE OPERATORS ===
+• No operator = equals (default)
+• ! = not equal to
+• > = greater than (timestamp fields)
+• >= = greater than or equal (timestamp fields)
+• < = less than (timestamp fields)
+• <= = less than or equal (timestamp fields)
+• ~ = text match (case insensitive)
+
+=== DATA TYPES & SYNTAX ===
+• Strings: 'value'
+• Dates: 'YYYY-MM-DDTHH:MM:SSZ' (UTC format) or relative like 'now-30d'
+• Booleans: true or false (no quotes)
+
+=== COMBINING CONDITIONS ===
+• + = AND condition
+• , = OR condition
+• ( ) = Group expressions
+
+=== falcon_search_host_groups FQL filter options ===
+
+"""
+    + generate_md_table(SEARCH_HOST_GROUPS_FQL_FILTERS)
+    + """
+
+=== EXAMPLE QUERIES ===
+
+**By name:**
+• name:'Production Servers'
+
+**By type:**
+• group_type:'static'
+• group_type:'staticByID'
+• group_type:'dynamic'
+
+**By creator:**
+• created_by:'user@example.com'
+
+**Recently created:**
+• created_timestamp:>'now-30d'
+• created_timestamp:>'2024-01-01T00:00:00Z'
+
+**Recently modified:**
+• modified_timestamp:>'now-7d'
+
+**Combined Conditions:**
+• group_type:'static'+created_by:'user@example.com'
+• (group_type:'static',group_type:'staticByID')+modified_timestamp:>'now-30d'
+
+=== 💡 SYNTAX RULES ===
+• Use single quotes around string values: 'value'
+• Date format must be UTC: 'YYYY-MM-DDTHH:MM:SSZ'
+• Relative dates use lowercase quoted syntax: 'now-7d', 'now-30d'
+• Combine conditions with + (AND) or , (OR)
+
+=== NOTE ON MEMBER SEARCH ===
+The falcon_search_host_group_members tool filters on HOST (device) attributes,
+not host group attributes. Consult falcon://hosts/search/fql-guide for the
+filter syntax of that tool.
+"""
+)

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -43,6 +43,9 @@ MODULE_METADATA: dict[str, dict[str, Any]] = {
     "dataprotection": {
         "slug": "data-protection",
     },
+    "hostgroups": {
+        "slug": "host-groups",
+    },
     "idp": {
         "title": "Identity Protection",
     },
@@ -217,6 +220,30 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     ],
     "falcon_get_host_details": [
         "Get the full details for host device abc123",
+    ],
+    # Host Groups
+    "falcon_search_host_groups": [
+        "Show me all static host groups",
+        "Find host groups created in the last 30 days",
+    ],
+    "falcon_search_host_group_members": [
+        "List the Windows hosts in host group abc123",
+        "Show me the members of the Production Servers group",
+    ],
+    "falcon_create_host_group": [
+        "Create a static host group called 'Critical Servers'",
+        "Create a dynamic host group for all Windows hosts",
+    ],
+    "falcon_update_host_group": [
+        "Rename host group abc123 to 'Decommissioned'",
+        "Update the assignment rule for the dynamic Windows group",
+    ],
+    "falcon_delete_host_groups": [
+        "Delete host group abc123",
+    ],
+    "falcon_perform_host_group_action": [
+        "Add the hosts matching platform_name Windows to group abc123",
+        "Remove host device xyz from host group abc123",
     ],
     # Identity Protection
     "falcon_idp_investigate_entity": [

--- a/tests/integration/test_host_groups.py
+++ b/tests/integration/test_host_groups.py
@@ -1,0 +1,243 @@
+"""Integration tests for the Host Groups module."""
+
+import time
+import warnings
+
+import pytest
+
+from falcon_mcp.modules.host_groups import HostGroupsModule
+from tests.integration.utils.base_integration_test import (
+    BaseIntegrationTest,
+    resolve_field_defaults,
+)
+
+
+@pytest.mark.integration
+class TestHostGroupsIntegration(BaseIntegrationTest):
+    """Integration tests for the Host Groups module with real API calls.
+
+    Validates:
+    - Correct FalconPy operation names (queryCombinedHostGroups,
+      queryCombinedGroupMembers, createHostGroups, updateHostGroups,
+      deleteHostGroups, performGroupAction)
+    - Combined search returns full entities in a single call (no two-step pattern)
+    - Body/query param formats for mutating endpoints
+    - Full lifecycle roundtrip (create -> update -> action -> delete)
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_module(self, falcon_client):
+        """Set up the Host Groups module with a real client."""
+        self.module = HostGroupsModule(falcon_client)
+
+    @pytest.fixture(scope="class")
+    def lifecycle_group(self, falcon_client):
+        """Create a static host group for the class and clean it up afterwards.
+
+        Exercises create -> update -> add/remove host action -> delete to validate
+        every mutating operation name and body format against the live API. Always
+        cleans up via delete, even if intermediate steps fail.
+        """
+        module = HostGroupsModule(falcon_client)
+        unique_name = f"falcon-mcp-test-{int(time.time())}"
+
+        create_kwargs = resolve_field_defaults(
+            module.create_host_group,
+            {
+                "name": unique_name,
+                "group_type": "static",
+                "description": "Integration test group - safe to delete",
+            },
+        )
+        create_result = module.create_host_group(**create_kwargs)
+
+        if not isinstance(create_result, list) or len(create_result) == 0:
+            pytest.skip(f"Unexpected create response: {create_result}")
+
+        first = create_result[0]
+        if isinstance(first, dict) and "error" in first:
+            pytest.skip(
+                f"Cannot create test host group (check Host Groups:write scope): {first}"
+            )
+        if not isinstance(first, dict) or "id" not in first:
+            pytest.skip(f"Unexpected create response shape: {create_result}")
+
+        group_id = first["id"]
+
+        yield {"id": group_id, "name": unique_name, "created": first}
+
+        # Teardown: always delete the group
+        try:
+            delete_kwargs = resolve_field_defaults(
+                module.delete_host_groups, {"ids": [group_id]}
+            )
+            module.delete_host_groups(**delete_kwargs)
+        except Exception as e:  # noqa: BLE001
+            warnings.warn(
+                f"Failed to clean up test host group {group_id}: {e}",
+                stacklevel=2,
+            )
+
+    def test_operation_names_are_correct(self, lifecycle_group):
+        """Validate every FalconPy operation name against the live API.
+
+        Wrong operation names fail with error responses. This covers all 6 ops:
+        the two searches plus the create/update/action/delete in the lifecycle.
+        """
+        group_id = lifecycle_group["id"]
+
+        # queryCombinedHostGroups
+        search_result = self.call_method(self.module.search_host_groups, limit=1)
+        self.assert_no_error(search_result, context="queryCombinedHostGroups")
+
+        # queryCombinedGroupMembers
+        members_result = self.call_method(
+            self.module.search_host_group_members, id=group_id, limit=1
+        )
+        self.assert_no_error(members_result, context="queryCombinedGroupMembers")
+
+        # updateHostGroups
+        update_result = self.call_method(
+            self.module.update_host_group,
+            id=group_id,
+            description="Integration test group - updated",
+        )
+        self.assert_no_error(update_result, context="updateHostGroups")
+
+        # performGroupAction (remove-hosts is a no-op safe action on an empty group)
+        action_result = self.call_method(
+            self.module.perform_host_group_action,
+            action_name="remove-hosts",
+            ids=[group_id],
+            filter="device_id:['000000000000000000000000000000ff']",
+        )
+        self.assert_no_error(action_result, context="performGroupAction")
+
+    def test_search_host_groups_returns_details(self):
+        """Test that search_host_groups returns full details in a single call."""
+        result = self.call_method(self.module.search_host_groups, limit=5)
+
+        self.assert_no_error(result, context="search_host_groups")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_host_groups"
+        )
+
+        if isinstance(result, list) and len(result) > 0:
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["id", "name", "group_type"],
+                context="search_host_groups",
+            )
+
+    def test_search_host_groups_with_filter(self):
+        """Test search_host_groups with an FQL filter."""
+        result = self.call_method(
+            self.module.search_host_groups,
+            filter="group_type:'static'",
+            limit=5,
+        )
+
+        self.assert_no_error(result, context="search_host_groups with filter")
+
+    def test_search_host_group_members_returns_hosts(self, lifecycle_group):
+        """Test that member search returns host device entities, not just IDs."""
+        result = self.call_method(
+            self.module.search_host_group_members,
+            id=lifecycle_group["id"],
+            limit=5,
+        )
+
+        self.assert_no_error(result, context="search_host_group_members")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_host_group_members"
+        )
+
+        if isinstance(result, list) and len(result) > 0:
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["device_id"],
+                context="search_host_group_members",
+            )
+
+    def test_search_host_group_members_with_filter(self):
+        """Validate the member `filter` param against a populated group.
+
+        `id` and `filter` are complementary, not mutually exclusive: `id` selects
+        which group's members to enumerate, `filter` narrows that set by HOST device
+        attributes. Find any group that has members, then apply a host FQL filter and
+        assert the call succeeds. Skips if the tenant has no populated groups.
+
+        Note: do NOT use filter="*" here — the live API rejects it with HTTP 400.
+        Omitting `filter` is the "all members" path.
+        """
+        groups = self.call_method(self.module.search_host_groups, limit=50)
+        if not isinstance(groups, list) or len(groups) == 0:
+            self.skip_with_warning(
+                "No host groups in tenant", context="member filter validation"
+            )
+            return
+
+        populated_id = None
+        for group in groups:
+            if not isinstance(group, dict) or "id" not in group:
+                continue
+            members = self.call_method(
+                self.module.search_host_group_members, id=group["id"], limit=1
+            )
+            if isinstance(members, list) and len(members) > 0:
+                populated_id = group["id"]
+                break
+
+        if populated_id is None:
+            self.skip_with_warning(
+                "No populated host groups in tenant",
+                context="member filter validation",
+            )
+            return
+
+        result = self.call_method(
+            self.module.search_host_group_members,
+            id=populated_id,
+            filter="platform_name:'Windows'",
+            limit=5,
+        )
+
+        self.assert_no_error(result, context="member search with host filter")
+        self.assert_valid_list_response(
+            result, min_length=0, context="member search with host filter"
+        )
+
+    def test_create_response_shape(self, lifecycle_group):
+        """Test that the create response from the fixture has expected fields."""
+        created = lifecycle_group["created"]
+
+        for field in ["id", "name", "group_type"]:
+            assert field in created, (
+                f"Expected '{field}' in created host group. "
+                f"Available fields: {list(created.keys())}"
+            )
+
+        assert created["group_type"] == "static", (
+            f"Expected group_type 'static', got '{created['group_type']}'"
+        )
+
+    def test_created_group_appears_in_search(self, lifecycle_group):
+        """Round-trip: verify the created group is findable via search."""
+        result = self.call_method(
+            self.module.search_host_groups,
+            filter=f"name:'{lifecycle_group['name']}'",
+            limit=10,
+        )
+
+        self.assert_no_error(result, context="round-trip search")
+        self.assert_valid_list_response(
+            result, min_length=1, context="round-trip search"
+        )
+
+        found_ids = [
+            item.get("id") for item in result if isinstance(item, dict)
+        ]
+        assert lifecycle_group["id"] in found_ids, (
+            f"Created group {lifecycle_group['id']} not found in search results. "
+            f"Found IDs: {found_ids}"
+        )

--- a/tests/modules/test_host_groups.py
+++ b/tests/modules/test_host_groups.py
@@ -1,0 +1,373 @@
+"""
+Tests for the Host Groups module.
+"""
+
+import unittest
+
+from mcp.types import ToolAnnotations
+
+from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
+from falcon_mcp.modules.host_groups import HostGroupsModule
+from tests.modules.utils.test_modules import TestModules
+
+
+class TestHostGroupsModule(TestModules):
+    """Test cases for the Host Groups module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(HostGroupsModule)
+
+    def test_register_tools(self):
+        """Test registering tools with the server."""
+        expected_tools = [
+            "falcon_search_host_groups",
+            "falcon_search_host_group_members",
+            "falcon_create_host_group",
+            "falcon_update_host_group",
+            "falcon_delete_host_groups",
+            "falcon_perform_host_group_action",
+        ]
+        self.assert_tools_registered(expected_tools)
+
+    def test_register_resources(self):
+        """Test registering resources with the server."""
+        expected_resources = [
+            "falcon_search_host_groups_fql_guide",
+        ]
+        self.assert_resources_registered(expected_resources)
+
+    def test_search_host_groups_success(self):
+        """Test searching host groups returns full details in a single call."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "id": "group-1",
+                        "name": "Production Servers",
+                        "group_type": "static",
+                    },
+                    {
+                        "id": "group-2",
+                        "name": "Windows Dynamic",
+                        "group_type": "dynamic",
+                    },
+                ]
+            },
+        }
+
+        result = self.module.search_host_groups(
+            filter="group_type:'static'",
+            limit=100,
+            offset=0,
+            sort="name.asc",
+        )
+
+        # Combined search is a SINGLE command call (no two-step query->get)
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "queryCombinedHostGroups")
+        self.assertEqual(call_args[1]["parameters"]["filter"], "group_type:'static'")
+        self.assertEqual(call_args[1]["parameters"]["sort"], "name.asc")
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "group-1")
+
+    def test_search_host_groups_empty_results_returns_fql_guide(self):
+        """Test host group search empty results include FQL guide context."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module.search_host_groups(filter="name:'nonexistent'")
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+        self.assertIn("fql_guide", result)
+        self.assertIn("No results matched", result["hint"])
+
+    def test_search_host_groups_error_returns_fql_guide(self):
+        """Test host group search errors include FQL guide context."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid filter"}]},
+        }
+
+        result = self.module.search_host_groups(filter="bad filter")
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 1)
+        self.assertIn("error", result["results"][0])
+        self.assertIn("fql_guide", result)
+
+    def test_search_host_group_members_success(self):
+        """Test searching host group members returns full host details."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"device_id": "device-1", "hostname": "PC-1"},
+                    {"device_id": "device-2", "hostname": "PC-2"},
+                ]
+            },
+        }
+
+        result = self.module.search_host_group_members(
+            id="group-1",
+            filter="platform_name:'Windows'",
+            limit=100,
+            offset=0,
+            sort="hostname.asc",
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "queryCombinedGroupMembers")
+        self.assertEqual(call_args[1]["parameters"]["id"], "group-1")
+        self.assertEqual(
+            call_args[1]["parameters"]["filter"], "platform_name:'Windows'"
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["device_id"], "device-1")
+
+    def test_search_host_group_members_error(self):
+        """Test member search error returns wrapped error."""
+        self.mock_client.command.return_value = {
+            "status_code": 404,
+            "body": {"errors": [{"message": "Group not found"}]},
+        }
+
+        result = self.module.search_host_group_members(
+            id="bad-group", filter=None, limit=100, offset=None, sort=None
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    def test_create_host_group_static_success(self):
+        """Test creating a static host group."""
+        self.mock_client.command.return_value = {
+            "status_code": 201,
+            "body": {
+                "resources": [
+                    {"id": "group-1", "name": "Critical Servers", "group_type": "static"}
+                ]
+            },
+        }
+
+        result = self.module.create_host_group(
+            name="Critical Servers",
+            group_type="static",
+            description="Important hosts",
+            assignment_rule=None,
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "createHostGroups",
+            body={
+                "resources": [
+                    {
+                        "name": "Critical Servers",
+                        "group_type": "static",
+                        "description": "Important hosts",
+                    }
+                ]
+            },
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "group-1")
+
+    def test_create_host_group_dynamic_with_assignment_rule(self):
+        """Test creating a dynamic host group includes assignment_rule."""
+        self.mock_client.command.return_value = {
+            "status_code": 201,
+            "body": {"resources": [{"id": "group-2", "group_type": "dynamic"}]},
+        }
+
+        self.module.create_host_group(
+            name="Windows Dynamic",
+            group_type="dynamic",
+            description=None,
+            assignment_rule="platform_name:'Windows'",
+        )
+
+        call_args = self.mock_client.command.call_args
+        resource = call_args[1]["body"]["resources"][0]
+        self.assertEqual(resource["assignment_rule"], "platform_name:'Windows'")
+        self.assertNotIn("description", resource)
+
+    def test_update_host_group_success(self):
+        """Test updating a host group."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "group-1", "name": "Renamed"}]},
+        }
+
+        result = self.module.update_host_group(
+            id="group-1",
+            name="Renamed",
+            description=None,
+            assignment_rule=None,
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "updateHostGroups",
+            body={"resources": [{"id": "group-1", "name": "Renamed"}]},
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "Renamed")
+
+    def test_delete_host_groups_success(self):
+        """Test deleting host groups sends IDs as query params."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": ["group-1"]},
+        }
+
+        result = self.module.delete_host_groups(ids=["group-1", "group-2"])
+
+        self.mock_client.command.assert_called_once_with(
+            "deleteHostGroups",
+            parameters={"ids": ["group-1", "group-2"]},
+        )
+        self.assertIsInstance(result, list)
+
+    def test_delete_host_groups_validation_error(self):
+        """Test delete_host_groups requires ids."""
+        result = self.module.delete_host_groups(ids=[])
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+        self.mock_client.command.assert_not_called()
+
+    def test_perform_host_group_action_add_hosts(self):
+        """Test adding hosts to a group sends action_name and body correctly."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "group-1"}]},
+        }
+
+        result = self.module.perform_host_group_action(
+            action_name="add-hosts",
+            ids=["group-1"],
+            filter="platform_name:'Windows'",
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "performGroupAction",
+            parameters={"action_name": "add-hosts"},
+            body={
+                "ids": ["group-1"],
+                "action_parameters": [
+                    {"name": "filter", "value": "platform_name:'Windows'"}
+                ],
+            },
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "group-1")
+
+    def test_perform_host_group_action_remove_hosts(self):
+        """Test removing hosts from a group passes remove-hosts action."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "group-1"}]},
+        }
+
+        self.module.perform_host_group_action(
+            action_name="remove-hosts",
+            ids=["group-1"],
+            filter="device_id:['dev-1']",
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["parameters"]["action_name"], "remove-hosts")
+
+    # Security validation tests
+
+    def test_search_host_groups_with_special_characters_in_filter(self):
+        """Test that special characters in filter are passed through safely."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        filter_with_special = "name:*';DROP TABLE--*"
+        self.module.search_host_groups(filter=filter_with_special)
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[1]["parameters"]["filter"], filter_with_special)
+
+    def test_create_host_group_permission_error(self):
+        """Test create_host_group with 403 permission error returns error response."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied, authorization failed"}]},
+        }
+
+        result = self.module.create_host_group(
+            name="Test",
+            group_type="static",
+            description=None,
+            assignment_rule=None,
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    def test_delete_host_groups_permission_error(self):
+        """Test delete_host_groups with 403 permission error returns error response."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "Access denied, authorization failed"}]},
+        }
+
+        result = self.module.delete_host_groups(ids=["group-1"])
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
+
+    # Annotation tests
+
+    def test_search_tools_have_read_only_annotations(self):
+        """Test that search tools are registered with read-only annotations."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations(
+            "falcon_search_host_groups", READ_ONLY_ANNOTATIONS
+        )
+        self.assert_tool_annotations(
+            "falcon_search_host_group_members", READ_ONLY_ANNOTATIONS
+        )
+
+    def test_mutating_tools_have_correct_annotations(self):
+        """Test that mutating tools carry the correct annotations."""
+        self.module.register_tools(self.mock_server)
+
+        non_destructive = ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=True,
+        )
+        self.assert_tool_annotations("falcon_create_host_group", non_destructive)
+        self.assert_tool_annotations("falcon_update_host_group", non_destructive)
+        self.assert_tool_annotations(
+            "falcon_perform_host_group_action", non_destructive
+        )
+
+        self.assert_tool_annotations(
+            "falcon_delete_host_groups",
+            ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -35,6 +35,11 @@ MUTATING_TOOL_ALLOWLIST: set[str] = {
     # firewall module
     "falcon_create_firewall_rule_group",
     "falcon_delete_firewall_rule_groups",
+    # host_groups module
+    "falcon_create_host_group",
+    "falcon_update_host_group",
+    "falcon_delete_host_groups",
+    "falcon_perform_host_group_action",
     # custom_ioa module
     "falcon_create_ioa_rule_group",
     "falcon_update_ioa_rule_group",


### PR DESCRIPTION
Adds a host_groups module that exposes the full FalconPy HostGroup service class: searching host groups, searching a group's host members, creating, updating, and deleting groups, and adding or removing hosts from groups. Both search tools use the combined endpoints so they return full entities in a single call rather than the two-step query-then-get pattern. Resolves #399.

The original issue proposed three read-only tools including a get-by-id; that was dropped because the combined search already returns byte-identical fields, and the scope was expanded to the full six-tool CRUD plus membership module.

Everything here was validated against the live API rather than trusting the SDK or docs, which surfaced a few things worth calling out. group_type has three real values (static, staticByID, dynamic), not the two the SDK implies. Create rejects an assignment_rule on static and staticByID groups, while update permits it and the rule actually takes effect, leaving the group in an inconsistent state, so the update tool's description steers against that. The member search filter is host FQL and works alongside the group id rather than being mutually exclusive with it, and passing filter='*' is rejected by the API even though the SDK documents it as "include all". The tool and parameter descriptions reflect all of this.