### PR TITLE
fix(modules): restore sort order in two-step search tools

### DIFF
--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -135,6 +135,48 @@ class BaseModule(ABC):
             default_result=[],
         )
 
+    def _reorder_by_ids(
+        self,
+        ordered_ids: list[str],
+        entities: list[dict[str, Any]],
+        id_field: str,
+    ) -> list[dict[str, Any]]:
+        """Reorder hydrated entities to match the sorted ID order from the query step.
+
+        Search tools query entity IDs first (honoring the requested sort) and then
+        hydrate full details by ID. Some "get entities by IDs" endpoints return
+        resources in arbitrary order, discarding the sort. This restores the order
+        of ``ordered_ids``. It is a no-op for endpoints that already preserve order.
+
+        Entities whose ID is not in ``ordered_ids`` are appended in their original
+        order (never dropped); IDs with no matching entity are skipped.
+
+        Args:
+            ordered_ids: Entity IDs from the query step, in the desired order.
+            entities: Hydrated entity dicts from the get-by-IDs step.
+            id_field: The key inside each entity dict that holds its ID.
+
+        Returns:
+            The entities reordered to match ordered_ids.
+        """
+        by_id = {str(entity.get(id_field, "")): entity for entity in entities}
+
+        result: list[dict[str, Any]] = []
+        placed: set[str] = set()
+        for entity_id in ordered_ids:
+            key = str(entity_id)
+            if key in by_id and key not in placed:
+                result.append(by_id[key])
+                placed.add(key)
+
+        # Preserve entities not referenced by ordered_ids rather than dropping them
+        result.extend(
+            entity for entity in entities
+            if str(entity.get(id_field, "")) not in placed
+        )
+
+        return result
+
     def _base_search_api_call(
         self,
         operation: str,

--- a/falcon_mcp/modules/cases.py
+++ b/falcon_mcp/modules/cases.py
@@ -166,7 +166,9 @@ class CasesModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # entities_cases_post_v2 returns cases in arbitrary order; restore the sort
+        # applied by the query step (validated against live API: field is id).
+        return self._reorder_by_ids(case_ids, details, id_field="id")
 
     def get_cases(
         self,
@@ -504,4 +506,5 @@ class CasesModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Preserve the query-step order in case the details endpoint reorders results.
+        return self._reorder_by_ids(template_ids, details, id_field="id")

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -429,6 +429,10 @@ class CloudModule(BaseModule):
         if self._is_error(details):
             return [details]
 
+        # Restore the query-step sort order before slimming, in case the entities
+        # endpoint reorders results.
+        details = self._reorder_by_ids(asset_ids, details, id_field="id")
+
         return [self._slim_cspm_asset(asset) for asset in details]
 
     def _batch_get_cspm_assets(self, asset_ids: list[str]) -> list[dict[str, Any]] | dict[str, Any]:
@@ -629,7 +633,13 @@ class CloudModule(BaseModule):
             return self._format_empty_response(filter)
 
         # Step 2: Fetch full IOM entity details (GET with query params, max 100 per call)
-        return self._batch_get_iom_entities(iom_ids)
+        details = self._batch_get_iom_entities(iom_ids)
+
+        if self._is_error(details):
+            return [details]
+
+        # Restore the query-step sort order in case the entities endpoint reorders results.
+        return self._reorder_by_ids(iom_ids, details, id_field="id")
 
     def search_cloud_risks(
         self,
@@ -823,12 +833,18 @@ class CloudModule(BaseModule):
             parameters=detail_params,
         )
 
-        return handle_api_response(
+        details = handle_api_response(
             detail_response,
             operation="GetSuppressionRules",
             error_message="Failed to get suppression rule details",
             default_result=[],
         )
+
+        if self._is_error(details):
+            return [details]
+
+        # Preserve the query-step order in case the details endpoint reorders results.
+        return self._reorder_by_ids(query_result, details, id_field="id")
 
     def create_cspm_suppression_rule(
         self,

--- a/falcon_mcp/modules/custom_ioa.py
+++ b/falcon_mcp/modules/custom_ioa.py
@@ -220,7 +220,8 @@ class CustomIOAModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Preserve the query-step order in case the details endpoint reorders results.
+        return self._reorder_by_ids(platform_ids, details, id_field="id")
 
     def get_ioa_rule_types(
         self,
@@ -265,7 +266,8 @@ class CustomIOAModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Preserve the query-step order in case the details endpoint reorders results.
+        return self._reorder_by_ids(rule_type_ids, details, id_field="id")
 
     def create_ioa_rule_group(
         self,

--- a/falcon_mcp/modules/data_protection.py
+++ b/falcon_mcp/modules/data_protection.py
@@ -127,9 +127,15 @@ class DataProtectionModule(BaseModule):
         if not ids:
             return self._format_empty_response(filter)
 
-        return self._base_get_by_ids(
+        details = self._base_get_by_ids(
             "entities_classification_get_v2", ids, use_params=True
         )
+
+        if self._is_error(details):
+            return [details]
+
+        # Restore the query-step sort order if the get endpoint reorders results.
+        return self._reorder_by_ids(ids, details, id_field="id")
 
     def search_data_protection_policies(
         self,
@@ -185,7 +191,13 @@ class DataProtectionModule(BaseModule):
         if not ids:
             return self._format_empty_response(filter)
 
-        return self._base_get_by_ids("entities_policy_get_v2", ids, use_params=True)
+        details = self._base_get_by_ids("entities_policy_get_v2", ids, use_params=True)
+
+        if self._is_error(details):
+            return [details]
+
+        # Restore the query-step sort order if the get endpoint reorders results.
+        return self._reorder_by_ids(ids, details, id_field="id")
 
     def search_data_protection_content_patterns(
         self,
@@ -236,4 +248,10 @@ class DataProtectionModule(BaseModule):
         if not ids:
             return self._format_empty_response(filter)
 
-        return self._base_get_by_ids("entities_content_pattern_get", ids, use_params=True)
+        details = self._base_get_by_ids("entities_content_pattern_get", ids, use_params=True)
+
+        if self._is_error(details):
+            return [details]
+
+        # Restore the query-step sort order if the get endpoint reorders results.
+        return self._reorder_by_ids(ids, details, id_field="id")

--- a/falcon_mcp/modules/detections.py
+++ b/falcon_mcp/modules/detections.py
@@ -159,7 +159,9 @@ class DetectionsModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # PostEntitiesAlertsV2 returns entities in arbitrary order; restore the sort
+        # applied by the query step (validated against live API: field is composite_id).
+        return self._reorder_by_ids(detection_ids, details, id_field="composite_id")
 
     def get_detection_details(
         self,

--- a/falcon_mcp/modules/exclusions.py
+++ b/falcon_mcp/modules/exclusions.py
@@ -291,7 +291,8 @@ class ExclusionsModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Restore the query-step sort order in case the get endpoint reorders results.
+        return self._reorder_by_ids(ids, details, id_field="id")
 
     # ---- Body builders ------------------------------------------------------------
 

--- a/falcon_mcp/modules/firewall.py
+++ b/falcon_mcp/modules/firewall.py
@@ -156,7 +156,8 @@ class FirewallModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Restore the query-step sort order in case get_rules reorders results.
+        return self._reorder_by_ids(rule_ids, details, id_field="id")
 
     def search_firewall_rule_groups(
         self,
@@ -226,7 +227,8 @@ class FirewallModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Restore the query-step sort order in case get_rule_groups reorders results.
+        return self._reorder_by_ids(rule_group_ids, details, id_field="id")
 
     def search_firewall_policy_rules(
         self,
@@ -294,7 +296,8 @@ class FirewallModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Restore the query-step sort order in case get_rules reorders results.
+        return self._reorder_by_ids(policy_rule_ids, details, id_field="id")
 
     def create_firewall_rule_group(
         self,

--- a/falcon_mcp/modules/hosts.py
+++ b/falcon_mcp/modules/hosts.py
@@ -133,7 +133,9 @@ class HostsModule(BaseModule):
             if self._is_error(details):
                 return [details]
 
-            return details
+            # Restore the query-step sort order in case the details endpoint
+            # returns entities in a different order (validated field: device_id).
+            return self._reorder_by_ids(device_ids, details, id_field="device_id")
 
         return []
 

--- a/falcon_mcp/modules/ioc.py
+++ b/falcon_mcp/modules/ioc.py
@@ -154,7 +154,8 @@ class IOCModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Restore the query-step sort order if the details endpoint reorders results.
+        return self._reorder_by_ids(indicator_ids, details, id_field="id")
 
     def add_ioc(
         self,

--- a/falcon_mcp/modules/policies.py
+++ b/falcon_mcp/modules/policies.py
@@ -461,7 +461,8 @@ class PoliciesModule(BaseModule):
             if self._is_error(details):
                 return [details]
 
-            return details
+            # Restore the query-step sort order in case the get endpoint reorders results.
+            return self._reorder_by_ids(ids, details, id_field="id")
 
         # Combined single-call path for the other five types.
         policies = self._base_search_api_call(

--- a/falcon_mcp/modules/quarantine.py
+++ b/falcon_mcp/modules/quarantine.py
@@ -139,7 +139,8 @@ class QuarantineModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Restore the query-step sort order if the details endpoint reorders results.
+        return self._reorder_by_ids(file_ids, details, id_field="id")
 
     def preview_quarantine_actions(
         self,

--- a/falcon_mcp/modules/recon.py
+++ b/falcon_mcp/modules/recon.py
@@ -168,7 +168,8 @@ class ReconModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Restore the query-step sort order; GetNotificationsDetailedV1 may reorder.
+        return self._reorder_by_ids(notification_ids, details, id_field="id")
 
     def search_recon_rules(
         self,
@@ -253,7 +254,8 @@ class ReconModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Restore the query-step sort order in case GetRulesV1 reorders results.
+        return self._reorder_by_ids(rule_ids, details, id_field="id")
 
     def search_recon_exposed_data_records(
         self,
@@ -285,7 +287,7 @@ class ReconModule(BaseModule):
             description=dedent("""
                 Sort records using these options:
                 created_date: When the record was created
-                updated_date: When the record was last updated
+                exposure_date: When the data was exposed/breached
 
                 Append |asc or |desc for direction (default desc).
                 Examples: 'created_date|desc', 'exposure_date|desc'
@@ -336,4 +338,5 @@ class ReconModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Restore the query-step sort order; the exposed-data details endpoint may reorder.
+        return self._reorder_by_ids(record_ids, details, id_field="id")

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -250,7 +250,8 @@ class RTRModule(BaseModule):
         if self._is_error(details):
             return [details]
 
-        return details
+        # Restore the query-step sort order in case RTR_ListSessions reorders results.
+        return self._reorder_by_ids(session_ids, details, id_field="id")
 
     def search_audit_sessions(
         self,

--- a/falcon_mcp/modules/scheduled_reports.py
+++ b/falcon_mcp/modules/scheduled_reports.py
@@ -149,7 +149,8 @@ class ScheduledReportsModule(BaseModule):
             if self._is_error(details):
                 return [details]
 
-            return details
+            # Restore the query-step sort order if the get endpoint reorders results.
+            return self._reorder_by_ids(report_ids, details, id_field="id")
 
         return []
 
@@ -229,7 +230,8 @@ class ScheduledReportsModule(BaseModule):
             if self._is_error(details):
                 return [details]
 
-            return details
+            # Restore the query-step sort order if the get endpoint reorders results.
+            return self._reorder_by_ids(execution_ids, details, id_field="id")
 
         return []
 

--- a/tests/modules/test_base.py
+++ b/tests/modules/test_base.py
@@ -716,5 +716,77 @@ class TestBaseModule(TestModules):
         self.assertFalse(call_kwargs["structured_output"])
 
 
+class TestBaseModuleReorderByIds(TestModules):
+    """Test cases for BaseModule._reorder_by_ids."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(ConcreteBaseModule)
+
+    def test_reorder_restores_sorted_order(self):
+        """Entities are reordered to match the query-step ID order."""
+        ordered_ids = ["c", "a", "b"]
+        entities = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        result = self.module._reorder_by_ids(ordered_ids, entities, "id")
+        self.assertEqual([e["id"] for e in result], ["c", "a", "b"])
+
+    def test_reorder_custom_id_field(self):
+        """The id_field argument selects which key to match on."""
+        ordered_ids = ["dev2", "dev1"]
+        entities = [{"device_id": "dev1"}, {"device_id": "dev2"}]
+        result = self.module._reorder_by_ids(ordered_ids, entities, "device_id")
+        self.assertEqual([e["device_id"] for e in result], ["dev2", "dev1"])
+
+    def test_reorder_extra_entity_appended_at_end(self):
+        """Entities not present in ordered_ids are appended, never dropped."""
+        ordered_ids = ["a", "b"]
+        entities = [{"id": "b"}, {"id": "a"}, {"id": "extra"}]
+        result = self.module._reorder_by_ids(ordered_ids, entities, "id")
+        self.assertEqual([e["id"] for e in result], ["a", "b", "extra"])
+
+    def test_reorder_missing_entity_skipped(self):
+        """IDs with no matching entity are skipped silently."""
+        ordered_ids = ["a", "missing", "b"]
+        entities = [{"id": "b"}, {"id": "a"}]
+        result = self.module._reorder_by_ids(ordered_ids, entities, "id")
+        self.assertEqual([e["id"] for e in result], ["a", "b"])
+
+    def test_reorder_empty_entities_returns_empty(self):
+        """An empty entity list returns an empty list."""
+        result = self.module._reorder_by_ids(["a", "b"], [], "id")
+        self.assertEqual(result, [])
+
+    def test_reorder_empty_ordered_ids_appends_all(self):
+        """With no ordered IDs, all entities are returned in original order."""
+        entities = [{"id": "a"}, {"id": "b"}]
+        result = self.module._reorder_by_ids([], entities, "id")
+        self.assertEqual([e["id"] for e in result], ["a", "b"])
+
+    def test_reorder_duplicate_id_in_ordered_ids_yields_no_extra_slot(self):
+        """A duplicate ID in ordered_ids yields one slot, not a repeated entity.
+
+        Query endpoints return primary-key IDs, so a repeat is degenerate; the
+        second occurrence is skipped like a missing-entity ID.
+        """
+        ordered_ids = ["a", "a", "b"]
+        entities = [{"id": "a"}, {"id": "b"}]
+        result = self.module._reorder_by_ids(ordered_ids, entities, "id")
+        self.assertEqual([e["id"] for e in result], ["a", "b"])
+
+    def test_reorder_extra_entity_appended_even_when_first_in_input(self):
+        """An unmatched entity is appended at the tail regardless of input position."""
+        ordered_ids = ["a", "b"]
+        entities = [{"id": "extra"}, {"id": "b"}, {"id": "a"}]
+        result = self.module._reorder_by_ids(ordered_ids, entities, "id")
+        self.assertEqual([e["id"] for e in result], ["a", "b", "extra"])
+
+    def test_reorder_already_ordered_is_noop(self):
+        """When entities already match ordered_ids, output is unchanged."""
+        ordered_ids = ["a", "b", "c"]
+        entities = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        result = self.module._reorder_by_ids(ordered_ids, entities, "id")
+        self.assertEqual([e["id"] for e in result], ["a", "b", "c"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/modules/test_cases.py
+++ b/tests/modules/test_cases.py
@@ -116,6 +116,34 @@ class TestCasesModule(TestModules):
         self.assertEqual(result[0]["id"], "case-id-1")
         self.assertEqual(result[1]["id"], "case-id-2")
 
+    def test_search_cases_reorders_to_match_sorted_ids(self):
+        """When entities_cases_post_v2 returns cases out of order, the result is
+        reordered to match the sorted ID order from queries_cases_get_v1.
+
+        Live API validated: the details endpoint scrambles order; entities carry
+        their ID in the ``id`` field.
+        """
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["case-b", "case-a"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "case-a", "name": "Case A"},
+                    {"id": "case-b", "name": "Case B"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_cases(sort="created_timestamp.desc")
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "case-b")
+        self.assertEqual(result[1]["id"], "case-a")
+
     def test_search_cases_empty_results(self):
         """Test that empty query results return clean empty response."""
         self.mock_client.command.return_value = {
@@ -535,6 +563,30 @@ class TestCasesModule(TestModules):
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["id"], "tmpl-id-1")
+
+    def test_list_templates_reorders_to_match_sorted_ids(self):
+        """When entities_templates_get_v1 returns templates out of order, the result
+        is reordered to match the query-step ID order."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["tmpl-id-2", "tmpl-id-1"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "tmpl-id-1", "name": "Incident Template"},
+                    {"id": "tmpl-id-2", "name": "Alert Template"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.list_case_templates(limit=50)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "tmpl-id-2")
+        self.assertEqual(result[1]["id"], "tmpl-id-1")
 
     def test_list_templates_empty(self):
         """Test that empty template query returns an empty list (no FQL guide)."""

--- a/tests/modules/test_cloud.py
+++ b/tests/modules/test_cloud.py
@@ -187,6 +187,32 @@ class TestCloudModule(TestModules):
         self.assertIn("cloud_provider", result[0])
         self.assertIn("resource_type", result[0])
 
+    def test_search_cspm_assets_reorders_to_match_sorted_ids(self):
+        """When cloud_security_assets_entities_get returns assets out of order,
+        the result is reordered to match the sorted ID order from the query step."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["asset-b", "asset-a"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "asset-a", "resource_type": "s3-bucket"},
+                    {"id": "asset-b", "resource_type": "ec2-instance"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_cspm_assets(
+            filter=None, limit=10
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "asset-b")
+        self.assertEqual(result[1]["id"], "asset-a")
+
     def test_search_cspm_assets_batching(self):
         """Test CSPM assets search handles >100 IDs with batching."""
         # Mock 250 IDs
@@ -208,7 +234,7 @@ class TestCloudModule(TestModules):
         ]
 
         batch1 = {"status_code": 200, "body": {"resources": batch1_assets}}
-        batch2 = {"status_code": 200, "body": {"resources": batch2_assets}}
+        batch2 = {"status_code": 200, "body": {"resources": list(reversed(batch2_assets))}}
         batch3 = {"status_code": 200, "body": {"resources": batch3_assets}}
 
         self.mock_client.command.side_effect = [
@@ -247,6 +273,10 @@ class TestCloudModule(TestModules):
 
         # Verify all 250 assets returned
         self.assertEqual(len(result), 250)
+
+        # Verify reorder restores query-step order across batches even though
+        # batch2 was returned reversed.
+        self.assertEqual([r["id"] for r in result], asset_ids)
 
     def test_search_cspm_assets_error_returns_fql_guide(self):
         """Test CSPM assets search returns FQL guide on error."""
@@ -520,6 +550,32 @@ class TestCloudModule(TestModules):
         self.assertEqual(len(result), 2)
         self.assertIn("severity", result[0])
 
+    def test_search_iom_findings_reorders_to_match_sorted_ids(self):
+        """When cspm_evaluations_iom_entities returns findings out of order,
+        the result is reordered to match the sorted ID order from the query step."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["iom-b", "iom-a"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "iom-a", "severity": "high", "status": "open"},
+                    {"id": "iom-b", "severity": "critical", "status": "open"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_iom_findings(
+            filter=None, limit=10
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "iom-b")
+        self.assertEqual(result[1]["id"], "iom-a")
+
     def test_search_iom_findings_error_returns_fql_guide(self):
         """Test IOM search returns FQL guide on error."""
         mock_response = {
@@ -554,7 +610,7 @@ class TestCloudModule(TestModules):
         query_response = {"status_code": 200, "body": {"resources": iom_ids}}
 
         batch1 = {"status_code": 200, "body": {"resources": [{"id": f"iom_{i}"} for i in range(100)]}}
-        batch2 = {"status_code": 200, "body": {"resources": [{"id": f"iom_{i}"} for i in range(100, 150)]}}
+        batch2 = {"status_code": 200, "body": {"resources": [{"id": f"iom_{i}"} for i in reversed(range(100, 150))]}}
 
         self.mock_client.command.side_effect = [query_response, batch1, batch2]
 
@@ -562,6 +618,23 @@ class TestCloudModule(TestModules):
 
         self.assertEqual(self.mock_client.command.call_count, 3)
         self.assertEqual(len(result), 150)
+        # Reorder restores query-step order across batches even though batch2 was reversed.
+        self.assertEqual([r["id"] for r in result], iom_ids)
+
+    def test_search_iom_findings_batch_error_fails_fast(self):
+        """Test IOM search wraps a step-2 (entities) error in a list."""
+        query_response = {"status_code": 200, "body": {"resources": ["iom_1", "iom_2"]}}
+        error_response = {
+            "status_code": 500,
+            "body": {"errors": [{"message": "Internal server error"}]},
+        }
+        self.mock_client.command.side_effect = [query_response, error_response]
+
+        result = self.module.search_iom_findings(limit=10)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn("error", result[0])
 
     def test_search_iom_findings_uses_params_true(self):
         """Test IOM entity fetch uses GET with query params."""
@@ -617,6 +690,30 @@ class TestCloudModule(TestModules):
         result = self.module.search_cspm_suppression_rules()
 
         self.assertEqual(result, [])
+
+    def test_search_suppression_rules_reorders_to_match_sorted_ids(self):
+        """When GetSuppressionRules returns rules out of order, the result is
+        reordered to match the query-step ID order."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["rule_2", "rule_1"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "rule_1", "suppression_reason": "accept-risk"},
+                    {"id": "rule_2", "suppression_reason": "false-positive"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_cspm_suppression_rules(limit=10)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "rule_2")
+        self.assertEqual(result[1]["id"], "rule_1")
 
     def test_create_suppression_rule_success(self):
         """Test creating a suppression rule."""

--- a/tests/modules/test_custom_ioa.py
+++ b/tests/modules/test_custom_ioa.py
@@ -174,6 +174,28 @@ class TestCustomIOAModule(TestModules):
         self.mock_client.command.assert_called_once()
         self.assertEqual(result, [])
 
+    def test_get_ioa_platforms_reorders_to_match_sorted_ids(self):
+        """When get_platformsMixin0 returns platforms out of order, the result is
+        reordered to match the query-step ID order."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["linux", "windows"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "windows", "name": "Windows"},
+                    {"id": "linux", "name": "Linux"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.get_ioa_platforms()
+
+        self.assertEqual([p["id"] for p in result], ["linux", "windows"])
+
     def test_get_ioa_platforms_query_error(self):
         """Test that query errors are surfaced correctly."""
         self.mock_client.command.return_value = {
@@ -214,6 +236,28 @@ class TestCustomIOAModule(TestModules):
         self.assertEqual(first_call[1]["parameters"]["limit"], 50)
         self.assertEqual(second_call[0][0], "get_rule_types")
         self.assertEqual(len(result), 2)
+
+    def test_get_ioa_rule_types_reorders_to_match_sorted_ids(self):
+        """When get_rule_types returns types out of order, the result is reordered
+        to match the query-step ID order."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["rt-002", "rt-001"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "rt-001", "name": "Process Creation"},
+                    {"id": "rt-002", "name": "Network Connection"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.get_ioa_rule_types(limit=50)
+
+        self.assertEqual([rt["id"] for rt in result], ["rt-002", "rt-001"])
 
     def test_get_ioa_rule_types_empty(self):
         """Test getting rule types when none exist returns empty list."""

--- a/tests/modules/test_data_protection.py
+++ b/tests/modules/test_data_protection.py
@@ -80,6 +80,32 @@ class TestDataProtectionModule(TestModules):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["name"], "Credit Card Detection")
 
+    def test_search_classifications_reorders_to_match_sorted_ids(self):
+        """When the get step returns classifications out of order, the result is
+        reordered to match the sorted ID order from the query step."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["cls-id-b", "cls-id-a"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "cls-id-a", "name": "Classification A"},
+                    {"id": "cls-id-b", "name": "Classification B"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_data_protection_classifications(
+            filter=None, limit=100, offset=0, sort="created_at.desc"
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "cls-id-b")
+        self.assertEqual(result[1]["id"], "cls-id-a")
+
     def test_search_classifications_empty_results(self):
         """Test that empty search returns clean empty response."""
         query_response = {
@@ -148,6 +174,32 @@ class TestDataProtectionModule(TestModules):
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["platform_name"], "win")
+
+    def test_search_policies_reorders_to_match_sorted_ids(self):
+        """When the get step returns policies out of order, the result is
+        reordered to match the sorted ID order from the query step."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["pol-id-b", "pol-id-a"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "pol-id-a", "name": "Policy A", "platform_name": "win"},
+                    {"id": "pol-id-b", "name": "Policy B", "platform_name": "win"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_data_protection_policies(
+            platform_name="win", filter=None, limit=100, offset=0, sort="created_at.desc"
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "pol-id-b")
+        self.assertEqual(result[1]["id"], "pol-id-a")
 
     def test_search_policies_passes_platform_name(self):
         """Test that platform_name is sent to the query API."""
@@ -238,6 +290,32 @@ class TestDataProtectionModule(TestModules):
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["type"], "predefined")
+
+    def test_search_content_patterns_reorders_to_match_sorted_ids(self):
+        """When the get step returns content patterns out of order, the result is
+        reordered to match the sorted ID order from the query step."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["cp-id-b", "cp-id-a"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "cp-id-a", "name": "Pattern A", "type": "predefined"},
+                    {"id": "cp-id-b", "name": "Pattern B", "type": "custom"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_data_protection_content_patterns(
+            filter=None, limit=100, offset=0, sort="created_at.desc"
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "cp-id-b")
+        self.assertEqual(result[1]["id"], "cp-id-a")
 
     def test_search_content_patterns_empty_results(self):
         """Test that empty content pattern search returns clean empty response."""

--- a/tests/modules/test_detections.py
+++ b/tests/modules/test_detections.py
@@ -81,8 +81,8 @@ class TestDetectionsModule(TestModules):
             "status_code": 200,
             "body": {
                 "resources": [
-                    {"id": "detection1", "name": "Test Detection 1"},
-                    {"id": "detection2", "name": "Test Detection 2"},
+                    {"composite_id": "detection1", "name": "Test Detection 1"},
+                    {"composite_id": "detection2", "name": "Test Detection 2"},
                 ]
             },
         }
@@ -112,8 +112,37 @@ class TestDetectionsModule(TestModules):
         # Verify result is raw list of detections (no wrapping)
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "detection1")
-        self.assertEqual(result[1]["id"], "detection2")
+        self.assertEqual(result[0]["composite_id"], "detection1")
+        self.assertEqual(result[1]["composite_id"], "detection2")
+
+    def test_search_detections_reorders_to_match_sorted_ids(self):
+        """When PostEntitiesAlertsV2 returns entities out of order, the result is
+        reordered to match the sorted ID order from GetQueriesAlertsV2.
+
+        Live API validated: the details endpoint scrambles order, and entities
+        carry their ID in the ``composite_id`` field.
+        """
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["high-sev", "low-sev"]},
+        }
+        # Details returned in the opposite (scrambled) order
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"composite_id": "low-sev", "severity": 10},
+                    {"composite_id": "high-sev", "severity": 90},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_detections(sort="severity.desc")
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["composite_id"], "high-sev")
+        self.assertEqual(result[1]["composite_id"], "low-sev")
 
     def test_search_detections_error(self):
         """Test searching for detections with API error returns FQL guide."""
@@ -208,7 +237,7 @@ class TestDetectionsModule(TestModules):
         }
         details_response = {
             "status_code": 200,
-            "body": {"resources": [{"id": "detection1", "name": "Test Detection 1"}]},
+            "body": {"resources": [{"composite_id": "detection1", "name": "Test Detection 1"}]},
         }
         self.mock_client.command.side_effect = [query_response, details_response]
 
@@ -232,7 +261,7 @@ class TestDetectionsModule(TestModules):
         # Verify result is raw list (success = no wrapping)
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["id"], "detection1")
+        self.assertEqual(result[0]["composite_id"], "detection1")
 
     def test_get_detection_details_include_hidden_false(self):
         """Test getting detection details with include_hidden=False."""

--- a/tests/modules/test_exclusions.py
+++ b/tests/modules/test_exclusions.py
@@ -136,6 +136,36 @@ class TestExclusionsModule(TestModules):
                 self.assertEqual(len(result), 2)
                 self.assertEqual(result[0]["id"], "excl-1")
 
+    def test_search_exclusions_reorders_to_match_sorted_ids(self):
+        """When the get step returns exclusions out of order, the result is
+        reordered to match the sorted ID order from the query step (ml type)."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["excl-b", "excl-a"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "excl-a", "value": "/tmp/a"},
+                    {"id": "excl-b", "value": "/tmp/b"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_exclusions(
+            exclusion_type="ml",
+            filter=None,
+            limit=50,
+            sort="created_on.desc",
+            offset=0,
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "excl-b")
+        self.assertEqual(result[1]["id"], "excl-a")
+
     def test_search_invalid_type(self):
         """An invalid exclusion_type returns an error response, not a crash."""
         result = self.module.search_exclusions(

--- a/tests/modules/test_firewall.py
+++ b/tests/modules/test_firewall.py
@@ -100,6 +100,37 @@ class TestFirewallModule(TestModules):
         self.assertEqual(second_call[1]["parameters"]["ids"], ["rule-id-1", "rule-id-2"])
         self.assertEqual(len(result), 2)
 
+    def test_search_firewall_rules_reorders_to_match_sorted_ids(self):
+        """When get_rules returns rules out of order, the result is reordered
+        to match the sorted ID order from query_rules."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["rule-id-b", "rule-id-a"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "rule-id-a", "name": "Rule A", "platform": "windows"},
+                    {"id": "rule-id-b", "name": "Rule B", "platform": "windows"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_firewall_rules(
+            filter=None,
+            limit=20,
+            offset=0,
+            sort="modified_on.desc",
+            q=None,
+            after=None,
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "rule-id-b")
+        self.assertEqual(result[1]["id"], "rule-id-a")
+
     def test_search_firewall_rules_empty_with_filter(self):
         """Test rule search empty results with filter returns clean empty response."""
         self.mock_client.command.return_value = {
@@ -153,6 +184,37 @@ class TestFirewallModule(TestModules):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["id"], "group-id-1")
 
+    def test_search_firewall_rule_groups_reorders_to_match_sorted_ids(self):
+        """When get_rule_groups returns groups out of order, the result is reordered
+        to match the sorted ID order from query_rule_groups."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["group-id-b", "group-id-a"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "group-id-a", "name": "Group A", "platform": "windows"},
+                    {"id": "group-id-b", "name": "Group B", "platform": "windows"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_firewall_rule_groups(
+            filter=None,
+            limit=10,
+            offset=0,
+            sort="modified_on.desc",
+            q=None,
+            after=None,
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "group-id-b")
+        self.assertEqual(result[1]["id"], "group-id-a")
+
     def test_search_firewall_policy_rules_success(self):
         """Test searching policy rules and fetching full rule details."""
         query_response = {
@@ -184,6 +246,37 @@ class TestFirewallModule(TestModules):
         self.assertEqual(first_call[1]["parameters"]["id"], "policy-1")
         self.assertEqual(self.mock_client.command.call_args_list[1][0][0], "get_rules")
         self.assertEqual(len(result), 1)
+
+    def test_search_firewall_policy_rules_reorders_to_match_sorted_ids(self):
+        """When get_rules returns policy rules out of order, the result is reordered
+        to match the sorted ID order from query_policy_rules."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["rule-id-b", "rule-id-a"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "rule-id-a", "name": "Policy Rule A", "platform": "windows"},
+                    {"id": "rule-id-b", "name": "Policy Rule B", "platform": "windows"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_firewall_policy_rules(
+            policy_id="policy-1",
+            filter=None,
+            limit=10,
+            offset=0,
+            sort="modified_on.desc",
+            q=None,
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "rule-id-b")
+        self.assertEqual(result[1]["id"], "rule-id-a")
 
     def test_create_firewall_rule_group_success(self):
         """Test creating a firewall rule group with convenience fields."""

--- a/tests/modules/test_hosts.py
+++ b/tests/modules/test_hosts.py
@@ -180,6 +180,35 @@ class TestHostsModule(TestModules):
         # Verify result
         self.assertEqual(result, [])
 
+    def test_search_hosts_reorders_to_match_sorted_ids(self):
+        """When PostDeviceDetailsV2 returns devices out of order, the result is
+        reordered to match the sorted ID order from QueryDevicesByFilter.
+
+        Live API validated: the details endpoint preserves order today, so this
+        guards against regressions and future endpoint behavior changes. Entities
+        carry their ID in the ``device_id`` field.
+        """
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["device2", "device1"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"device_id": "device1", "hostname": "alpha"},
+                    {"device_id": "device2", "hostname": "bravo"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_hosts(sort="last_seen.desc")
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["device_id"], "device2")
+        self.assertEqual(result[1]["device_id"], "device1")
+
     def test_get_host_details(self):
         """Test getting host details."""
         # Setup mock response

--- a/tests/modules/test_ioc.py
+++ b/tests/modules/test_ioc.py
@@ -74,6 +74,35 @@ class TestIOCModule(TestModules):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["id"], "ioc-id-1")
 
+    def test_search_iocs_reorders_to_match_sorted_ids(self):
+        """When indicator_get_v1 returns IOCs out of order, the result is reordered
+        to match the sorted ID order from indicator_search_v1."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["ioc-id-b", "ioc-id-a"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "ioc-id-a", "type": "domain", "value": "a.example"},
+                    {"id": "ioc-id-b", "type": "ipv4", "value": "1.2.3.4"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_iocs(
+            filter=None,
+            limit=25,
+            offset=0,
+            sort="modified_on.desc",
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "ioc-id-b")
+        self.assertEqual(result[1]["id"], "ioc-id-a")
+
     def test_search_iocs_empty_results_returns_fql_guide(self):
         """Test IOC search empty results return clean empty response."""
         self.mock_client.command.return_value = {

--- a/tests/modules/test_policies.py
+++ b/tests/modules/test_policies.py
@@ -183,6 +183,36 @@ class TestPoliciesModule(TestModules):
                 self.assertEqual(len(result), 2)
                 self.assertEqual(result[0]["id"], "pol-1")
 
+    def test_search_device_control_reorders_to_match_sorted_ids(self):
+        """When getDeviceControlPoliciesV2 returns policies out of order, the
+        result is reordered to match the sorted ID order from the query step."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["pol-2", "pol-1"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "pol-1", "name": "a", "usb_settings": {}},
+                    {"id": "pol-2", "name": "b", "usb_settings": {}},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_policies(
+            policy_type="device_control",
+            filter=None,
+            limit=50,
+            offset=0,
+            sort="name.asc",
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "pol-2")
+        self.assertEqual(result[1]["id"], "pol-1")
+
     def test_search_invalid_type(self):
         """An invalid policy_type returns an error and makes no API call."""
         result = self.module.search_policies(

--- a/tests/modules/test_quarantine.py
+++ b/tests/modules/test_quarantine.py
@@ -104,6 +104,35 @@ class TestQuarantineModule(TestModules):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[1]["status"], "quarantined")
 
+    def test_search_quarantined_files_reorders_to_match_sorted_ids(self):
+        """When GetQuarantineFiles returns files out of order, the result is
+        reordered to match the sorted ID order from QueryQuarantineFiles."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["qf-b", "qf-a"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "qf-a", "status": "quarantined"},
+                    {"id": "qf-b", "status": "released"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_quarantined_files(
+            filter=None,
+            limit=25,
+            offset="0",
+            sort="date_updated|desc",
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "qf-b")
+        self.assertEqual(result[1]["id"], "qf-a")
+
     def test_search_quarantined_files_error_returns_fql_guide(self):
         """Test quarantine search returns FQL guide on filter error."""
         self.mock_client.command.return_value = {

--- a/tests/modules/test_recon.py
+++ b/tests/modules/test_recon.py
@@ -77,6 +77,34 @@ class TestReconModule(TestModules):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["id"], "notif1")
 
+    def test_search_recon_notifications_reorders_to_match_sorted_ids(self):
+        """When GetNotificationsDetailedV1 returns notifications out of order, the
+        result is reordered to match the sorted ID order from QueryNotificationsV1.
+
+        Live API validated: the details endpoint scrambles order; entities carry
+        their ID in the ``id`` field.
+        """
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["notif-b", "notif-a"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "notif-a", "status": "new"},
+                    {"id": "notif-b", "status": "new"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_recon_notifications(sort="created_date.desc")
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "notif-b")
+        self.assertEqual(result[1]["id"], "notif-a")
+
     def test_search_recon_notifications_empty(self):
         """Test that empty query results return the empty-response dict (no fql_guide)."""
         self.mock_client.command.return_value = {
@@ -161,6 +189,32 @@ class TestReconModule(TestModules):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["id"], "rule1")
 
+    def test_search_recon_rules_reorders_to_match_sorted_ids(self):
+        """When GetRulesV1 returns rules out of order, the result is reordered
+        to match the sorted ID order from QueryRulesV1."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["rule-b", "rule-a"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "rule-a", "topic": "SA_DOMAIN", "status": "active"},
+                    {"id": "rule-b", "topic": "SA_TYPOSQUATTING", "status": "active"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_recon_rules(
+            filter=None, limit=5, sort="created_date.desc"
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "rule-b")
+        self.assertEqual(result[1]["id"], "rule-a")
+
     def test_search_recon_rules_empty(self):
         """Test that empty rule query returns the empty-response dict."""
         self.mock_client.command.return_value = {
@@ -226,6 +280,32 @@ class TestReconModule(TestModules):
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["email"], "user@example.com")
+
+    def test_search_recon_exposed_data_records_reorders_to_match_sorted_ids(self):
+        """When GetNotificationsExposedDataRecordsV1 returns records out of order,
+        the result is reordered to match the sorted ID order from the query step."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["rec-b", "rec-a"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "rec-a", "email": "a@example.com", "credential_status": "newly_reported"},
+                    {"id": "rec-b", "email": "b@example.com", "credential_status": "previously_reported"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, details_response]
+
+        result = self.module.search_recon_exposed_data_records(
+            filter=None, limit=10, sort="created_date.desc"
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "rec-b")
+        self.assertEqual(result[1]["id"], "rec-a")
 
     def test_search_recon_exposed_data_records_empty(self):
         """Test that empty exposed-data query returns the empty-response dict."""

--- a/tests/modules/test_rtr.py
+++ b/tests/modules/test_rtr.py
@@ -139,6 +139,35 @@ class TestRTRModule(TestModules):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["id"], "session-1")
 
+    def test_search_sessions_reorders_to_match_sorted_ids(self):
+        """When RTR_ListSessions returns sessions out of order, the result is
+        reordered to match the sorted ID order from RTR_ListAllSessions."""
+        search_response = {
+            "status_code": 200,
+            "body": {"resources": ["session-b", "session-a"]},
+        }
+        details_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "session-a", "aid": "aid-1"},
+                    {"id": "session-b", "aid": "aid-2"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [search_response, details_response]
+
+        result = self.module.search_sessions(
+            filter=None,
+            limit=25,
+            offset=0,
+            sort="created_at.desc",
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "session-b")
+        self.assertEqual(result[1]["id"], "session-a")
+
     def test_search_audit_sessions(self):
         """Test searching RTR audit sessions."""
         self.mock_client.command.return_value = {

--- a/tests/modules/test_scheduled_reports.py
+++ b/tests/modules/test_scheduled_reports.py
@@ -107,6 +107,36 @@ class TestScheduledReportsModule(TestModules):
         self.assertEqual(result[1]["id"], "report-id-2")
         self.assertEqual(result[1]["name"], "Daily Vulnerability Scan")
 
+    def test_search_scheduled_reports_reorders_to_match_sorted_ids(self):
+        """When scheduled_reports_get returns reports out of order, the result is
+        reordered to match the sorted ID order from scheduled_reports_query."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["report-id-b", "report-id-a"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "report-id-a", "name": "Report A", "status": "ACTIVE"},
+                    {"id": "report-id-b", "name": "Report B", "status": "ACTIVE"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_scheduled_reports(
+            filter=None,
+            limit=100,
+            offset=0,
+            sort="created_on.desc",
+            q=None,
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "report-id-b")
+        self.assertEqual(result[1]["id"], "report-id-a")
+
     def test_search_scheduled_reports_empty(self):
         """Test searching scheduled reports with empty response."""
         # Setup mock response with empty resources
@@ -233,6 +263,35 @@ class TestScheduledReportsModule(TestModules):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["id"], "execution-id-1")
         self.assertEqual(result[0]["status"], "DONE")
+
+    def test_search_report_executions_reorders_to_match_sorted_ids(self):
+        """When report_executions_get returns executions out of order, the result
+        is reordered to match the sorted ID order from report_executions_query."""
+        query_response = {
+            "status_code": 200,
+            "body": {"resources": ["execution-id-b", "execution-id-a"]},
+        }
+        get_response = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"id": "execution-id-a", "status": "DONE"},
+                    {"id": "execution-id-b", "status": "PENDING"},
+                ]
+            },
+        }
+        self.mock_client.command.side_effect = [query_response, get_response]
+
+        result = self.module.search_report_executions(
+            filter=None,
+            limit=50,
+            offset=0,
+            sort="created_on.desc",
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "execution-id-b")
+        self.assertEqual(result[1]["id"], "execution-id-a")
 
     def test_download_report_execution_csv_format(self):
         """Test downloading CSV format report returns decoded string content.

--- a/tests/modules/test_spotlight.py
+++ b/tests/modules/test_spotlight.py
@@ -72,6 +72,26 @@ class TestSpotlightModule(TestModules):
         self.assertEqual(result[0]["status"], "open")
         self.assertEqual(result[0]["cvss_base_score"], 8.5)
 
+    def test_search_vulnerabilities_forwards_sort(self):
+        """The sort parameter is forwarded to combinedQueryVulnerabilities.
+
+        Spotlight is single-step (combinedQueryVulnerabilities returns full entities
+        with sort applied), so no reordering is needed — but we assert sort reaches
+        the operation.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        self.module.search_vulnerabilities(
+            filter="status:'open'", sort="created_timestamp|desc"
+        )
+
+        call_args = self.mock_client.command.call_args
+        self.assertEqual(call_args[0][0], "combinedQueryVulnerabilities")
+        self.assertEqual(call_args[1]["parameters"]["sort"], "created_timestamp|desc")
+
     def test_search_vulnerabilities_no_filter(self):
         """Test searching vulnerabilities with no filter parameter."""
         # Setup mock response with sample vulnerability data


### PR DESCRIPTION
Downstream consumers reported that the sort parameter was being silently ignored on search tools, forcing them to re-sort results client-side. It turned out sort was never actually dropped on our side — it reaches the query call fine. The real problem is the two-step pattern most search tools use: they query entity IDs (with sort applied and honored by the API), then hydrate full details by ID in a second call. Some of the get-by-ID endpoints return entities in whatever order they like, which throws away the sort. I confirmed this against the live API for detections, recon notifications, and cases.

The fix is a small shared helper, `_reorder_by_ids`, that reorders the hydrated entities back into the order the query step returned. It's a no-op when the endpoint already preserves order, so wiring it into every two-step search tool is safe defense-in-depth rather than a guess about which endpoints misbehave. Each caller passes the field its entities use for the ID (`composite_id` for detections, `device_id` for hosts, `id` everywhere else — all verified against real responses).

While validating sort fields against the API I also found the recon exposed-data-records docstring listed `updated_date` as a sort option (it returns a 500) and omitted `exposure_date` (which works), so I corrected that.

Tests cover the helper directly plus a per-tool regression that feeds entities back scrambled and asserts the output matches the query order.