### PR TITLE
docs(examples/adk): fix dead Agentspace doc link

### DIFF
--- a/examples/adk/README.md
+++ b/examples/adk/README.md
@@ -406,7 +406,7 @@ SUCCESS: cURL command completed successfully for AgentSpace registration.
 
 <br>
 
-> You can find more about [Agentspace registration](https://cloud.google.com/agentspace/agentspace-enterprise/docs/assistant#create-assistant-existing-app).
+> You can find more about [Agentspace registration](https://cloud.google.com/gemini-enterprise/docs/).
 
 Now you can access the agent in the Agentspace application you created earlier.
 


### PR DESCRIPTION
Replaces the broken `cloud.google.com/agentspace/agentspace-enterprise/docs/assistant#create-assistant-existing-app` link (verified 404) in `examples/adk/README.md` with the new docs home for the rebranded product at `cloud.google.com/gemini-enterprise/docs/` (verified 200). The legacy Agentspace docs path was retired when the product was renamed to Gemini Enterprise.