### PR TITLE
revert(deps): remove constraint-dependencies block, add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "deps(python):"
     labels:
@@ -25,6 +27,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "deps(actions):"
     labels:
@@ -40,6 +44,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "deps(docker):"
     labels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,25 +43,6 @@ dev = [
 [project.scripts]
 falcon-mcp = "falcon_mcp.server:main"
 
-# Security floors for transitive dev dependencies flagged by internal product-security
-# CVE scanning. Each entry pairs a fix-version floor with a ceiling that holds the package
-# inside its current major/minor line, so `uv lock` clears the advisories without major bumps.
-[tool.uv]
-constraint-dependencies = [
-    "langchain>=0.3.30,<0.4",
-    "langchain-core>=0.3.86,<0.4",
-    "langchain-text-splitters>=0.3.9,<0.4",
-    "langsmith>=0.8.0",
-    "aiohttp>=3.14.1,<4",
-    "cryptography>=46.0.7,<47",
-    "pillow>=12.2.0,<13",
-    "urllib3>=2.7.0,<3",
-    "orjson>=3.11.6,<4",
-    "protobuf>=6.33.5,<7",
-    "python-multipart>=0.0.30,<0.1",
-    "click>=8.3.3,<9",
-]
-
 [tool.black]
 line-length = 100
 target-version = ["py311"]

--- a/uv.lock
+++ b/uv.lock
@@ -12,22 +12,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-[manifest]
-constraints = [
-    { name = "aiohttp", specifier = ">=3.14.1,<4" },
-    { name = "click", specifier = ">=8.3.3,<9" },
-    { name = "cryptography", specifier = ">=46.0.7,<47" },
-    { name = "langchain", specifier = ">=0.3.30,<0.4" },
-    { name = "langchain-core", specifier = ">=0.3.86,<0.4" },
-    { name = "langchain-text-splitters", specifier = ">=0.3.9,<0.4" },
-    { name = "langsmith", specifier = ">=0.8.0" },
-    { name = "orjson", specifier = ">=3.11.6,<4" },
-    { name = "pillow", specifier = ">=12.2.0,<13" },
-    { name = "protobuf", specifier = ">=6.33.5,<7" },
-    { name = "python-multipart", specifier = ">=0.0.30,<0.1" },
-    { name = "urllib3", specifier = ">=2.7.0,<3" },
-]
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
The `[tool.uv] constraint-dependencies` block added in #447 introduced transitive dependency version bumps that should go through the normal review process. This removes that block entirely — the `starlette>=1.3.1` floor in dev dependencies is kept since it was a legitimate dependabot bump.

To prevent similar unintended bumps going forward, adds a 7-day `cooldown` to all three dependabot ecosystems (uv, github-actions, docker) so new releases sit for a week before a bump PR is opened. `uv.lock` will need to be regenerated after this merges.