### PR TITLE
fix(tests/integration): correct platform field assertion in firewall tests

### DIFF
--- a/tests/integration/test_firewall.py
+++ b/tests/integration/test_firewall.py
@@ -52,7 +52,7 @@ class TestFirewallIntegration(BaseIntegrationTest):
         if len(result) > 0:
             self.assert_search_returns_details(
                 result,
-                expected_fields=["id", "platform"],
+                expected_fields=["id", "platform_ids"],
                 context="search_firewall_rules",
             )
 


### PR DESCRIPTION
The firewall integration test `test_search_firewall_rules_returns_details` was asserting `expected_fields=["id", "platform"]`, but the Falcon Firewall Management `get_rules` API returns `platform_ids` (an array), not a scalar `platform` field. The `platform` name is valid in FQL filter/sort expressions, but the response object uses `platform_ids`. This is a test bug, not a tool regression — `search_firewall_rules` returns the raw `get_rules` response unchanged.

The sibling `test_search_firewall_rule_groups_returns_details` assertion at line 97 (`expected_fields=["id", "platform"]`) is left alone — rule groups use a singular `platform` string per the FalconPy payload model.

Closes #448