### PR TITLE
fix(modules/ioc): return delete summary

### DIFF
--- a/docs/modules/ioc.md
+++ b/docs/modules/ioc.md
@@ -40,7 +40,7 @@ Returns the created indicator records on success.
 Remove custom IOCs by IDs or FQL filter.
 
 Provide either specific IDs or an FQL filter for bulk removal. If both are
-given, filter takes precedence. Returns an empty list on success.
+given, filter takes precedence. Returns a success summary with deleted IOC IDs.
 
 **Example prompts:**
 

--- a/falcon_mcp/modules/ioc.py
+++ b/falcon_mcp/modules/ioc.py
@@ -292,11 +292,11 @@ class IOCModule(BaseModule):
             default=None,
             description="Limit action to IOCs originating from the MSSP parent.",
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         """Remove custom IOCs by IDs or FQL filter.
 
         Provide either specific IDs or an FQL filter for bulk removal. If both are
-        given, filter takes precedence. Returns an empty list on success.
+        given, filter takes precedence. Returns a success summary with deleted IOC IDs.
         """
         if not ids and not filter:
             return [
@@ -321,7 +321,11 @@ class IOCModule(BaseModule):
         if self._is_error(result):
             return [result]
 
-        return result
+        return {
+            "status": "deleted",
+            "deleted_ids": result,
+            "count": len(result),
+        }
 
     def _build_add_ioc_payload(
         self,

--- a/tests/modules/test_ioc.py
+++ b/tests/modules/test_ioc.py
@@ -263,7 +263,7 @@ class TestIOCModule(TestModules):
         """Test removing IOCs by explicit IDs."""
         self.mock_client.command.return_value = {
             "status_code": 200,
-            "body": {"resources": [{"id": "ioc-id-1"}]},
+            "body": {"resources": ["ioc-id-1"]},
         }
 
         result = self.module.remove_iocs(
@@ -274,14 +274,15 @@ class TestIOCModule(TestModules):
             "indicator_delete_v1",
             parameters={"ids": ["ioc-id-1"], "comment": "cleanup"},
         )
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["id"], "ioc-id-1")
+        self.assertEqual(result["status"], "deleted")
+        self.assertEqual(result["deleted_ids"], ["ioc-id-1"])
+        self.assertEqual(result["count"], 1)
 
     def test_remove_iocs_by_filter(self):
         """Test removing IOCs by FQL filter."""
         self.mock_client.command.return_value = {
             "status_code": 200,
-            "body": {"resources": [{"id": "ioc-id-1"}, {"id": "ioc-id-2"}]},
+            "body": {"resources": ["ioc-id-1", "ioc-id-2"]},
         }
 
         result = self.module.remove_iocs(
@@ -297,7 +298,8 @@ class TestIOCModule(TestModules):
             call_args[1]["parameters"]["filter"], "source:'mcp'+expired:true"
         )
         self.assertEqual(call_args[1]["parameters"]["comment"], "cleanup expired IOCs")
-        self.assertEqual(len(result), 2)
+        self.assertEqual(result["deleted_ids"], ["ioc-id-1", "ioc-id-2"])
+        self.assertEqual(result["count"], 2)
 
     def test_remove_iocs_validation_error(self):
         """Test remove_iocs requires either ids or filter."""
@@ -458,5 +460,3 @@ class TestIOCModule(TestModules):
 
 if __name__ == "__main__":
     unittest.main()
-
-

--- a/tests/modules/test_ioc.py
+++ b/tests/modules/test_ioc.py
@@ -457,6 +457,31 @@ class TestIOCModule(TestModules):
             ),
         )
 
+    def test_remove_iocs_success_returns_envelope_not_validation_error(self):
+        """Regression test: remove_iocs must return a typed success envelope on success.
+
+        indicator_delete_v1 returns resources as a list of plain ID strings, not
+        objects. The tool was previously annotated -> list[dict[str, Any]], so a
+        list[str] response caused a Pydantic ValidationError on the success path
+        (GitHub issue #443). The fix wraps the deleted IDs in a structured dict
+        so the return type is always valid and the success/failure signal is
+        unambiguous.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": ["ioc-id-1", "ioc-id-2"]},
+        }
+
+        result = self.module.remove_iocs(
+            ids=["ioc-id-1", "ioc-id-2"], filter=None, comment=None, from_parent=None
+        )
+
+        # Must be a dict, not a list[str] (which would fail output-schema validation)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["status"], "deleted")
+        self.assertEqual(sorted(result["deleted_ids"]), ["ioc-id-1", "ioc-id-2"])
+        self.assertEqual(result["count"], 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #443.

`indicator_delete_v1` returns deleted IOC IDs as strings, so `remove_iocs` was passing through a `list[str]` even though the tool output schema expected objects. This wraps successful deletes in a small summary object and updates the IOC tests to use the real response shape.

## Testing

- `uv run --extra dev pytest`
- `uv run ruff check . --select I`
- `uv run ruff check .`
- `uv run mypy .`
