### PR TITLE
fix(modules/detections): replace verdict param with tags to be inline with ui experience

### DIFF
--- a/docs/modules/detections.md
+++ b/docs/modules/detections.md
@@ -50,18 +50,23 @@ info, tactic/technique details, and threat classification.
 
 **Required scopes:** `Alerts:write`
 
-Update the status, assignment, visibility, or verdict of one or more detections.
+Update the status, assignment, visibility, comments, and tags of one or more detections.
 
-Use to change status (new, in_progress, reopened, closed), assign to a user by
-UUID, email address, or full name, append a comment, unassign, hide/show
-detections in the UI, or set a verdict (true_positive, false_positive, ignored).
-At least one update parameter must be provided. Returns `[]` (empty list) on success; returns an error dict on failure.
+Use to change status (new, in_progress, reopened, closed), assign to a user by UUID,
+email address, or full name, unassign, append a comment, hide/show detections in the UI,
+or add/remove tags. Resolution is tag-based: applying the conventional tags true_positive,
+false_positive, or ignored is what populates the console's Resolution view. At least one
+update parameter must be provided. Returns `[]` (empty list) on success, or
+`{"result": [], "hint": "..."}` when closing without adding a resolution tag in this call;
+returns an error dict on failure.
 
 **Example prompts:**
 
 - "Mark detection abc123 as in_progress"
 - "Assign detection abc123 to analyst@example.com"
 - "Close these detections and add a comment: resolved via playbook"
+- "Mark detection abc123 as a true positive and close it"
+- "Remove all fc/ prefixed tags from this detection"
 
 ## Resources
 

--- a/falcon_mcp/modules/detections.py
+++ b/falcon_mcp/modules/detections.py
@@ -217,17 +217,33 @@ class DetectionsModule(BaseModule):
             default=None,
             description="Whether to show the detection(s) in the Falcon UI. Set to False to hide.",
         ),
-        verdict: str | None = Field(
+        add_tags: list[str] | None = Field(
             default=None,
-            description="Resolution verdict tag to add. Allowed values: true_positive, false_positive, ignored. Tags are additive — calling this tool does not clear a previously set verdict tag.",
+            description=(
+                "Tags to add to the detection(s). Tags are free-form strings; any value is accepted. "
+                "true_positive, false_positive, and ignored are the conventional resolution tags the "
+                "Falcon console surfaces in its Resolution column — use them when recording a resolution, "
+                "but they are guidance, not an enforced set."
+            ),
+        ),
+        remove_tags: list[str] | None = Field(
+            default=None,
+            description="Tags to remove from the detection(s). Each value must match an existing tag exactly.",
+        ),
+        remove_tags_by_prefix: str | None = Field(
+            default=None,
+            description="Remove all tags on the detection(s) that start with this prefix (e.g. 'fc/').",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Update the status, assignment, visibility, or verdict of one or more detections.
+        """Update the status, assignment, visibility, comments, and tags of one or more detections.
 
-        Use to change status (new, in_progress, reopened, closed), assign to a user by
-        UUID, email address, or full name, append a comment, unassign, hide/show
-        detections in the UI, or set a verdict (true_positive, false_positive, ignored).
-        At least one update parameter must be provided. Returns `[]` (empty list) on success; returns an error dict on failure.
+        Use to change status (new, in_progress, reopened, closed), assign to a user by UUID,
+        email address, or full name, unassign, append a comment, hide/show detections in the UI,
+        or add/remove tags. Resolution is tag-based: applying the conventional tags true_positive,
+        false_positive, or ignored is what populates the console's Resolution view. At least one
+        update parameter must be provided. Returns `[]` (empty list) on success, or
+        `{"result": [], "hint": "..."}` when closing without adding a resolution tag in this call;
+        returns an error dict on failure.
         """
         # Validate mutually exclusive assignment parameters
         assignment_params = [assign_to_uuid, assign_to_user_id, assign_to_name]
@@ -240,9 +256,16 @@ class DetectionsModule(BaseModule):
         if append_comment is not None and append_comment.strip() == "":
             return {"error": "append_comment must not be empty."}
 
-        _valid_verdicts = {"true_positive", "false_positive", "ignored"}
-        if verdict is not None and verdict not in _valid_verdicts:
-            return {"error": f"verdict must be one of: {', '.join(sorted(_valid_verdicts))}."}
+        for tag in add_tags or []:
+            if tag.strip() == "":
+                return {"error": "add_tags must not contain empty or whitespace-only strings."}
+
+        for tag in remove_tags or []:
+            if tag.strip() == "":
+                return {"error": "remove_tags must not contain empty or whitespace-only strings."}
+
+        if remove_tags_by_prefix is not None and remove_tags_by_prefix.strip() == "":
+            return {"error": "remove_tags_by_prefix must not be empty or whitespace-only."}
 
         _valid_statuses = {"new", "in_progress", "reopened", "closed"}
         if status is not None and status not in _valid_statuses:
@@ -269,8 +292,13 @@ class DetectionsModule(BaseModule):
             action_parameters.append({"name": "show_in_ui", "value": str(show_in_ui).lower()})
         if unassign is True:
             action_parameters.append({"name": "unassign", "value": "true"})
-        if verdict is not None:
-            action_parameters.append({"name": "add_tag", "value": verdict})
+
+        for tag in add_tags or []:
+            action_parameters.append({"name": "add_tag", "value": tag})
+        for tag in remove_tags or []:
+            action_parameters.append({"name": "remove_tag", "value": tag})
+        if remove_tags_by_prefix is not None:
+            action_parameters.append({"name": "remove_tags_by_prefix", "value": remove_tags_by_prefix})
 
         if not action_parameters:
             return {"error": "At least one update parameter must be provided."}
@@ -280,9 +308,29 @@ class DetectionsModule(BaseModule):
             "action_parameters": action_parameters,
         }
 
-        return self._base_query_api_call(
+        result = self._base_query_api_call(
             operation="PatchEntitiesAlertsV3",
             body_params=body,
             error_message="Failed to update detections",
             default_result=[],
         )
+
+        # Soft hint: closing without adding a resolution tag in this call may leave the
+        # detection out of the console's Resolution view. Non-fatal — only wraps the success
+        # case. We only know this call's add_tags, not any resolution tag set previously.
+        _resolution_tags = {"true_positive", "false_positive", "ignored"}
+        if (
+            not self._is_error(result)
+            and status == "closed"
+            and not _resolution_tags.intersection(add_tags or [])
+        ):
+            return {
+                "result": result,
+                "hint": (
+                    "No resolution tag was added in this update call. The console convention is to "
+                    "add true_positive, false_positive, or ignored when closing a detection so it "
+                    "appears in the Resolution view (skip if a resolution tag was already set)."
+                ),
+            }
+
+        return result

--- a/falcon_mcp/resources/detections.py
+++ b/falcon_mcp/resources/detections.py
@@ -340,9 +340,9 @@ SEARCH_DETECTIONS_FQL_FILTERS = [
         "tags",
         "Array",
         """
-        Contains FalconGroupingTags, SensorGroupingTags, and verdict tags (array field).
-        Verdict tags set via update_detections verdict param: true_positive, false_positive, ignored.
-        Use to filter by verdict: tags:'true_positive'
+        Contains FalconGroupingTags, SensorGroupingTags, and resolution tags (array field).
+        Resolution tags added via the falcon_update_detections add_tags param: true_positive, false_positive, ignored.
+        Use to filter by resolution: tags:'true_positive'
         Exact match only — wildcards and ~ are not supported on array fields.
         Ex: true_positive, false_positive, ignored, fc/offering/falcon_complete
         """
@@ -912,7 +912,7 @@ Examples: 'severity.desc', 'timestamp.desc'
 • Severity (by range): severity:>=80 (Critical+) | severity:>=60 (High+) | severity:>=40 (Medium+) | severity:>=20 (Low+)
 • Product: product:'epp' | product:'idp' | product:'xdr' | product:'overwatch' (see field table for all)
 • Assignment: assigned_to_name:!'*' (unassigned) | assigned_to_name:'user.name'
-• Verdict/tags: tags:'true_positive' | tags:'false_positive' | tags:'ignored'
+• Resolution tags: tags:'true_positive' | tags:'false_positive' | tags:'ignored'
 • Timestamps: created_timestamp:>'2025-01-01T00:00:00Z' | created_timestamp:>='date1'+created_timestamp:<='date2'
   Relative dates supported: timestamp:>'now-24h' | timestamp:>'now-7d' | timestamp:>'now-30d' (lowercase 'now', quoted)
 • Wildcards: name:'EICAR*' | description:'*credential*' | agent_id:'77d11725*' | pattern_id:'301*'

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -193,6 +193,8 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
         "Mark detection abc123 as in_progress",
         "Assign detection abc123 to analyst@example.com",
         "Close these detections and add a comment: resolved via playbook",
+        "Mark detection abc123 as a true positive and close it",
+        "Remove all fc/ prefixed tags from this detection",
     ],
     # Discover
     "falcon_search_applications": [

--- a/tests/integration/test_detections.py
+++ b/tests/integration/test_detections.py
@@ -146,7 +146,9 @@ class TestDetectionsIntegration(BaseIntegrationTest):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         # Skip on 401/403 — the caller lacks Alerts:write
@@ -174,8 +176,9 @@ class TestDetectionsIntegration(BaseIntegrationTest):
                 f"got {updated[0].get('status')!r}"
             )
         finally:
-            # Restore original status
-            self.call_method(
+            # Restore original status. A hint-wrapped dict is an acceptable (non-error)
+            # outcome here if the original status was 'closed'.
+            restore_result = self.call_method(
                 self.module.update_detections,
                 ids=[detection_id],
                 status=original_status,
@@ -185,22 +188,26 @@ class TestDetectionsIntegration(BaseIntegrationTest):
                 unassign=None,
                 append_comment=None,
                 show_in_ui=None,
-                verdict=None,
+                add_tags=None,
+                remove_tags=None,
+                remove_tags_by_prefix=None,
             )
+            self.assert_no_error(restore_result, context="restore original_status")
 
-    def test_update_detections_verdict(self):
-        """Test setting a verdict tag (true_positive) via PatchEntitiesAlertsV3.
+    def test_update_detections_tags(self):
+        """Test adding and removing a resolution tag via PatchEntitiesAlertsV3.
 
-        Validates that add_tag action_parameter is accepted and the tag appears
-        in the read-back entity. Always cleans up the tag afterward.
+        Validates the add_tag and remove_tag action_parameters against a real
+        detection: adds true_positive and confirms it in the read-back, then
+        removes it via the tool's own remove_tags path and confirms it is gone.
 
         Skips gracefully if Alerts:write scope is not available.
         """
         search_result = self.call_method(self.module.search_detections, limit=1)
         if not search_result or isinstance(search_result, dict):
             self.skip_with_warning(
-                "No detections available to test update_detections verdict",
-                context="test_update_detections_verdict",
+                "No detections available to test update_detections tags",
+                context="test_update_detections_tags",
             )
             return
 
@@ -208,11 +215,11 @@ class TestDetectionsIntegration(BaseIntegrationTest):
         if not detection_id:
             self.skip_with_warning(
                 "Could not extract composite_id from search results",
-                context="test_update_detections_verdict",
+                context="test_update_detections_tags",
             )
             return
 
-        # Set verdict to true_positive
+        # Add the true_positive resolution tag
         result = self.call_method(
             self.module.update_detections,
             ids=[detection_id],
@@ -223,7 +230,9 @@ class TestDetectionsIntegration(BaseIntegrationTest):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict="true_positive",
+            add_tags=["true_positive"],
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         # Skip on 401/403 — the caller lacks Alerts:write
@@ -232,11 +241,11 @@ class TestDetectionsIntegration(BaseIntegrationTest):
             status_code = details.get("status_code", 0) if isinstance(details, dict) else 0
             if status_code in (401, 403):
                 self.skip_with_warning(
-                    f"Insufficient scope for update_detections verdict (Alerts:write required): {result}",
-                    context="test_update_detections_verdict",
+                    f"Insufficient scope for update_detections tags (Alerts:write required): {result}",
+                    context="test_update_detections_tags",
                 )
                 return
-            pytest.fail(f"update_detections verdict failed unexpectedly: {result}")
+            pytest.fail(f"update_detections add_tags failed unexpectedly: {result}")
 
         # Read back and confirm tag is present; cleanup always runs via try/finally
         updated = self.call_method(
@@ -244,21 +253,98 @@ class TestDetectionsIntegration(BaseIntegrationTest):
             ids=[detection_id],
         )
         try:
-            self.assert_no_error(updated, context="read-back after update_detections verdict")
-            assert updated, f"get_detection_details returned empty after successful verdict update for {detection_id}"
+            self.assert_no_error(updated, context="read-back after update_detections add_tags")
+            assert updated, f"get_detection_details returned empty after successful add_tags for {detection_id}"
             tags = updated[0].get("tags") or []
             assert "true_positive" in tags, (
-                f"Expected 'true_positive' in tags after setting verdict, got: {tags}"
+                f"Expected 'true_positive' in tags after add_tags, got: {tags}"
             )
         finally:
-            # Clean up — remove the tag via direct API call (remove_tag is not exposed on the tool)
-            self.module.client.command(
-                "PatchEntitiesAlertsV3",
-                body={
-                    "composite_ids": [detection_id],
-                    "action_parameters": [{"name": "remove_tag", "value": "true_positive"}],
-                },
+            # Remove the tag via the tool's own remove_tags path (now live-validated)
+            remove_result = self.call_method(
+                self.module.update_detections,
+                ids=[detection_id],
+                status=None,
+                assign_to_uuid=None,
+                assign_to_user_id=None,
+                assign_to_name=None,
+                unassign=None,
+                append_comment=None,
+                show_in_ui=None,
+                add_tags=None,
+                remove_tags=["true_positive"],
+                remove_tags_by_prefix=None,
             )
+            self.assert_no_error(remove_result, context="update_detections remove_tags")
+
+        # Confirm the tag is gone after removal
+        after_remove = self.call_method(
+            self.module.get_detection_details,
+            ids=[detection_id],
+        )
+        self.assert_no_error(after_remove, context="read-back after update_detections remove_tags")
+        assert after_remove, f"get_detection_details returned empty after remove_tags for {detection_id}"
+        remaining_tags = after_remove[0].get("tags") or []
+        assert "true_positive" not in remaining_tags, (
+            f"Expected 'true_positive' to be removed, but still present: {remaining_tags}"
+        )
+
+        # Round-trip remove_tags_by_prefix: add a prefixed tag, then remove by prefix
+        prefix_tag = "fc_mcp_probe/scratch"
+        prefix = "fc_mcp_probe/"
+        add_prefixed = self.call_method(
+            self.module.update_detections,
+            ids=[detection_id],
+            status=None,
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=[prefix_tag],
+            remove_tags=None,
+            remove_tags_by_prefix=None,
+        )
+        self.assert_no_error(add_prefixed, context="update_detections add prefixed tag")
+        try:
+            with_prefix = self.call_method(
+                self.module.get_detection_details,
+                ids=[detection_id],
+            )
+            self.assert_no_error(with_prefix, context="read-back after adding prefixed tag")
+            assert with_prefix, f"get_detection_details returned empty after adding prefixed tag for {detection_id}"
+            assert prefix_tag in (with_prefix[0].get("tags") or []), (
+                f"Expected {prefix_tag!r} in tags, got: {with_prefix[0].get('tags')}"
+            )
+        finally:
+            remove_by_prefix = self.call_method(
+                self.module.update_detections,
+                ids=[detection_id],
+                status=None,
+                assign_to_uuid=None,
+                assign_to_user_id=None,
+                assign_to_name=None,
+                unassign=None,
+                append_comment=None,
+                show_in_ui=None,
+                add_tags=None,
+                remove_tags=None,
+                remove_tags_by_prefix=prefix,
+            )
+            self.assert_no_error(remove_by_prefix, context="update_detections remove_tags_by_prefix")
+
+        # Confirm the prefixed tag is gone after prefix removal
+        after_prefix_remove = self.call_method(
+            self.module.get_detection_details,
+            ids=[detection_id],
+        )
+        self.assert_no_error(after_prefix_remove, context="read-back after remove_tags_by_prefix")
+        assert after_prefix_remove, f"get_detection_details returned empty after remove_tags_by_prefix for {detection_id}"
+        assert prefix_tag not in (after_prefix_remove[0].get("tags") or []), (
+            f"Expected {prefix_tag!r} to be removed by prefix, but still present: "
+            f"{after_prefix_remove[0].get('tags')}"
+        )
 
     def test_update_detections_show_in_ui(self):
         """Test toggling show_in_ui validates that string encoding reaches the API correctly.
@@ -298,7 +384,9 @@ class TestDetectionsIntegration(BaseIntegrationTest):
             unassign=None,
             append_comment=None,
             show_in_ui=new_show_in_ui,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         # Skip on 401/403 — the caller lacks Alerts:write
@@ -336,5 +424,7 @@ class TestDetectionsIntegration(BaseIntegrationTest):
                 unassign=None,
                 append_comment=None,
                 show_in_ui=original_show_in_ui,
-                verdict=None,
+                add_tags=None,
+                remove_tags=None,
+                remove_tags_by_prefix=None,
             )

--- a/tests/modules/test_detections.py
+++ b/tests/modules/test_detections.py
@@ -133,6 +133,37 @@ class TestDetectionsModule(TestModules):
         self.assertIn("fql_guide", result)
         self.assertIn("hint", result)
 
+    def test_search_detections_details_error(self):
+        """Test that a details-step error (query ok, details 400) returns the wrapped error."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["detection1"]},
+        }
+        details_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "server error"}]},
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_detections(filter="status:'new'")
+
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], dict)
+        self.assertIn("error", result[0])
+
+    def test_search_detections_empty_results(self):
+        """Test that an empty query result returns a clean empty response (no FQL guide)."""
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"resources": []}},
+        ]
+
+        result = self.module.search_detections(filter="status:'new'")
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+        self.assertEqual(result["total"], 0)
+        self.assertNotIn("fql_guide", result)
+
     def test_get_detection_details(self):
         """Test getting detection details."""
         # Setup mock response
@@ -275,7 +306,7 @@ class TestDetectionsModule(TestModules):
             ids=["id1"], status="in_progress",
             assign_to_uuid=None, assign_to_user_id=None,
             assign_to_name=None, unassign=None, append_comment=None, show_in_ui=None,
-            verdict=None,
+            add_tags=None, remove_tags=None, remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_called_once_with(
@@ -301,7 +332,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]
@@ -324,7 +357,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]
@@ -344,7 +379,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -370,7 +407,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=False,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]
@@ -393,7 +432,9 @@ class TestDetectionsModule(TestModules):
             unassign=True,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]
@@ -413,7 +454,9 @@ class TestDetectionsModule(TestModules):
             unassign=False,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -436,7 +479,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_called_once()
@@ -454,7 +499,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -472,7 +519,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -490,7 +539,9 @@ class TestDetectionsModule(TestModules):
             unassign=True,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -508,7 +559,9 @@ class TestDetectionsModule(TestModules):
             unassign=True,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -526,7 +579,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -545,7 +600,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -566,7 +623,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=True,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]
@@ -589,7 +648,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]
@@ -612,7 +673,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment="Investigating now",
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]
@@ -621,8 +684,8 @@ class TestDetectionsModule(TestModules):
             call_body["action_parameters"],
         )
 
-    def test_update_detections_verdict_false_positive(self):
-        """Test setting verdict to false_positive emits add_tag action_parameter."""
+    def test_update_detections_add_tags_resolution(self):
+        """Test add_tags with a resolution tag emits an add_tag action_parameter."""
         mock_response = {"status_code": 200, "body": {"resources": []}}
         self.mock_client.command.return_value = mock_response
 
@@ -635,17 +698,19 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict="false_positive",
+            add_tags=["true_positive"],
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]
         self.assertIn(
-            {"name": "add_tag", "value": "false_positive"},
+            {"name": "add_tag", "value": "true_positive"},
             call_body["action_parameters"],
         )
 
-    def test_update_detections_verdict_ignored(self):
-        """Test setting verdict to ignored emits add_tag action_parameter."""
+    def test_update_detections_add_tags_arbitrary(self):
+        """Test that arbitrary (non-resolution) tags are accepted and emitted."""
         mock_response = {"status_code": 200, "body": {"resources": []}}
         self.mock_client.command.return_value = mock_response
 
@@ -658,14 +723,131 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict="ignored",
+            add_tags=["custom_tag", "testing"],
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]
         self.assertIn(
-            {"name": "add_tag", "value": "ignored"},
+            {"name": "add_tag", "value": "custom_tag"},
             call_body["action_parameters"],
         )
+        self.assertIn(
+            {"name": "add_tag", "value": "testing"},
+            call_body["action_parameters"],
+        )
+
+    def test_update_detections_remove_tags(self):
+        """Test remove_tags emits a remove_tag action_parameter per tag."""
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = mock_response
+
+        self.module.update_detections(
+            ids=["id1"],
+            status=None,
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=None,
+            remove_tags=["false_positive"],
+            remove_tags_by_prefix=None,
+        )
+
+        call_body = self.mock_client.command.call_args[1]["body"]
+        self.assertIn(
+            {"name": "remove_tag", "value": "false_positive"},
+            call_body["action_parameters"],
+        )
+
+    def test_update_detections_remove_tags_by_prefix(self):
+        """Test remove_tags_by_prefix emits the remove_tags_by_prefix action_parameter."""
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = mock_response
+
+        self.module.update_detections(
+            ids=["id1"],
+            status=None,
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix="fc/",
+        )
+
+        call_body = self.mock_client.command.call_args[1]["body"]
+        self.assertIn(
+            {"name": "remove_tags_by_prefix", "value": "fc/"},
+            call_body["action_parameters"],
+        )
+
+    def test_update_detections_empty_tag_returns_error(self):
+        """Test that an empty/whitespace tag returns an error without calling API."""
+        result = self.module.update_detections(
+            ids=["id1"],
+            status=None,
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=["   "],
+            remove_tags=None,
+            remove_tags_by_prefix=None,
+        )
+
+        self.mock_client.command.assert_not_called()
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    def test_update_detections_empty_remove_tag_returns_error(self):
+        """Test that an empty/whitespace value in remove_tags returns an error without calling API."""
+        result = self.module.update_detections(
+            ids=["id1"],
+            status=None,
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=None,
+            remove_tags=["   "],
+            remove_tags_by_prefix=None,
+        )
+
+        self.mock_client.command.assert_not_called()
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    def test_update_detections_empty_prefix_returns_error(self):
+        """Test that an empty/whitespace remove_tags_by_prefix returns an error without calling API."""
+        for prefix in ("", "   "):
+            result = self.module.update_detections(
+                ids=["id1"],
+                status=None,
+                assign_to_uuid=None,
+                assign_to_user_id=None,
+                assign_to_name=None,
+                unassign=None,
+                append_comment=None,
+                show_in_ui=None,
+                add_tags=None,
+                remove_tags=None,
+                remove_tags_by_prefix=prefix,
+            )
+
+            self.mock_client.command.assert_not_called()
+            self.assertIsInstance(result, dict)
+            self.assertIn("error", result)
 
     def test_update_detections_two_assign_params_returns_error(self):
         """Test that providing multiple assign_to_* params returns an error without calling API."""
@@ -678,7 +860,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -697,7 +881,9 @@ class TestDetectionsModule(TestModules):
             unassign=True,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -716,7 +902,9 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment="",
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
@@ -735,57 +923,17 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment="   ",
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         self.mock_client.command.assert_not_called()
         self.assertIsInstance(result, dict)
         self.assertIn("error", result)
 
-    def test_update_detections_verdict_true_positive(self):
-        """Test setting verdict to true_positive emits add_tag action_parameter."""
-        mock_response = {"status_code": 200, "body": {"resources": []}}
-        self.mock_client.command.return_value = mock_response
-
-        self.module.update_detections(
-            ids=["id1"],
-            status=None,
-            assign_to_uuid=None,
-            assign_to_user_id=None,
-            assign_to_name=None,
-            unassign=None,
-            append_comment=None,
-            show_in_ui=None,
-            verdict="true_positive",
-        )
-
-        call_body = self.mock_client.command.call_args[1]["body"]
-        self.assertIn(
-            {"name": "add_tag", "value": "true_positive"},
-            call_body["action_parameters"],
-        )
-
-    def test_update_detections_verdict_invalid_returns_error(self):
-        """Test that an invalid verdict value returns an error without calling API."""
-        result = self.module.update_detections(
-            ids=["id1"],
-            status=None,
-            assign_to_uuid=None,
-            assign_to_user_id=None,
-            assign_to_name=None,
-            unassign=None,
-            append_comment=None,
-            show_in_ui=None,
-            verdict="definitely_not_a_verdict",
-        )
-
-        self.mock_client.command.assert_not_called()
-        self.assertIsInstance(result, dict)
-        self.assertIn("error", result)
-        self.assertIn("verdict", result["error"])
-
-    def test_update_detections_verdict_combined_with_status(self):
-        """Test combining verdict with status update in one call."""
+    def test_update_detections_add_tags_combined_with_status(self):
+        """Test combining add_tags with a status update in one call."""
         mock_response = {"status_code": 200, "body": {"resources": []}}
         self.mock_client.command.return_value = mock_response
 
@@ -798,13 +946,138 @@ class TestDetectionsModule(TestModules):
             unassign=None,
             append_comment=None,
             show_in_ui=None,
-            verdict="true_positive",
+            add_tags=["true_positive"],
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]
         param_names = [p["name"] for p in call_body["action_parameters"]]
         self.assertIn("update_status", param_names)
         self.assertIn("add_tag", param_names)
+
+    def test_update_detections_close_without_resolution_tag_returns_hint(self):
+        """Test that closing without a resolution tag wraps success with a hint.
+
+        Covers both add_tags=None and add_tags=[] (explicit empty list) — both must
+        trigger the hint since neither carries a resolution tag.
+        """
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+
+        for add_tags in (None, []):
+            self.mock_client.command.reset_mock()
+            self.mock_client.command.return_value = mock_response
+
+            result = self.module.update_detections(
+                ids=["id1"],
+                status="closed",
+                assign_to_uuid=None,
+                assign_to_user_id=None,
+                assign_to_name=None,
+                unassign=None,
+                append_comment=None,
+                show_in_ui=None,
+                add_tags=add_tags,
+                remove_tags=None,
+                remove_tags_by_prefix=None,
+            )
+
+            self.mock_client.command.assert_called_once()
+            self.assertIsInstance(result, dict)
+            self.assertIn("hint", result)
+            self.assertIn("resolution", result["hint"].lower())
+            self.assertEqual(result["result"], [])
+
+    def test_update_detections_close_with_resolution_tag_no_hint(self):
+        """Test that closing with any resolution tag returns the plain success shape."""
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+
+        for tag in ("true_positive", "false_positive", "ignored"):
+            self.mock_client.command.return_value = mock_response
+            result = self.module.update_detections(
+                ids=["id1"],
+                status="closed",
+                assign_to_uuid=None,
+                assign_to_user_id=None,
+                assign_to_name=None,
+                unassign=None,
+                append_comment=None,
+                show_in_ui=None,
+                add_tags=[tag],
+                remove_tags=None,
+                remove_tags_by_prefix=None,
+            )
+
+            self.assertEqual(result, [], msg=f"hint must not fire for resolution tag {tag!r}")
+
+    def test_update_detections_close_with_mixed_tags_no_hint(self):
+        """Test that a resolution tag mixed with a custom tag still suppresses the hint."""
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = mock_response
+
+        result = self.module.update_detections(
+            ids=["id1"],
+            status="closed",
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=["true_positive", "my_custom_tag"],
+            remove_tags=None,
+            remove_tags_by_prefix=None,
+        )
+
+        self.assertEqual(result, [])
+
+    def test_update_detections_close_with_non_resolution_tag_returns_hint(self):
+        """Test that closing with only a non-resolution tag still emits the hint."""
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = mock_response
+
+        result = self.module.update_detections(
+            ids=["id1"],
+            status="closed",
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=["MY_CUSTOM_TAG"],
+            remove_tags=None,
+            remove_tags_by_prefix=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("hint", result)
+        self.assertEqual(result["result"], [])
+
+    def test_update_detections_close_api_error_no_hint(self):
+        """Test that an API error while closing is returned as-is, not hint-wrapped."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Bad request"}]},
+        }
+
+        result = self.module.update_detections(
+            ids=["id1"],
+            status="closed",
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+        self.assertNotIn("hint", result)
 
     def test_update_detections_unassign_false_is_noop(self):
         """Test that unassign=False does not add the action parameter."""
@@ -820,7 +1093,9 @@ class TestDetectionsModule(TestModules):
             unassign=False,
             append_comment=None,
             show_in_ui=None,
-            verdict=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
         )
 
         call_body = self.mock_client.command.call_args[1]["body"]


### PR DESCRIPTION
This reworks `falcon_update_detections` so its tagging matches how the Falcon console actually treats resolutions. The old tool exposed a `verdict` param with a hard-coded allow-set of `true_positive`/`false_positive`/`ignored`, but there is no verdict or disposition field on the API — those three values are ordinary free-form tags, and the console's Resolution column just renders whichever of them happens to be present. A detection can carry `true_positive` alongside any custom tag with no special status. The old enum couldn't apply any other tag the same UI dropdown offers, and it had no way to remove a tag at all.

So `verdict` is gone, replaced by general tag management: `add_tags`, `remove_tags`, and `remove_tags_by_prefix`. Any string is accepted; the three resolution tags are described as the conventional values the console surfaces, offered as guidance rather than enforced. There's a soft nudge toward the console's close→resolution convention: closing a detection without adding a resolution tag in the same call returns a non-fatal hint instead of silently leaving it out of the Resolution view. It never blocks, and the plain success shape is preserved when the hint doesn't apply.

Status, assignment, comment, and `show_in_ui` handling are untouched. Everything is live-validated against the API — the integration test does a real add → remove → remove-by-prefix round-trip, and `remove_tag`/`remove_tags_by_prefix` both return 200 and read back as expected.