### PR TITLE
fix(scheduled_reports): send request body as array in launch_scheduled_report (#464)

### DIFF
--- a/falcon_mcp/modules/scheduled_reports.py
+++ b/falcon_mcp/modules/scheduled_reports.py
@@ -165,9 +165,19 @@ class ScheduledReportsModule(BaseModule):
         falcon_search_report_executions and downloaded with
         falcon_download_report_execution when complete.
         """
-        result = self._base_query_api_call(
+        # scheduled_reports_launch expects the request body as a JSON array of
+        # {id} objects, not a bare object. _base_query_api_call routes body_params
+        # through prepare_api_parameters, which always returns a plain dict, so
+        # call the client directly to preserve the list-of-dict shape (mirrors
+        # falcon_mcp/modules/rtr.py and correlation_rules.py).
+        response = self.client.command(
+            "scheduled_reports_launch",
+            body=[{"id": id}],
+        )
+
+        result = handle_api_response(
+            response,
             operation="scheduled_reports_launch",
-            body_params={"id": id},
             error_message="Failed to launch scheduled report",
             default_result=[],
         )

--- a/tests/modules/test_scheduled_reports.py
+++ b/tests/modules/test_scheduled_reports.py
@@ -189,7 +189,7 @@ class TestScheduledReportsModule(TestModules):
         # Verify client command was called correctly
         self.mock_client.command.assert_called_once_with(
             "scheduled_reports_launch",
-            body={"id": "report-id-1"},
+            body=[{"id": "report-id-1"}],
         )
 
         # Verify result


### PR DESCRIPTION
Fixes #464.

`falcon_launch_scheduled_report` routed the request through `_base_query_api_call` with `body_params={"id": id}`, so the API received a bare object `{"id": "..."}`. The endpoint `scheduled_reports_launch` (`POST /reports/entities/scheduled-reports/execution/v1`) expects a JSON array of `{id}` objects, matching the shape `FalconPy` builds via `reports_payload`.

Switched to a direct `self.client.command("scheduled_reports_launch", body=[{"id": id}])` call, mirroring the existing list-body pattern in `falcon_mcp/modules/rtr.py` and `correlation_rules.py`. Updated the unit test assertion accordingly.