### PR TITLE
fix(modules/spotlight): allow facet to accept a list of values

### DIFF
--- a/falcon_mcp/modules/spotlight.py
+++ b/falcon_mcp/modules/spotlight.py
@@ -57,7 +57,7 @@ class SpotlightModule(BaseModule):
         filter: str | None = Field(
             default=None,
             description="FQL filter expression. See `falcon://spotlight/vulnerabilities/fql-guide` for syntax.",
-            examples={"status:'open'", "cve.severity:'HIGH'"},
+            examples=["status:'open'", "cve.severity:'HIGH'"],
         ),
         limit: int = Field(
             default=10,
@@ -84,22 +84,24 @@ class SpotlightModule(BaseModule):
 
                 Examples: 'created_timestamp|desc', 'updated_timestamp|desc', 'closed_timestamp|asc'
             """).strip(),
-            examples={
+            examples=[
                 "created_timestamp|desc",
                 "updated_timestamp|desc",
                 "closed_timestamp|asc",
-            },
+            ],
         ),
         after: str | None = Field(
             default=None,
             description="A pagination token used with the limit parameter to manage pagination of results. On your first request, don't provide an after token. On subsequent requests, provide the after token from the previous response to continue from that place in the results.",
         ),
-        facet: str | None = Field(
+        facet: str | list[str] | None = Field(
             default=None,
             description=dedent("""
-                Important: Use only one value!
+                Select one or more detail blocks to be returned for each vulnerability.
 
-                Select various detail blocks to be returned for each vulnerability.
+                Accepts a single value (e.g. 'cve') or a list of values
+                (e.g. ['cve', 'host_info', 'remediation']) to retrieve multiple
+                detail blocks in a single request.
 
                 Supported values:
                 • host_info: Include host/asset information and context
@@ -110,9 +112,9 @@ class SpotlightModule(BaseModule):
                 Use host_info when you need asset context, remediation for fix information,
                 cve for detailed vulnerability scoring, and evaluation_logic for assessment details.
 
-                Examples: 'host_info', 'cve', 'remediation'
+                Examples: 'cve', ['cve', 'host_info'], ['cve', 'host_info', 'remediation', 'evaluation_logic']
             """).strip(),
-            examples={"host_info", "cve", "remediation", "evaluation_logic"},
+            examples=["cve", ["cve", "host_info"], ["cve", "host_info", "remediation", "evaluation_logic"]],
         ),
     ) -> list[dict[str, Any]]:
         """Search for vulnerabilities in your CrowdStrike environment.

--- a/tests/integration/test_spotlight.py
+++ b/tests/integration/test_spotlight.py
@@ -78,6 +78,36 @@ class TestSpotlightIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_vulnerabilities with facet")
         self.assert_valid_list_response(result, min_length=0, context="search_vulnerabilities with facet")
 
+        if len(result) > 0:
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["cve"],
+                context="search_vulnerabilities with facet",
+            )
+
+    def test_search_vulnerabilities_with_multiple_facets(self):
+        """Test search_vulnerabilities with multiple facets in a single request."""
+        result = self.call_method(
+            self.module.search_vulnerabilities,
+            filter="status:'open'",
+            facet=["cve", "host_info"],
+            limit=3,
+        )
+
+        self.assert_no_error(result, context="search_vulnerabilities with multiple facets")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_vulnerabilities with multiple facets"
+        )
+
+        # Verify both requested facet blocks are actually present in a single
+        # response — this is the core contract of the multi-facet enhancement.
+        if len(result) > 0:
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["cve", "host_info"],
+                context="search_vulnerabilities with multiple facets",
+            )
+
     def test_operation_name_is_correct(self):
         """Validate that FalconPy operation name is correct.
 

--- a/tests/modules/test_spotlight.py
+++ b/tests/modules/test_spotlight.py
@@ -101,6 +101,69 @@ class TestSpotlightModule(TestModules):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["cve_id"], "CVE-2023-12345")
 
+    def test_search_vulnerabilities_with_single_facet(self):
+        """Test that a single facet string is forwarded unchanged to the API."""
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = mock_response
+
+        result = self.module.search_vulnerabilities(filter="status:'open'", facet="cve")
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "combinedQueryVulnerabilities")
+
+        params = call_args[1]["parameters"]
+        self.assertEqual(params["facet"], "cve")
+        self.assertEqual(result, [])
+
+    def test_search_vulnerabilities_with_multiple_facets(self):
+        """Test that a list of facets is forwarded intact (no joining/mangling)."""
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = mock_response
+
+        result = self.module.search_vulnerabilities(
+            filter="status:'open'",
+            facet=["cve", "host_info", "remediation"],
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "combinedQueryVulnerabilities")
+
+        params = call_args[1]["parameters"]
+        self.assertEqual(params["facet"], ["cve", "host_info", "remediation"])
+        self.assertEqual(result, [])
+
+    def test_search_vulnerabilities_facet_empty_list(self):
+        """Test that an empty facet list is forwarded as-is (no facets requested)."""
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = mock_response
+
+        self.module.search_vulnerabilities(filter="status:'open'", facet=[])
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        call_args = self.mock_client.command.call_args
+        params = call_args[1]["parameters"]
+        # An empty list is not None, so prepare_api_parameters does not strip it;
+        # it reaches the API unchanged and is treated as "no facets requested".
+        self.assertEqual(params["facet"], [])
+
+    def test_search_vulnerabilities_facet_none_stripped(self):
+        """Test that a None facet is stripped from the forwarded parameters.
+
+        When the tool runs through FastMCP the unset facet resolves to None;
+        prepare_api_parameters must drop it so it never reaches the API.
+        """
+        mock_response = {"status_code": 200, "body": {"resources": []}}
+        self.mock_client.command.return_value = mock_response
+
+        self.module.search_vulnerabilities(filter="status:'open'", facet=None)
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        call_args = self.mock_client.command.call_args
+        params = call_args[1]["parameters"]
+        self.assertNotIn("facet", params)
+
     def test_search_vulnerabilities_empty_response(self):
         """Test searching vulnerabilities with empty response."""
         # Setup mock response with empty resources


### PR DESCRIPTION
The `facet` parameter on `falcon_search_vulnerabilities` only accepted a single string, so anyone who wanted more than one detail block (cve, host_info, remediation, evaluation_logic) had to make a separate request for each one. The underlying `combinedQueryVulnerabilities` operation already supports multiple facets in a single call, so the restriction was ours, not the API's.

This widens the parameter to `str | list[str]` and forwards it as-is. A list flows straight through `prepare_api_parameters` (which only strips `None` values) and FalconPy serializes it as repeated query params, same as the existing `ids` list parameters elsewhere. Passing a single string still works exactly as before.

I also dropped the old "use only one value" note from the docstring and updated the examples to show the list form.

Verified against the live API: a request with `facet=['cve', 'host_info', 'remediation']` returns each result with all three blocks present. Added unit tests covering single-value, multi-value, empty-list, and unset forwarding, and extended the integration tests to assert the requested facet blocks actually come back.