### PR TITLE
fix(deps): bump cryptography minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ constraint-dependencies = [
     "pyjwt>=2.12.0",
     "idna>=3.15",
     "requests>=2.33.0",
+    "cryptography>=48.0.1",
 ]
 
 [tool.black]


### PR DESCRIPTION
Bumps the cryptography floor to `>=48.0.1` to pull in updated OpenSSL in the bundled wheels.