### PR TITLE
feat(modules): add pagination envelope to search tools

### DIFF
--- a/docs/modules/cases.md
+++ b/docs/modules/cases.md
@@ -121,6 +121,7 @@ Use this to discover cases by status, severity, assignee, time range, or
 evidence attributes. Consult falcon://cases/search/fql-guide before
 constructing filter expressions. Returns full case records including
 status, severity, evidence, assigned user, and analysis results.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/cloud.md
+++ b/docs/modules/cloud.md
@@ -111,6 +111,7 @@ violations on specific resources, use falcon_search_iom_findings instead. Consul
 falcon://cloud/cloud-risks/fql-guide before constructing filter expressions.
 Returns full risk details including severity, lifecycle status, asset context, and
 threat intelligence attribution.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -130,6 +131,7 @@ Use this to find cloud resources (EC2, VPCs, S3, etc.) by provider, region,
 resource type, or tags. Consult falcon://cloud/cspm-assets/fql-guide before
 constructing filter expressions. Returns slimmed asset details with security
 posture context (IOM/IOA counts, exposure, severity).
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions. For cursor-based paging, use `pagination.next` as the `after` parameter on the next call.
 
 **Example prompts:**
 
@@ -144,6 +146,7 @@ Search for CSPM IOM suppression rules.
 Use this to review existing suppressions before creating new ones. Returns
 suppression rule objects including scope, reason, and expiration details.
 Returns an empty list if no rules exist.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -160,6 +163,7 @@ Use this to find CVEs affecting container images by severity, CVSS score, or
 CVE ID. Consult falcon://cloud/images-vulnerabilities/fql-guide before constructing
 filter expressions. Returns vulnerability details including CVE IDs, scores, and
 impacted image counts.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -178,6 +182,7 @@ IOMs and IOAs across assets, use falcon_search_cloud_risks instead. For runtime
 behavioral threats, use falcon_search_detections. Consult
 falcon://cloud/cspm-iom-findings/fql-guide before constructing filter expressions.
 Returns IOM entities with cloud context, evaluation details, and resource information.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/correlationrules.md
+++ b/docs/modules/correlationrules.md
@@ -57,6 +57,7 @@ Use this to find detection rules by name, status, severity, or MITRE tactic/tech
 Consult falcon://correlation-rules/search/fql-guide before constructing filter expressions.
 Returns full rule objects; use the `rule_id` field when passing results to update or
 delete tools. Filter with state:'published' to get one result per rule.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/custom-ioa.md
+++ b/docs/modules/custom-ioa.md
@@ -115,6 +115,7 @@ Search Custom IOA rule groups and return full details including their rules.
 Use this to find rule groups by platform, name, or enabled state. Consult
 falcon://custom-ioa/rule-groups/fql-guide before constructing filter expressions.
 Returns rule group objects with their contained behavioral detection rules.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/data-protection.md
+++ b/docs/modules/data-protection.md
@@ -23,6 +23,7 @@ patterns to detect. Consult
 falcon://data-protection/classifications/fql-guide before constructing
 filter expressions. Returns full classification details including content
 pattern references and rule configuration.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -39,6 +40,7 @@ Use this to find regex-based content detection patterns by type, category,
 or region. Consult falcon://data-protection/content-patterns/fql-guide
 before constructing filter expressions. Returns full pattern details
 including regex definitions and match thresholds.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -56,6 +58,7 @@ or precedence. Requires a platform_name ('win' or 'mac'). Consult
 falcon://data-protection/policies/fql-guide before constructing filter
 expressions. Returns full policy details including host groups and
 classification assignments.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/detections.md
+++ b/docs/modules/detections.md
@@ -39,6 +39,7 @@ across all Falcon products: endpoint (EPP), identity (IDP), XDR, OverWatch, and
 NG-SIEM. Consult falcon://detections/search/fql-guide before constructing filter
 expressions. Returns full alert records including process context, device info,
 tactic/technique details, and threat classification.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/discover.md
+++ b/docs/modules/discover.md
@@ -21,6 +21,7 @@ Search for applications discovered in your CrowdStrike environment.
 Use this to find applications by name, vendor, or installation details. Consult
 falcon://discover/applications/fql-guide before constructing filter expressions.
 Returns application entities with optional host info and usage data (based on facet).
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -36,6 +37,7 @@ Finds systems discovered by Falcon-managed hosts that lack a sensor themselves.
 Consult falcon://discover/hosts/fql-guide before constructing filter expressions.
 The tool automatically adds entity_type:'unmanaged' to all queries. Returns full
 asset details including platform, network, and criticality information.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/exclusions.md
+++ b/docs/modules/exclusions.md
@@ -75,6 +75,7 @@ certificate-based exclusions by name, value, scope, or timestamp. The
 Consult falcon://exclusions/search/fql-guide before constructing filter
 expressions — the available fields differ per type. Returns full
 exclusion records including id, scope, and timestamps.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/firewall.md
+++ b/docs/modules/firewall.md
@@ -54,6 +54,7 @@ Search firewall rules within a specific policy container.
 Use this when you need rules scoped to a particular policy. Consult
 falcon://firewall/rules/fql-guide before constructing filter expressions.
 Returns full rule details for the specified policy.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -68,6 +69,7 @@ Search firewall rule groups and return full rule group details.
 Use this to find rule groups by name, platform, or enabled state. Consult
 falcon://firewall/rules/fql-guide before constructing filter expressions.
 Returns rule group objects including their contained rules.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions. For cursor-based paging, use `pagination.next` as the `after` parameter on the next call.
 
 **Example prompts:**
 
@@ -82,6 +84,7 @@ Search firewall rules and return full rule details.
 Use this to find firewall rules by name, platform, or enabled state. Consult
 falcon://firewall/rules/fql-guide before constructing filter expressions.
 Returns complete rule objects including conditions and actions.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions. For cursor-based paging, use `pagination.next` as the `after` parameter on the next call.
 
 **Example prompts:**
 

--- a/docs/modules/host-groups.md
+++ b/docs/modules/host-groups.md
@@ -76,6 +76,7 @@ Use this to list the devices that belong to a host group. Requires the group
 `id` and filters on HOST attributes (platform, hostname, etc.) — consult
 falcon://hosts/search/fql-guide for the filter syntax. Returns full host device
 entities including device_id, hostname, platform, and network context.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -92,6 +93,7 @@ Use this to find host groups by name, type, creator, or timestamps. Consult
 falcon://host-groups/search/fql-guide before constructing filter expressions.
 Returns full host group details including id, name, group_type, description,
 and audit metadata in a single call.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/hosts.md
+++ b/docs/modules/hosts.md
@@ -36,6 +36,7 @@ Use this to find devices by hostname, platform, IP, sensor version, or other
 attributes. Consult falcon://hosts/search/fql-guide before constructing filter
 expressions. Returns full host details including device info, OS, and network
 context.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/intel.md
+++ b/docs/modules/intel.md
@@ -37,6 +37,7 @@ Research threat actors and adversary groups tracked by CrowdStrike intelligence.
 Use this to search actors by name, target countries/industries, or activity dates.
 Consult falcon://intel/actors/fql-guide before constructing filter expressions.
 Returns full actor profiles including aliases, motivations, and targeting details.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -51,7 +52,9 @@ Search for threat indicators and IOCs from CrowdStrike intelligence.
 
 Use this to find indicators by type, publish date, malware family, or threat actor
 association. Consult falcon://intel/indicators/fql-guide before constructing filter
-expressions. Returns full indicator details including labels, relations, and kill chain stage.
+expressions. Returns full indicator details including labels, relations, and kill
+chain stage.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -66,6 +69,7 @@ Search CrowdStrike intelligence publications and threat reports.
 Use this to find reports by name, target industry, threat type, or publication date.
 Consult falcon://intel/reports/fql-guide before constructing filter expressions.
 Returns full report metadata including title, description, and target details.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/ioc.md
+++ b/docs/modules/ioc.md
@@ -56,6 +56,7 @@ Search custom IOCs and return full IOC details.
 Use this to find IOCs by type, value, action, severity, or expiration status.
 Consult falcon://ioc/search/fql-guide before constructing filter expressions.
 Returns full indicator records including metadata, platforms, and host groups.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions. For cursor-based paging, use `pagination.next` as the `after` parameter on the next call.
 
 **Example prompts:**
 

--- a/docs/modules/policies.md
+++ b/docs/modules/policies.md
@@ -87,6 +87,7 @@ queried. Consult falcon://policies/search/fql-guide before constructing
 filter expressions; the `name` match operator differs per type. Returns
 full policy records including id, name, platform_name, enabled, settings,
 and assigned host groups.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -107,6 +108,7 @@ Requires the policy `id`; filters on HOST attributes — consult
 falcon://hosts/search/fql-guide for the filter syntax. Returns full host
 device entities including device_id, hostname, platform_name, and network
 context.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/quarantine.md
+++ b/docs/modules/quarantine.md
@@ -58,6 +58,7 @@ Use this to discover quarantine records by host, hash, user, or state.
 Consult falcon://quarantine/files/search/fql-guide before constructing
 filter expressions. Returns full quarantine details including hostname,
 sha256, paths, state, and associated alert and detection IDs.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/recon.md
+++ b/docs/modules/recon.md
@@ -24,6 +24,7 @@ emails, login IDs, password hashes, domains, and breach metadata. Consult
 expressions. These records are part of the external cyber risk monitoring capability of
 CrowdStrike Counter Adversary Operations (CAO). Returns full records including credential
 fields, location data, and associated notification context.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -35,7 +36,8 @@ fields, location data, and associated notification context.
 
 **Required scopes:** `Monitoring rules (Falcon Intelligence Recon):read`
 
-Search Falcon Intelligence Recon notifications (also called recon alerts) and return their full details.
+Search Falcon Intelligence Recon notifications (also called recon alerts)
+and return their full details.
 
 Use this for dark web matches, leaked credentials, typosquatting matches, and breach
 summaries triggered by your monitoring rules. Consult
@@ -44,6 +46,7 @@ This serves the external cyber risk monitoring capability of CrowdStrike Counter
 Operations (CAO). For endpoint, XDR, or NG-SIEM alerts, use `falcon_search_detections`
 instead. Returns full notification records with a nested `notification` object
 containing status, rule metadata, breach_summary, and item details.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -65,6 +68,7 @@ monitoring is enabled. Consult `falcon://recon/rules/search/fql-guide` before
 constructing filter expressions. These monitoring rules power the external cyber risk
 monitoring capability of CrowdStrike Counter Adversary Operations (CAO). Returns full
 rule definitions including topic, priority, filter expressions, and notification settings.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/rtr.md
+++ b/docs/modules/rtr.md
@@ -168,6 +168,7 @@ which host was targeted, or which command activity Falcon recorded.
 This is read-only audit visibility; it does not open sessions or run
 commands. Consult falcon://rtr/audit/sessions/search/fql-guide before
 constructing filter expressions.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -183,6 +184,7 @@ Search RTR sessions and return full session details.
 Use this to find sessions by hostname, agent ID, user, or creation time. Consult
 falcon://rtr/sessions/search/fql-guide before constructing filter expressions.
 Returns session metadata including host info, commands executed, and status.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/scheduled-reports.md
+++ b/docs/modules/scheduled-reports.md
@@ -53,6 +53,7 @@ Search for report/search execution history.
 Use this to find executions by status, report ID, or completion date. Consult
 falcon://scheduled-reports/executions/search/fql-guide before constructing filter
 expressions. Returns full execution details including status and timestamps.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 
@@ -67,6 +68,7 @@ Search for scheduled reports and searches in your CrowdStrike environment.
 Use this to find reports by status, type, creator, or creation date. Consult
 falcon://scheduled-reports/search/fql-guide before constructing filter expressions.
 Returns full report/search entity details including schedule configuration.
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
 
 **Example prompts:**
 

--- a/docs/modules/shield.md
+++ b/docs/modules/shield.md
@@ -40,7 +40,8 @@ Get events from the Falcon Shield (SaaS Security) activity monitor; data is reta
 Use this to investigate user activity, threats, or IoC events across connected SaaS platforms;
 when filtering by integration_id, category, or actor, the date range must be within 24 hours.
 Returns activity event objects including timestamp, event name, actor identity, integration,
-category, and location details.
+category, and location details. This endpoint does not report a total count, so `pagination.total`
+is always null — page through results with `pagination.next`/`skip` rather than asking "how many".
 
 **Example prompts:**
 

--- a/docs/modules/spotlight.md
+++ b/docs/modules/spotlight.md
@@ -22,6 +22,7 @@ Use this to find vulnerabilities by CVE severity, status, host, or remediation
 state. Consult falcon://spotlight/vulnerabilities/fql-guide before constructing
 filter expressions. Returns vulnerability details including CVE info, host context,
 and remediation guidance (based on facet selection).
+Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions. For cursor-based paging, use `pagination.next` as the `after` parameter on the next call.
 
 **Example prompts:**
 

--- a/falcon_mcp/dynamic.py
+++ b/falcon_mcp/dynamic.py
@@ -217,7 +217,7 @@ class DynamicMode:
         and mutation risk (read_only / destructive fields). Do not execute destructive
         tools without confirming the user's intent.
         Results are returned in full — use each tool's own limit parameter to control
-        response volume. Empty result sets return a dict with results, total_count, and
+        response volume. Empty result sets return a dict with results, pagination, and
         hint keys rather than a bare empty list.
         """
         entry = self.catalog.get(tool_name)
@@ -247,7 +247,7 @@ class DynamicMode:
         if isinstance(result, list) and len(result) == 0:
             return {
                 "results": [],
-                "total_count": 0,
+                "pagination": {"total": 0, "next": None},
                 "hint": "No records returned. Use falcon_search_tools to review the tool parameters if this is unexpected.",
             }
         return result

--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -331,23 +331,89 @@ class BaseModule(ABC):
             default_result=[],
         )
 
+    def _base_search_with_meta(
+        self,
+        operation: str,
+        search_params: dict[str, Any],
+        error_message: str = "Search operation failed",
+    ) -> tuple[list[dict[str, Any]] | dict[str, Any], dict[str, Any] | None]:
+        """Like _base_search_api_call but also returns the response's pagination metadata.
+
+        Hydration (fetching full entity details by ID) discards `body.meta.pagination`
+        from the query-step response, so callers that need `total`/`after` must capture
+        it here, before calling `_base_get_by_ids`.
+
+        Args:
+            operation: The API operation name (e.g., "QueryDevicesByFilter")
+            search_params: Dictionary of search parameters (filter, limit, offset, sort, etc.)
+            error_message: Custom error message for failed operations
+
+        Returns:
+            Tuple of (resources or error dict, pagination dict or None)
+        """
+        prepared_params = prepare_api_parameters(search_params)
+
+        logger.debug("Executing %s with params: %s", operation, prepared_params)
+
+        response = self.client.command(operation, parameters=prepared_params)
+
+        result = handle_api_response(
+            response,
+            operation=operation,
+            error_message=error_message,
+            default_result=[],
+        )
+
+        if self._is_error(result):
+            return result, None
+
+        pagination = self._extract_pagination(response)
+        return result, pagination
+
+    @staticmethod
+    def _extract_pagination(response: dict[str, Any]) -> dict[str, Any] | None:
+        """Pull `body.meta.pagination` out of a raw API response, if present."""
+        return ((response.get("body") or {}).get("meta") or {}).get("pagination")
+
+    def _build_pagination_envelope(
+        self,
+        results: list[dict[str, Any]],
+        pagination: dict[str, Any] | None,
+        filter_used: str | None = None,
+    ) -> dict[str, Any]:
+        """Assemble the standard search-tool response envelope.
+
+        Args:
+            results: The full entity details to return to the caller
+            pagination: The raw `body.meta.pagination` dict from the API response, if any
+            filter_used: The FQL filter string that was used, if applicable
+
+        Returns:
+            Dict with `results`, `pagination` (total/offset/limit/next), and
+            optionally `filter_used`
+        """
+        pag: dict[str, Any] = {}
+        if pagination:
+            # `total` may be absent (some endpoints omit it) — report None rather
+            # than inventing a count, so a caller can tell "unknown" from a real total.
+            pag["total"] = pagination.get("total")
+            if "offset" in pagination:
+                pag["offset"] = pagination["offset"]
+            if "limit" in pagination:
+                pag["limit"] = pagination["limit"]
+            pag["next"] = pagination.get("after") or None
+        else:
+            # No pagination metadata: the API gave us no count, so report None rather
+            # than synthesizing one. A non-null `total` always means the API returned it.
+            pag = {"total": None, "next": None}
+
+        envelope: dict[str, Any] = {"results": results, "pagination": pag}
+        if filter_used is not None:
+            envelope["filter_used"] = filter_used
+        return envelope
+
     def _is_error(self, response: Any) -> bool:
         return isinstance(response, dict) and "error" in response
-
-    def _format_empty_response(
-        self,
-        filter_used: str | None,
-    ) -> dict[str, Any]:
-        """Format response for a successful search that returned zero results.
-
-        Use when the API returned HTTP 200 but zero matching resources.
-        Does NOT include FQL documentation — the filter was accepted by the API.
-        """
-        return {
-            "results": [],
-            "total": 0,
-            "filter_used": filter_used,
-        }
 
     def _format_fql_error_response(
         self,
@@ -359,7 +425,8 @@ class BaseModule(ABC):
 
         Use ONLY when the API returned an error (400+) that suggests the FQL
         filter syntax is incorrect. Do NOT use for empty results (200 with 0
-        resources) — use _format_empty_response for that case.
+        resources) — empty results use the standard pagination envelope, not
+        this FQL-error shape.
 
         Args:
             errors: List containing the error dict from the API

--- a/falcon_mcp/modules/cases.py
+++ b/falcon_mcp/modules/cases.py
@@ -137,8 +137,9 @@ class CasesModule(BaseModule):
         evidence attributes. Consult falcon://cases/search/fql-guide before
         constructing filter expressions. Returns full case records including
         status, severity, evidence, assigned user, and analysis results.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        case_ids = self._base_search_api_call(
+        case_ids, pagination = self._base_search_with_meta(
             operation="queries_cases_get_v1",
             search_params={
                 "filter": filter,
@@ -156,7 +157,7 @@ class CasesModule(BaseModule):
             )
 
         if not case_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation="entities_cases_post_v2",
@@ -168,7 +169,8 @@ class CasesModule(BaseModule):
 
         # entities_cases_post_v2 returns cases in arbitrary order; restore the sort
         # applied by the query step (validated against live API: field is id).
-        return self._reorder_by_ids(case_ids, details, id_field="id")
+        details = self._reorder_by_ids(case_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def get_cases(
         self,

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -125,21 +125,31 @@ class CloudModule(BaseModule):
         kubernetes_containers_fql_resource = TextResource(
             uri=AnyUrl("falcon://cloud/kubernetes-containers/fql-guide"),
             name="falcon_kubernetes_containers_fql_filter_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_kubernetes_containers` and `falcon_count_kubernetes_containers` tools.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_kubernetes_containers` and `falcon_count_kubernetes_containers` "
+                "tools."
+            ),
             text=KUBERNETES_CONTAINERS_FQL_DOCUMENTATION,
         )
 
         images_vulnerabilities_fql_resource = TextResource(
             uri=AnyUrl("falcon://cloud/images-vulnerabilities/fql-guide"),
             name="falcon_images_vulnerabilities_fql_filter_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_images_vulnerabilities` tool.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_images_vulnerabilities` tool."
+            ),
             text=IMAGES_VULNERABILITIES_FQL_DOCUMENTATION,
         )
 
         cspm_assets_fql_resource = TextResource(
             uri=AnyUrl("falcon://cloud/cspm-assets/fql-guide"),
             name="falcon_search_cspm_assets_fql_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_cspm_assets` tool.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_cspm_assets` tool."
+            ),
             text=SEARCH_CSPM_ASSETS_FQL_DOCUMENTATION,
         )
 
@@ -219,7 +229,7 @@ class CloudModule(BaseModule):
             ).strip(),
             examples={"container_name.desc", "last_seen.desc"},
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for Kubernetes containers in your CrowdStrike container inventory.
 
         Use this to find containers by cluster, namespace, image, or cloud provider.
@@ -227,7 +237,7 @@ class CloudModule(BaseModule):
         expressions. Returns full container details including image, status, and vulnerabilities.
         """
 
-        return self._base_search_api_call(
+        results, pagination = self._base_search_with_meta(
             operation="ReadContainerCombined",
             search_params={
                 "filter": filter,
@@ -237,6 +247,9 @@ class CloudModule(BaseModule):
             },
             error_message="Failed to search Kubernetes containers",
         )
+        if self._is_error(results):
+            return [results]
+        return self._build_pagination_envelope(results or [], pagination, filter)
 
     def count_kubernetes_containers(
         self,
@@ -314,38 +327,31 @@ class CloudModule(BaseModule):
             ).strip(),
             examples={"cvss_score.desc", "cps_current_rating.asc"},
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for container image vulnerabilities in CrowdStrike Image Assessments.
 
         Use this to find CVEs affecting container images by severity, CVSS score, or
         CVE ID. Consult falcon://cloud/images-vulnerabilities/fql-guide before constructing
         filter expressions. Returns vulnerability details including CVE IDs, scores, and
         impacted image counts.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
 
-        # Prepare parameters
-        params = prepare_api_parameters(
-            {
+        result, pagination = self._base_search_with_meta(
+            operation="ReadCombinedVulnerabilities",
+            search_params={
                 "filter": filter,
                 "limit": limit,
                 "offset": offset,
                 "sort": sort,
-            }
-        )
-
-        # Define the operation name
-        operation = "ReadCombinedVulnerabilities"
-
-        # Make the API request
-        response = self.client.command(operation, parameters=params)
-
-        # Handle the response
-        return handle_api_response(
-            response,
-            operation=operation,
+            },
             error_message="Failed to perform operation",
-            default_result=[],
         )
+
+        if self._is_error(result):
+            return [result]
+
+        return self._build_pagination_envelope(result, pagination, filter)
 
     def search_cspm_assets(
         self,
@@ -397,9 +403,10 @@ class CloudModule(BaseModule):
         resource type, or tags. Consult falcon://cloud/cspm-assets/fql-guide before
         constructing filter expressions. Returns slimmed asset details with security
         posture context (IOM/IOA counts, exposure, severity).
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions. For cursor-based paging, use `pagination.next` as the `after` parameter on the next call.
         """
         # Step 1: Query for asset IDs
-        asset_ids = self._base_search_api_call(
+        asset_ids, pagination = self._base_search_with_meta(
             operation="cloud_security_assets_queries",
             search_params={
                 "filter": filter,
@@ -421,7 +428,7 @@ class CloudModule(BaseModule):
 
         # Handle empty results
         if not asset_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         # Step 2: Batch fetch full details (API limit: 100 IDs per request)
         details = self._batch_get_cspm_assets(asset_ids)
@@ -433,7 +440,9 @@ class CloudModule(BaseModule):
         # endpoint reorders results.
         details = self._reorder_by_ids(asset_ids, details, id_field="id")
 
-        return [self._slim_cspm_asset(asset) for asset in details]
+        return self._build_pagination_envelope(
+            [self._slim_cspm_asset(asset) for asset in details], pagination, filter
+        )
 
     def _batch_get_cspm_assets(self, asset_ids: list[str]) -> list[dict[str, Any]] | dict[str, Any]:
         """Fetch CSPM asset details in batches of 100 (API limit).
@@ -607,9 +616,10 @@ class CloudModule(BaseModule):
         behavioral threats, use falcon_search_detections. Consult
         falcon://cloud/cspm-iom-findings/fql-guide before constructing filter expressions.
         Returns IOM entities with cloud context, evaluation details, and resource information.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
         # Step 1: Query for IOM IDs
-        iom_ids = self._base_search_api_call(
+        iom_ids, pagination = self._base_search_with_meta(
             operation="cspm_evaluations_iom_queries",
             search_params={
                 "filter": filter,
@@ -630,7 +640,7 @@ class CloudModule(BaseModule):
 
         # Handle empty results
         if not iom_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         # Step 2: Fetch full IOM entity details (GET with query params, max 100 per call)
         details = self._batch_get_iom_entities(iom_ids)
@@ -639,7 +649,8 @@ class CloudModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order in case the entities endpoint reorders results.
-        return self._reorder_by_ids(iom_ids, details, id_field="id")
+        details = self._reorder_by_ids(iom_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def search_cloud_risks(
         self,
@@ -669,7 +680,7 @@ class CloudModule(BaseModule):
             ),
             examples=["severity|desc", "first_seen|desc", "account_name|asc"],
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for cloud risks in your CrowdStrike environment.
 
         Use this to find risks by severity, status, cloud provider, account, asset, rule,
@@ -679,8 +690,9 @@ class CloudModule(BaseModule):
         falcon://cloud/cloud-risks/fql-guide before constructing filter expressions.
         Returns full risk details including severity, lifecycle status, asset context, and
         threat intelligence attribution.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        return self._base_search_api_call(
+        results, pagination = self._base_search_with_meta(
             operation="combined_cloud_risks",
             search_params={
                 "filter": filter,
@@ -690,6 +702,11 @@ class CloudModule(BaseModule):
             },
             error_message="Failed to search cloud risks",
         )
+
+        if self._is_error(results):
+            return [results]
+
+        return self._build_pagination_envelope(results, pagination, filter)
 
     def search_cloud_groups(
         self,
@@ -717,14 +734,14 @@ class CloudModule(BaseModule):
             description="Sort groups. Default: name|asc. Examples: 'name|asc', 'created_at|desc'",
             examples=["name|asc", "created_at|desc"],
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """List cloud groups in your CrowdStrike environment.
 
         Use this to discover available cloud groups before filtering risks by
         `cloud_group` or `groups.*` FQL fields in `falcon_search_cloud_risks`.
         Returns full group details including name, selectors, and tags.
         """
-        return self._base_search_api_call(
+        results, pagination = self._base_search_with_meta(
             operation="ListCloudGroupsExternal",
             search_params={
                 "filter": filter,
@@ -734,6 +751,11 @@ class CloudModule(BaseModule):
             },
             error_message="Failed to search cloud groups",
         )
+
+        if self._is_error(results):
+            return [results]
+
+        return self._build_pagination_envelope(results, pagination, filter)
 
     def get_cloud_groups(
         self,
@@ -803,6 +825,7 @@ class CloudModule(BaseModule):
         Use this to review existing suppressions before creating new ones. Returns
         suppression rule objects including scope, reason, and expiration details.
         Returns an empty list if no rules exist.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
         # Step 1: Query suppression rule IDs
         params = prepare_api_parameters({"limit": limit, "offset": offset})
@@ -811,6 +834,8 @@ class CloudModule(BaseModule):
             override="GET,/cloud-policies/queries/suppression-rules/v1",
             parameters=params,
         )
+
+        pagination = self._extract_pagination(query_response)
 
         query_result = handle_api_response(
             query_response,
@@ -823,7 +848,7 @@ class CloudModule(BaseModule):
             return query_result
 
         if not query_result:
-            return []
+            return self._build_pagination_envelope([], pagination)
 
         # Step 2: Fetch suppression rule details
         detail_params = prepare_api_parameters({"ids": query_result})
@@ -844,7 +869,8 @@ class CloudModule(BaseModule):
             return [details]
 
         # Preserve the query-step order in case the details endpoint reorders results.
-        return self._reorder_by_ids(query_result, details, id_field="id")
+        details = self._reorder_by_ids(query_result, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination)
 
     def create_cspm_suppression_rule(
         self,

--- a/falcon_mcp/modules/correlation_rules.py
+++ b/falcon_mcp/modules/correlation_rules.py
@@ -99,8 +99,9 @@ class CorrelationRulesModule(BaseModule):
         Consult falcon://correlation-rules/search/fql-guide before constructing filter expressions.
         Returns full rule objects; use the `rule_id` field when passing results to update or
         delete tools. Filter with state:'published' to get one result per rule.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        result = self._base_search_api_call(
+        result, pagination = self._base_search_with_meta(
             operation="combined_rules_get_v2",
             search_params={
                 "filter": filter,
@@ -116,10 +117,7 @@ class CorrelationRulesModule(BaseModule):
                 [result], filter, SEARCH_CORRELATION_RULES_FQL_DOCUMENTATION
             )
 
-        if not result:
-            return self._format_empty_response(filter)
-
-        return result
+        return self._build_pagination_envelope(result or [], pagination, filter)
 
     def create_correlation_rule(
         self,

--- a/falcon_mcp/modules/custom_ioa.py
+++ b/falcon_mcp/modules/custom_ioa.py
@@ -170,8 +170,9 @@ class CustomIOAModule(BaseModule):
         Use this to find rule groups by platform, name, or enabled state. Consult
         falcon://custom-ioa/rule-groups/fql-guide before constructing filter expressions.
         Returns rule group objects with their contained behavioral detection rules.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        result = self._base_search_api_call(
+        result, pagination = self._base_search_with_meta(
             operation="query_rule_groups_full",
             search_params={
                 "filter": filter,
@@ -188,10 +189,7 @@ class CustomIOAModule(BaseModule):
                 [result], filter, SEARCH_IOA_RULE_GROUPS_FQL_DOCUMENTATION
             )
 
-        if not result:
-            return self._format_empty_response(filter)
-
-        return result
+        return self._build_pagination_envelope(result or [], pagination, filter)
 
     def get_ioa_platforms(self) -> list[dict[str, Any]] | dict[str, Any]:
         """Get all available platforms for Custom IOA rule groups.

--- a/falcon_mcp/modules/data_protection.py
+++ b/falcon_mcp/modules/data_protection.py
@@ -106,8 +106,9 @@ class DataProtectionModule(BaseModule):
         falcon://data-protection/classifications/fql-guide before constructing
         filter expressions. Returns full classification details including content
         pattern references and rule configuration.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        ids = self._base_search_api_call(
+        ids, pagination = self._base_search_with_meta(
             operation="queries_classification_get_v2",
             search_params={
                 "filter": filter,
@@ -116,7 +117,6 @@ class DataProtectionModule(BaseModule):
                 "sort": sort,
             },
             error_message="Failed to search Data Protection classifications",
-            default_result=[],
         )
 
         if self._is_error(ids):
@@ -125,7 +125,7 @@ class DataProtectionModule(BaseModule):
             )
 
         if not ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             "entities_classification_get_v2", ids, use_params=True
@@ -135,7 +135,8 @@ class DataProtectionModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order if the get endpoint reorders results.
-        return self._reorder_by_ids(ids, details, id_field="id")
+        details = self._reorder_by_ids(ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def search_data_protection_policies(
         self,
@@ -169,8 +170,9 @@ class DataProtectionModule(BaseModule):
         falcon://data-protection/policies/fql-guide before constructing filter
         expressions. Returns full policy details including host groups and
         classification assignments.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        ids = self._base_search_api_call(
+        ids, pagination = self._base_search_with_meta(
             operation="queries_policy_get_v2",
             search_params={
                 "platform_name": platform_name,
@@ -180,7 +182,6 @@ class DataProtectionModule(BaseModule):
                 "sort": sort,
             },
             error_message="Failed to search Data Protection policies",
-            default_result=[],
         )
 
         if self._is_error(ids):
@@ -189,7 +190,7 @@ class DataProtectionModule(BaseModule):
             )
 
         if not ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids("entities_policy_get_v2", ids, use_params=True)
 
@@ -197,7 +198,8 @@ class DataProtectionModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order if the get endpoint reorders results.
-        return self._reorder_by_ids(ids, details, id_field="id")
+        details = self._reorder_by_ids(ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def search_data_protection_content_patterns(
         self,
@@ -227,8 +229,9 @@ class DataProtectionModule(BaseModule):
         or region. Consult falcon://data-protection/content-patterns/fql-guide
         before constructing filter expressions. Returns full pattern details
         including regex definitions and match thresholds.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        ids = self._base_search_api_call(
+        ids, pagination = self._base_search_with_meta(
             operation="queries_content_pattern_get_v2",
             search_params={
                 "filter": filter,
@@ -237,7 +240,6 @@ class DataProtectionModule(BaseModule):
                 "sort": sort,
             },
             error_message="Failed to search Data Protection content patterns",
-            default_result=[],
         )
 
         if self._is_error(ids):
@@ -246,7 +248,7 @@ class DataProtectionModule(BaseModule):
             )
 
         if not ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids("entities_content_pattern_get", ids, use_params=True)
 
@@ -254,4 +256,5 @@ class DataProtectionModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order if the get endpoint reorders results.
-        return self._reorder_by_ids(ids, details, id_field="id")
+        details = self._reorder_by_ids(ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)

--- a/falcon_mcp/modules/detections.py
+++ b/falcon_mcp/modules/detections.py
@@ -63,7 +63,10 @@ class DetectionsModule(BaseModule):
         search_detections_fql_resource = TextResource(
             uri=AnyUrl("falcon://detections/search/fql-guide"),
             name="falcon_search_detections_fql_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_detections` tool.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_detections` tool."
+            ),
             text=SEARCH_DETECTIONS_FQL_DOCUMENTATION,
         )
 
@@ -76,18 +79,27 @@ class DetectionsModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression. See `falcon://detections/search/fql-guide` for syntax.",
+            description=(
+                "FQL filter expression. See `falcon://detections/search/fql-guide`"
+                " for syntax."
+            ),
             examples=["status:'new'+severity_name:'High'", "device.hostname:'DC*'"],
         ),
         limit: int = Field(
             default=10,
             ge=1,
             le=9999,
-            description="The maximum number of detections to return in this response (default: 10; max: 9999). Use with the offset parameter to manage pagination of results.",
+            description=(
+                "The maximum number of detections to return in this response (default: 10; "
+                "max: 9999). Use with the offset parameter to manage pagination of results."
+            ),
         ),
         offset: int | None = Field(
             default=None,
-            description="The first detection to return, where 0 is the latest detection. Use with the offset parameter to manage pagination of results.",
+            description=(
+                "The first detection to return, where 0 is the latest detection. Use with "
+                "the offset parameter to manage pagination of results."
+            ),
         ),
         q: str | None = Field(
             default=None,
@@ -101,14 +113,16 @@ class DetectionsModule(BaseModule):
                 timestamp: Timestamp when the detection occurred
                 created_timestamp: When the detection was created
                 updated_timestamp: When the detection was last modified
-                severity: Severity level of the detection (1-100, recommended when filtering by severity)
+                severity: Severity level of the detection (1-100, recommended when filtering
+                by severity)
                 confidence: Confidence level of the detection (1-100)
                 agent_id: Agent ID associated with the detection
 
                 Sort either asc (ascending) or desc (descending).
                 Both formats are supported: 'severity.desc' or 'severity|desc'
 
-                When searching for high severity detections, use 'severity.desc' to get the highest severity detections first.
+                When searching for high severity detections, use 'severity.desc' to get the
+                highest severity detections first.
                 For chronological ordering, use 'timestamp.desc' for most recent detections first.
 
                 Examples: 'severity.desc', 'timestamp.desc'
@@ -125,8 +139,9 @@ class DetectionsModule(BaseModule):
         NG-SIEM. Consult falcon://detections/search/fql-guide before constructing filter
         expressions. Returns full alert records including process context, device info,
         tactic/technique details, and threat classification.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        detection_ids = self._base_search_api_call(
+        detection_ids, pagination = self._base_search_with_meta(
             operation="GetQueriesAlertsV2",
             search_params={
                 "filter": filter,
@@ -146,7 +161,7 @@ class DetectionsModule(BaseModule):
 
         # Handle empty results
         if not detection_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         # Get detection details - past FQL concerns, normal API flow
         details = self._base_get_by_ids(
@@ -161,7 +176,8 @@ class DetectionsModule(BaseModule):
 
         # PostEntitiesAlertsV2 returns entities in arbitrary order; restore the sort
         # applied by the query step (validated against live API: field is composite_id).
-        return self._reorder_by_ids(detection_ids, details, id_field="composite_id")
+        details = self._reorder_by_ids(detection_ids, details, id_field="composite_id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def get_detection_details(
         self,
@@ -170,7 +186,10 @@ class DetectionsModule(BaseModule):
         ),
         include_hidden: bool = Field(
             default=True,
-            description="Whether to include hidden detections (default: True). When True, shows all detections including previously hidden ones for comprehensive visibility.",
+            description=(
+                "Whether to include hidden detections (default: True). When True, shows "
+                "all detections including previously hidden ones for comprehensive visibility."
+            ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Retrieve details for detection IDs you already have.
@@ -195,27 +214,45 @@ class DetectionsModule(BaseModule):
         ),
         status: str | None = Field(
             default=None,
-            description="New status for the detection(s). Allowed values: new, in_progress, reopened, closed.",
+            description=(
+                "New status for the detection(s). Allowed values: new, in_progress, "
+                "reopened, closed."
+            ),
         ),
         assign_to_uuid: str | None = Field(
             default=None,
-            description="UUID of the user to assign the detection(s) to. Example: '00000000-0000-0000-0000-000000000000'.",
+            description=(
+                "UUID of the user to assign the detection(s) to. "
+                "Example: '00000000-0000-0000-0000-000000000000'."
+            ),
         ),
         assign_to_user_id: str | None = Field(
             default=None,
-            description="Email address of the user to assign the detection(s) to. Example: 'analyst@example.com'.",
+            description=(
+                "Email address of the user to assign the detection(s) to. "
+                "Example: 'analyst@example.com'."
+            ),
         ),
         assign_to_name: str | None = Field(
             default=None,
-            description="Full name of the user to assign the detection(s) to. Example: 'Jane Smith'.",
+            description=(
+                "Full name of the user to assign the detection(s) to. "
+                "Example: 'Jane Smith'."
+            ),
         ),
         unassign: bool | None = Field(
             default=None,
-            description="Pass True to remove the current assignee. False is a no-op; only True has any effect.",
+            description=(
+                "Pass True to remove the current assignee. False is a no-op; "
+                "only True has any effect."
+            ),
         ),
         append_comment: str | None = Field(
             default=None,
-            description="Comment to append to the detection(s). Comments are visible in the Falcon console. Must be a non-empty, non-whitespace string.",
+            description=(
+                "Comment to append to the detection(s). Comments are visible in the Falcon "
+                "console. Must be a non-empty, non-whitespace string."
+            ),
         ),
         show_in_ui: bool | None = Field(
             default=None,
@@ -224,19 +261,27 @@ class DetectionsModule(BaseModule):
         add_tags: list[str] | None = Field(
             default=None,
             description=(
-                "Tags to add to the detection(s). Tags are free-form strings; any value is accepted. "
-                "true_positive, false_positive, and ignored are the conventional resolution tags the "
-                "Falcon console surfaces in its Resolution column — use them when recording a resolution, "
+                "Tags to add to the detection(s). Tags are free-form strings; any value is "
+                "accepted. "
+                "true_positive, false_positive, and ignored are the conventional resolution "
+                "tags the "
+                "Falcon console surfaces in its Resolution column — use them when recording "
+                "a resolution, "
                 "but they are guidance, not an enforced set."
             ),
         ),
         remove_tags: list[str] | None = Field(
             default=None,
-            description="Tags to remove from the detection(s). Each value must match an existing tag exactly.",
+            description=(
+                "Tags to remove from the detection(s). Each value must match an existing "
+                "tag exactly."
+            ),
         ),
         remove_tags_by_prefix: str | None = Field(
             default=None,
-            description="Remove all tags on the detection(s) that start with this prefix (e.g. 'fc/').",
+            description=(
+                "Remove all tags on the detection(s) that start with this prefix (e.g. 'fc/')."
+            ),
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Update the status, assignment, visibility, comments, and tags of one or more detections.
@@ -252,7 +297,11 @@ class DetectionsModule(BaseModule):
         # Validate mutually exclusive assignment parameters
         assignment_params = [assign_to_uuid, assign_to_user_id, assign_to_name]
         if sum(p is not None for p in assignment_params) > 1:
-            return {"error": "Provide at most one of assign_to_uuid, assign_to_user_id, assign_to_name."}
+            return {
+                "error": (
+                    "Provide at most one of assign_to_uuid, assign_to_user_id, assign_to_name."
+                )
+            }
 
         if unassign is True and any(p is not None for p in assignment_params):
             return {"error": "Cannot combine unassign with an assignment parameter."}
@@ -302,7 +351,9 @@ class DetectionsModule(BaseModule):
         for tag in remove_tags or []:
             action_parameters.append({"name": "remove_tag", "value": tag})
         if remove_tags_by_prefix is not None:
-            action_parameters.append({"name": "remove_tags_by_prefix", "value": remove_tags_by_prefix})
+            action_parameters.append(
+                {"name": "remove_tags_by_prefix", "value": remove_tags_by_prefix}
+            )
 
         if not action_parameters:
             return {"error": "At least one update parameter must be provided."}

--- a/falcon_mcp/modules/discover.py
+++ b/falcon_mcp/modules/discover.py
@@ -11,16 +11,11 @@ from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
 from pydantic import AnyUrl, Field
 
-from falcon_mcp.common.errors import handle_api_response
-from falcon_mcp.common.logging import get_logger
-from falcon_mcp.common.utils import prepare_api_parameters
 from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.resources.discover import (
     SEARCH_APPLICATIONS_FQL_DOCUMENTATION,
     SEARCH_UNMANAGED_ASSETS_FQL_DOCUMENTATION,
 )
-
-logger = get_logger(__name__)
 
 
 class DiscoverModule(BaseModule):
@@ -106,45 +101,29 @@ class DiscoverModule(BaseModule):
             description="Property used to sort the results. All properties can be used to sort unless otherwise noted in their property descriptions.",
             examples={"name.asc", "vendor.desc", "last_updated_timestamp.desc"},
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for applications discovered in your CrowdStrike environment.
 
         Use this to find applications by name, vendor, or installation details. Consult
         falcon://discover/applications/fql-guide before constructing filter expressions.
         Returns application entities with optional host info and usage data (based on facet).
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        # Prepare parameters for combined_applications
-        params = prepare_api_parameters(
-            {
+        applications, pagination = self._base_search_with_meta(
+            operation="combined_applications",
+            search_params={
                 "filter": filter,
                 "facet": facet,
                 "limit": limit,
                 "sort": sort,
-            }
-        )
-
-        # Define the operation name
-        operation = "combined_applications"
-
-        logger.debug("Searching applications with params: %s", params)
-
-        # Make the API request
-        response = self.client.command(operation, parameters=params)
-
-        # Use handle_api_response to get application data
-        applications = handle_api_response(
-            response,
-            operation=operation,
+            },
             error_message="Failed to search applications",
-            default_result=[],
         )
 
-        # If handle_api_response returns an error dict instead of a list,
-        # it means there was an error, so we return it wrapped in a list
         if self._is_error(applications):
             return [applications]
 
-        return applications
+        return self._build_pagination_envelope(applications, pagination, filter)
 
     def search_unmanaged_assets(
         self,
@@ -184,13 +163,14 @@ class DiscoverModule(BaseModule):
             """).strip(),
             examples={"hostname.asc", "last_seen_timestamp.desc", "criticality.desc"},
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for unmanaged assets (hosts without Falcon sensor) in your environment.
 
         Finds systems discovered by Falcon-managed hosts that lack a sensor themselves.
         Consult falcon://discover/hosts/fql-guide before constructing filter expressions.
         The tool automatically adds entity_type:'unmanaged' to all queries. Returns full
         asset details including platform, network, and criticality information.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
         # Always enforce entity_type:'unmanaged' filter
         base_filter = "entity_type:'unmanaged'"
@@ -201,35 +181,18 @@ class DiscoverModule(BaseModule):
         else:
             combined_filter = base_filter
 
-        # Prepare parameters for combined_hosts
-        params = prepare_api_parameters(
-            {
+        assets, pagination = self._base_search_with_meta(
+            operation="combined_hosts",
+            search_params={
                 "filter": combined_filter,
                 "limit": limit,
                 "offset": offset,
                 "sort": sort,
-            }
-        )
-
-        # Define the operation name
-        operation = "combined_hosts"
-
-        logger.debug("Searching unmanaged assets with params: %s", params)
-
-        # Make the API request
-        response = self.client.command(operation, parameters=params)
-
-        # Use handle_api_response to get unmanaged asset data
-        assets = handle_api_response(
-            response,
-            operation=operation,
+            },
             error_message="Failed to search unmanaged assets",
-            default_result=[],
         )
 
-        # If handle_api_response returns an error dict instead of a list,
-        # it means there was an error, so we return it wrapped in a list
         if self._is_error(assets):
             return [assets]
 
-        return assets
+        return self._build_pagination_envelope(assets, pagination, filter)

--- a/falcon_mcp/modules/exclusions.py
+++ b/falcon_mcp/modules/exclusions.py
@@ -148,7 +148,10 @@ class ExclusionsModule(BaseModule):
         search_exclusions_fql_resource = TextResource(
             uri=AnyUrl("falcon://exclusions/search/fql-guide"),
             name="falcon_search_exclusions_fql_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_exclusions` tool.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_exclusions` tool."
+            ),
             text=SEARCH_EXCLUSIONS_FQL_DOCUMENTATION,
         )
 
@@ -220,17 +223,27 @@ class ExclusionsModule(BaseModule):
         ),
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression. See `falcon://exclusions/search/fql-guide` for syntax (fields vary by type).",
+            description=(
+                "FQL filter expression. See `falcon://exclusions/search/fql-guide` "
+                "for syntax (fields vary by type)."
+            ),
         ),
         limit: int = Field(
             default=100,
             ge=1,
             le=500,
-            description="Maximum number of exclusions to return. Capped at 100 for 'certificate', 500 otherwise.",
+            description=(
+                "Maximum number of exclusions to return. Capped at 100 for "
+                "'certificate', 500 otherwise."
+            ),
         ),
         sort: str | None = Field(
             default=None,
-            description="Sort expression. See `falcon://exclusions/search/fql-guide`. A `.desc` direction is added automatically for ioa/ml/sensor_visibility when omitted.",
+            description=(
+                "Sort expression. See `falcon://exclusions/search/fql-guide`. "
+                "A `.desc` direction is added automatically for "
+                "ioa/ml/sensor_visibility when omitted."
+            ),
         ),
         offset: int | None = Field(
             default=None,
@@ -245,6 +258,7 @@ class ExclusionsModule(BaseModule):
         Consult falcon://exclusions/search/fql-guide before constructing filter
         expressions — the available fields differ per type. Returns full
         exclusion records including id, scope, and timestamps.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
         type_error = self._validate_exclusion_type(exclusion_type)
         if type_error is not None:
@@ -261,7 +275,7 @@ class ExclusionsModule(BaseModule):
         offset: int | None,
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Shared two-step search (query IDs -> fetch details) for an exclusion type."""
-        ids = self._base_search_api_call(
+        ids, pagination = self._base_search_with_meta(
             operation=self._OPERATIONS[exclusion_type]["query"],
             search_params={
                 "filter": filter,
@@ -278,9 +292,7 @@ class ExclusionsModule(BaseModule):
             )
 
         if not ids:
-            return self._format_fql_error_response(
-                [], filter, SEARCH_EXCLUSIONS_FQL_DOCUMENTATION
-            )
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation=self._OPERATIONS[exclusion_type]["get"],
@@ -292,7 +304,8 @@ class ExclusionsModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order in case the get endpoint reorders results.
-        return self._reorder_by_ids(ids, details, id_field="id")
+        details = self._reorder_by_ids(ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     # ---- Body builders ------------------------------------------------------------
 
@@ -574,7 +587,10 @@ class ExclusionsModule(BaseModule):
         ),
         pattern_id: str | None = Field(
             default=None,
-            description="IOA rule pattern ID to exclude (a real existing pattern). Required for 'ioa'.",
+            description=(
+                "IOA rule pattern ID to exclude (a real existing pattern). "
+                "Required for 'ioa'."
+            ),
         ),
         ifn_regex: str | None = Field(
             default=None,
@@ -602,11 +618,17 @@ class ExclusionsModule(BaseModule):
         ),
         certificate: dict[str, Any] | None = Field(
             default=None,
-            description="Certificate dict (issuer, subject, serial, thumbprint, valid_from, valid_to). Required for 'certificate'.",
+            description=(
+                "Certificate dict (issuer, subject, serial, thumbprint, "
+                "valid_from, valid_to). Required for 'certificate'."
+            ),
         ),
         status: str | None = Field(
             default=None,
-            description="Certificate exclusion status: 'enabled' or 'disabled'. Required for 'certificate'.",
+            description=(
+                "Certificate exclusion status: 'enabled' or 'disabled'. "
+                "Required for 'certificate'."
+            ),
         ),
         excluded_from: list[str] | None = Field(
             default=None,
@@ -614,11 +636,17 @@ class ExclusionsModule(BaseModule):
         ),
         is_descendant_process: bool | None = Field(
             default=None,
-            description="Whether the ML exclusion applies to descendant processes. Optional, 'ml' only.",
+            description=(
+                "Whether the ML exclusion applies to descendant processes. "
+                "Optional, 'ml' only."
+            ),
         ),
         host_groups: list[str] | None = Field(
             default=None,
-            description="Host group IDs to scope the exclusion. Required (non-empty) for 'sensor_visibility'; optional for other types.",
+            description=(
+                "Host group IDs to scope the exclusion. Required (non-empty) for "
+                "'sensor_visibility'; optional for other types."
+            ),
         ),
         applied_globally: bool | None = Field(
             default=None,
@@ -736,7 +764,10 @@ class ExclusionsModule(BaseModule):
         ),
         status: str | None = Field(
             default=None,
-            description="Certificate exclusion status: 'enabled' or 'disabled'. Required for 'certificate'.",
+            description=(
+                "Certificate exclusion status: 'enabled' or 'disabled'. "
+                "Required for 'certificate'."
+            ),
         ),
         excluded_from: list[str] | None = Field(
             default=None,
@@ -744,11 +775,17 @@ class ExclusionsModule(BaseModule):
         ),
         is_descendant_process: bool | None = Field(
             default=None,
-            description="Whether the ML exclusion applies to descendant processes. Optional, 'ml' only.",
+            description=(
+                "Whether the ML exclusion applies to descendant processes. "
+                "Optional, 'ml' only."
+            ),
         ),
         host_groups: list[str] | None = Field(
             default=None,
-            description="Host group IDs to scope the exclusion. Required (non-empty) for 'sensor_visibility'; optional for other types.",
+            description=(
+                "Host group IDs to scope the exclusion. Required (non-empty) for "
+                "'sensor_visibility'; optional for other types."
+            ),
         ),
         applied_globally: bool | None = Field(
             default=None,

--- a/falcon_mcp/modules/firewall.py
+++ b/falcon_mcp/modules/firewall.py
@@ -123,8 +123,9 @@ class FirewallModule(BaseModule):
         Use this to find firewall rules by name, platform, or enabled state. Consult
         falcon://firewall/rules/fql-guide before constructing filter expressions.
         Returns complete rule objects including conditions and actions.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions. For cursor-based paging, use `pagination.next` as the `after` parameter on the next call.
         """
-        rule_ids = self._base_search_api_call(
+        rule_ids, pagination = self._base_search_with_meta(
             operation="query_rules",
             search_params={
                 "filter": filter,
@@ -145,7 +146,7 @@ class FirewallModule(BaseModule):
             return [rule_ids]
 
         if not rule_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation="get_rules",
@@ -157,7 +158,8 @@ class FirewallModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order in case get_rules reorders results.
-        return self._reorder_by_ids(rule_ids, details, id_field="id")
+        details = self._reorder_by_ids(rule_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def search_firewall_rule_groups(
         self,
@@ -194,8 +196,9 @@ class FirewallModule(BaseModule):
         Use this to find rule groups by name, platform, or enabled state. Consult
         falcon://firewall/rules/fql-guide before constructing filter expressions.
         Returns rule group objects including their contained rules.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions. For cursor-based paging, use `pagination.next` as the `after` parameter on the next call.
         """
-        rule_group_ids = self._base_search_api_call(
+        rule_group_ids, pagination = self._base_search_with_meta(
             operation="query_rule_groups",
             search_params={
                 "filter": filter,
@@ -216,7 +219,7 @@ class FirewallModule(BaseModule):
             return [rule_group_ids]
 
         if not rule_group_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation="get_rule_groups",
@@ -228,7 +231,8 @@ class FirewallModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order in case get_rule_groups reorders results.
-        return self._reorder_by_ids(rule_group_ids, details, id_field="id")
+        details = self._reorder_by_ids(rule_group_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def search_firewall_policy_rules(
         self,
@@ -263,8 +267,9 @@ class FirewallModule(BaseModule):
         Use this when you need rules scoped to a particular policy. Consult
         falcon://firewall/rules/fql-guide before constructing filter expressions.
         Returns full rule details for the specified policy.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        policy_rule_ids = self._base_search_api_call(
+        policy_rule_ids, pagination = self._base_search_with_meta(
             operation="query_policy_rules",
             search_params={
                 "id": policy_id,
@@ -285,7 +290,7 @@ class FirewallModule(BaseModule):
             return [policy_rule_ids]
 
         if not policy_rule_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation="get_rules",
@@ -297,7 +302,8 @@ class FirewallModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order in case get_rules reorders results.
-        return self._reorder_by_ids(policy_rule_ids, details, id_field="id")
+        details = self._reorder_by_ids(policy_rule_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def create_firewall_rule_group(
         self,

--- a/falcon_mcp/modules/host_groups.py
+++ b/falcon_mcp/modules/host_groups.py
@@ -99,7 +99,10 @@ class HostGroupsModule(BaseModule):
         search_host_groups_fql_resource = TextResource(
             uri=AnyUrl("falcon://host-groups/search/fql-guide"),
             name="falcon_search_host_groups_fql_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_host_groups` tool.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_host_groups` tool."
+            ),
             text=SEARCH_HOST_GROUPS_FQL_DOCUMENTATION,
         )
 
@@ -112,7 +115,10 @@ class HostGroupsModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression. See `falcon://host-groups/search/fql-guide` for syntax.",
+            description=(
+                "FQL filter expression. See `falcon://host-groups/search/fql-guide` "
+                "for syntax."
+            ),
             examples={"group_type:'static'", "name:'Production Servers'"},
         ),
         limit: int = Field(
@@ -151,8 +157,9 @@ class HostGroupsModule(BaseModule):
         falcon://host-groups/search/fql-guide before constructing filter expressions.
         Returns full host group details including id, name, group_type, description,
         and audit metadata in a single call.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        host_groups = self._base_search_api_call(
+        host_groups, pagination = self._base_search_with_meta(
             operation="queryCombinedHostGroups",
             search_params={
                 "filter": filter,
@@ -168,19 +175,22 @@ class HostGroupsModule(BaseModule):
                 [host_groups], filter, SEARCH_HOST_GROUPS_FQL_DOCUMENTATION
             )
 
-        if not host_groups:
-            return self._format_empty_response(filter)
-
-        return host_groups
+        return self._build_pagination_envelope(host_groups or [], pagination, filter)
 
     def search_host_group_members(
         self,
         id: str = Field(
-            description="The host group ID whose members should be retrieved. If you don't already have it, use falcon_search_host_groups to look it up.",
+            description=(
+                "The host group ID whose members should be retrieved. If you don't "
+                "already have it, use falcon_search_host_groups to look it up."
+            ),
         ),
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression on HOST attributes. See `falcon://hosts/search/fql-guide` for syntax.",
+            description=(
+                "FQL filter expression on HOST attributes. See "
+                "`falcon://hosts/search/fql-guide` for syntax."
+            ),
             examples={"platform_name:'Windows'", "hostname:'PC*'"},
         ),
         limit: int = Field(
@@ -205,8 +215,9 @@ class HostGroupsModule(BaseModule):
         `id` and filters on HOST attributes (platform, hostname, etc.) — consult
         falcon://hosts/search/fql-guide for the filter syntax. Returns full host device
         entities including device_id, hostname, platform, and network context.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        members = self._base_search_api_call(
+        members, pagination = self._base_search_with_meta(
             operation="queryCombinedGroupMembers",
             search_params={
                 "id": id,
@@ -221,7 +232,7 @@ class HostGroupsModule(BaseModule):
         if self._is_error(members):
             return [members]
 
-        return members
+        return self._build_pagination_envelope(members or [], pagination, filter)
 
     def create_host_group(
         self,
@@ -229,7 +240,12 @@ class HostGroupsModule(BaseModule):
             description="Name for the new host group.",
         ),
         group_type: str = Field(
-            description="Type of host group. One of: 'static' (hosts added manually by ID via falcon_perform_host_group_action), 'staticByID' (same, populated after creation), or 'dynamic' (hosts matched automatically by an assignment_rule).",
+            description=(
+                "Type of host group. One of: 'static' (hosts added manually by ID "
+                "via falcon_perform_host_group_action), 'staticByID' (same, populated "
+                "after creation), or 'dynamic' (hosts matched automatically by an "
+                "assignment_rule)."
+            ),
         ),
         description: str | None = Field(
             default=None,

--- a/falcon_mcp/modules/hosts.py
+++ b/falcon_mcp/modules/hosts.py
@@ -96,15 +96,16 @@ class HostsModule(BaseModule):
             """).strip(),
             examples={"hostname.asc", "last_seen.desc"},
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for hosts in your CrowdStrike environment.
 
         Use this to find devices by hostname, platform, IP, sensor version, or other
         attributes. Consult falcon://hosts/search/fql-guide before constructing filter
         expressions. Returns full host details including device info, OS, and network
         context.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        device_ids = self._base_search_api_call(
+        device_ids, pagination = self._base_search_with_meta(
             operation="QueryDevicesByFilter",
             search_params={
                 "filter": filter,
@@ -115,29 +116,25 @@ class HostsModule(BaseModule):
             error_message="Failed to search hosts",
         )
 
-        # If handle_api_response returns an error dict instead of a list,
-        # it means there was an error, so we return it wrapped in a list
         if self._is_error(device_ids):
             return [device_ids]
 
-        # If we have device IDs, get the details for each one
-        if device_ids:
-            details = self._base_get_by_ids(
-                operation="PostDeviceDetailsV2",
-                ids=device_ids,
-                id_key="ids",
-            )
+        if not device_ids:
+            return self._build_pagination_envelope([], pagination, filter)
 
-            # If handle_api_response returns an error dict instead of a list,
-            # it means there was an error, so we return it wrapped in a list
-            if self._is_error(details):
-                return [details]
+        details = self._base_get_by_ids(
+            operation="PostDeviceDetailsV2",
+            ids=device_ids,
+            id_key="ids",
+        )
 
-            # Restore the query-step sort order in case the details endpoint
-            # returns entities in a different order (validated field: device_id).
-            return self._reorder_by_ids(device_ids, details, id_field="device_id")
+        if self._is_error(details):
+            return [details]
 
-        return []
+        # Restore the query-step sort order in case the details endpoint
+        # returns entities in a different order (validated field: device_id).
+        details = self._reorder_by_ids(device_ids, details, id_field="device_id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def get_host_details(
         self,

--- a/falcon_mcp/modules/intel.py
+++ b/falcon_mcp/modules/intel.py
@@ -65,21 +65,30 @@ class IntelModule(BaseModule):
         search_actors_fql_resource = TextResource(
             uri=AnyUrl("falcon://intel/actors/fql-guide"),
             name="falcon_search_actors_fql_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_actors` tool.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_actors` tool."
+            ),
             text=QUERY_ACTOR_ENTITIES_FQL_DOCUMENTATION,
         )
 
         search_indicators_fql_resource = TextResource(
             uri=AnyUrl("falcon://intel/indicators/fql-guide"),
             name="falcon_search_indicators_fql_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_indicators` tool.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_indicators` tool."
+            ),
             text=QUERY_INDICATOR_ENTITIES_FQL_DOCUMENTATION,
         )
 
         search_reports_fql_resource = TextResource(
             uri=AnyUrl("falcon://intel/reports/fql-guide"),
             name="falcon_search_reports_fql_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_reports` tool.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_reports` tool."
+            ),
             text=QUERY_REPORT_ENTITIES_FQL_DOCUMENTATION,
         )
 
@@ -100,7 +109,9 @@ class IntelModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression. See `falcon://intel/actors/fql-guide` for syntax.",
+            description=(
+                "FQL filter expression. See `falcon://intel/actors/fql-guide` for syntax."
+            ),
         ),
         limit: int = Field(
             default=10,
@@ -116,7 +127,12 @@ class IntelModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="The field and direction to sort results on. The format is {field}|{asc/desc}. Valid values include: name, target_countries, target_industries, type, created_date, last_activity_date and last_modified_date. Ex: created_date|desc",
+            description=(
+                "The field and direction to sort results on. The format is "
+                "{field}|{asc/desc}. Valid values include: name, target_countries, "
+                "target_industries, type, created_date, last_activity_date and "
+                "last_modified_date. Ex: created_date|desc"
+            ),
             examples={"created_date|desc"},
         ),
         q: str | None = Field(
@@ -124,14 +140,15 @@ class IntelModule(BaseModule):
             description="Free text search across all indexed fields.",
             examples={"BEAR"},
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Research threat actors and adversary groups tracked by CrowdStrike intelligence.
 
         Use this to search actors by name, target countries/industries, or activity dates.
         Consult falcon://intel/actors/fql-guide before constructing filter expressions.
         Returns full actor profiles including aliases, motivations, and targeting details.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        api_response = self._base_search_api_call(
+        api_response, pagination = self._base_search_with_meta(
             operation="QueryIntelActorEntities",
             search_params={
                 "filter": filter,
@@ -146,13 +163,16 @@ class IntelModule(BaseModule):
         if self._is_error(api_response):
             return [api_response]
 
-        return api_response
+        return self._build_pagination_envelope(api_response or [], pagination, filter)
 
     def query_indicator_entities(
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression. See `falcon://intel/indicators/fql-guide` for syntax.",
+            description=(
+                "FQL filter expression. See `falcon://intel/indicators/fql-guide` "
+                "for syntax."
+            ),
         ),
         limit: int = Field(
             default=10,
@@ -166,7 +186,11 @@ class IntelModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="The field and direction to sort results on. The format is {field}|{asc/desc}. Valid values are: id, indicator, type, published_date, last_updated, and _marker. Ex: published_date|desc",
+            description=(
+                "The field and direction to sort results on. The format is "
+                "{field}|{asc/desc}. Valid values are: id, indicator, type, "
+                "published_date, last_updated, and _marker. Ex: published_date|desc"
+            ),
             examples={"published_date|desc"},
         ),
         q: str | None = Field(
@@ -175,20 +199,27 @@ class IntelModule(BaseModule):
         ),
         include_deleted: bool = Field(
             default=False,
-            description="Flag indicating if both published and deleted indicators should be returned.",
+            description=(
+                "Flag indicating if both published and deleted indicators "
+                "should be returned."
+            ),
         ),
         include_relations: bool = Field(
             default=False,
-            description="Flag indicating if related indicators should be returned.",
+            description=(
+                "Flag indicating if related indicators should be returned."
+            ),
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for threat indicators and IOCs from CrowdStrike intelligence.
 
         Use this to find indicators by type, publish date, malware family, or threat actor
         association. Consult falcon://intel/indicators/fql-guide before constructing filter
-        expressions. Returns full indicator details including labels, relations, and kill chain stage.
+        expressions. Returns full indicator details including labels, relations, and kill
+        chain stage.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        api_response = self._base_search_api_call(
+        api_response, pagination = self._base_search_with_meta(
             operation="QueryIntelIndicatorEntities",
             search_params={
                 "filter": filter,
@@ -205,13 +236,15 @@ class IntelModule(BaseModule):
         if self._is_error(api_response):
             return [api_response]
 
-        return api_response
+        return self._build_pagination_envelope(api_response or [], pagination, filter)
 
     def query_report_entities(
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression. See `falcon://intel/reports/fql-guide` for syntax.",
+            description=(
+                "FQL filter expression. See `falcon://intel/reports/fql-guide` for syntax."
+            ),
         ),
         limit: int = Field(
             default=10,
@@ -225,21 +258,27 @@ class IntelModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="The field and direction to sort results on in the format of: {field}.{asc}or {field}.{desc}. Valid values include: name, target_countries, target_industries, type, created_date, last_modified_date. Ex: created_date|desc",
+            description=(
+                "The field and direction to sort results on in the format of: "
+                "{field}.{asc}or {field}.{desc}. Valid values include: name, "
+                "target_countries, target_industries, type, created_date, "
+                "last_modified_date. Ex: created_date|desc"
+            ),
             examples={"created_date|desc"},
         ),
         q: str | None = Field(
             default=None,
             description="Free text search across all indexed fields.",
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search CrowdStrike intelligence publications and threat reports.
 
         Use this to find reports by name, target industry, threat type, or publication date.
         Consult falcon://intel/reports/fql-guide before constructing filter expressions.
         Returns full report metadata including title, description, and target details.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        api_response = self._base_search_api_call(
+        api_response, pagination = self._base_search_with_meta(
             operation="QueryIntelReportEntities",
             search_params={
                 "filter": filter,
@@ -251,12 +290,10 @@ class IntelModule(BaseModule):
             error_message="Failed to search reports",
         )
 
-        # If handle_api_response returns an error dict instead of a list,
-        # it means there was an error, so we return it wrapped in a list
         if self._is_error(api_response):
             return [api_response]
 
-        return api_response
+        return self._build_pagination_envelope(api_response or [], pagination, filter)
 
     def get_mitre_report(
         self,
@@ -314,7 +351,10 @@ class IntelModule(BaseModule):
             if not actor_id or actor_id == 'None':
                 return [{
                     "error": "Invalid actor data",
-                    "message": f"Found actor '{selected_actor.get('name', 'Unknown')}' but missing ID field",
+                    "message": (
+                        f"Found actor '{selected_actor.get('name', 'Unknown')}'"
+                        " but missing ID field"
+                    ),
                     "actor_data": selected_actor
                 }]
 

--- a/falcon_mcp/modules/ioc.py
+++ b/falcon_mcp/modules/ioc.py
@@ -123,8 +123,9 @@ class IOCModule(BaseModule):
         Use this to find IOCs by type, value, action, severity, or expiration status.
         Consult falcon://ioc/search/fql-guide before constructing filter expressions.
         Returns full indicator records including metadata, platforms, and host groups.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions. For cursor-based paging, use `pagination.next` as the `after` parameter on the next call.
         """
-        indicator_ids = self._base_search_api_call(
+        indicator_ids, pagination = self._base_search_with_meta(
             operation="indicator_search_v1",
             search_params={
                 "filter": filter,
@@ -143,7 +144,7 @@ class IOCModule(BaseModule):
             )
 
         if not indicator_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation="indicator_get_v1",
@@ -155,7 +156,8 @@ class IOCModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order if the details endpoint reorders results.
-        return self._reorder_by_ids(indicator_ids, details, id_field="id")
+        details = self._reorder_by_ids(indicator_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def add_ioc(
         self,

--- a/falcon_mcp/modules/policies.py
+++ b/falcon_mcp/modules/policies.py
@@ -410,6 +410,7 @@ class PoliciesModule(BaseModule):
         filter expressions; the `name` match operator differs per type. Returns
         full policy records including id, name, platform_name, enabled, settings,
         and assigned host groups.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
         type_error = self._validate_policy_type(policy_type)
         if type_error is not None:
@@ -431,7 +432,7 @@ class PoliciesModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Dispatch search to the combined op or the device_control two-step flow."""
         if self._SEARCH_MODE[policy_type] == "two_step":
-            ids = self._base_search_api_call(
+            ids, pagination = self._base_search_with_meta(
                 operation=self._OPERATIONS[policy_type]["query"],
                 search_params={
                     "filter": filter,
@@ -448,9 +449,7 @@ class PoliciesModule(BaseModule):
                 )
 
             if not ids:
-                return self._format_fql_error_response(
-                    [], filter, SEARCH_POLICIES_FQL_DOCUMENTATION
-                )
+                return self._build_pagination_envelope([], pagination, filter)
 
             details = self._base_get_by_ids(
                 operation=self._OPERATIONS[policy_type]["get"],
@@ -462,10 +461,11 @@ class PoliciesModule(BaseModule):
                 return [details]
 
             # Restore the query-step sort order in case the get endpoint reorders results.
-            return self._reorder_by_ids(ids, details, id_field="id")
+            details = self._reorder_by_ids(ids, details, id_field="id")
+            return self._build_pagination_envelope(details, pagination, filter)
 
         # Combined single-call path for the other five types.
-        policies = self._base_search_api_call(
+        policies, pagination = self._base_search_with_meta(
             operation=self._OPERATIONS[policy_type]["combined"],
             search_params={
                 "filter": filter,
@@ -481,12 +481,7 @@ class PoliciesModule(BaseModule):
                 [policies], filter, SEARCH_POLICIES_FQL_DOCUMENTATION
             )
 
-        if not policies:
-            return self._format_fql_error_response(
-                [], filter, SEARCH_POLICIES_FQL_DOCUMENTATION
-            )
-
-        return policies
+        return self._build_pagination_envelope(policies or [], pagination, filter)
 
     # ---- Members ------------------------------------------------------------------
 
@@ -531,6 +526,7 @@ class PoliciesModule(BaseModule):
         falcon://hosts/search/fql-guide for the filter syntax. Returns full host
         device entities including device_id, hostname, platform_name, and network
         context.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
         type_error = self._validate_policy_type(policy_type)
         if type_error is not None:
@@ -544,7 +540,7 @@ class PoliciesModule(BaseModule):
                 )
             ]
 
-        members = self._base_search_api_call(
+        members, pagination = self._base_search_with_meta(
             operation=self._OPERATIONS[policy_type]["members"],
             search_params={
                 "id": id,
@@ -559,7 +555,7 @@ class PoliciesModule(BaseModule):
         if self._is_error(members):
             return [members]
 
-        return members
+        return self._build_pagination_envelope(members or [], pagination, filter)
 
     # ---- Body builder -------------------------------------------------------------
 

--- a/falcon_mcp/modules/quarantine.py
+++ b/falcon_mcp/modules/quarantine.py
@@ -110,8 +110,9 @@ class QuarantineModule(BaseModule):
         Consult falcon://quarantine/files/search/fql-guide before constructing
         filter expressions. Returns full quarantine details including hostname,
         sha256, paths, state, and associated alert and detection IDs.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        file_ids = self._base_search_api_call(
+        file_ids, pagination = self._base_search_with_meta(
             operation="QueryQuarantineFiles",
             search_params={
                 "filter": filter,
@@ -120,7 +121,6 @@ class QuarantineModule(BaseModule):
                 "sort": sort,
             },
             error_message="Failed to search quarantined files",
-            default_result=[],
         )
 
         if self._is_error(file_ids):
@@ -129,7 +129,7 @@ class QuarantineModule(BaseModule):
             )
 
         if not file_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation="GetQuarantineFiles",
@@ -140,7 +140,8 @@ class QuarantineModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order if the details endpoint reorders results.
-        return self._reorder_by_ids(file_ids, details, id_field="id")
+        details = self._reorder_by_ids(file_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def preview_quarantine_actions(
         self,

--- a/falcon_mcp/modules/recon.py
+++ b/falcon_mcp/modules/recon.py
@@ -61,7 +61,10 @@ class ReconModule(BaseModule):
             TextResource(
                 uri=AnyUrl("falcon://recon/notifications/search/fql-guide"),
                 name="falcon_search_recon_notifications_fql_guide",
-                description="Contains the guide for the `filter` param of the `falcon_search_recon_notifications` tool.",
+                description=(
+                    "Contains the guide for the `filter` param of the "
+                    "`falcon_search_recon_notifications` tool."
+                ),
                 text=SEARCH_RECON_NOTIFICATIONS_FQL_DOCUMENTATION,
             ),
         )
@@ -71,7 +74,10 @@ class ReconModule(BaseModule):
             TextResource(
                 uri=AnyUrl("falcon://recon/rules/search/fql-guide"),
                 name="falcon_search_recon_rules_fql_guide",
-                description="Contains the guide for the `filter` param of the `falcon_search_recon_rules` tool.",
+                description=(
+                    "Contains the guide for the `filter` param of the "
+                    "`falcon_search_recon_rules` tool."
+                ),
                 text=SEARCH_RECON_RULES_FQL_DOCUMENTATION,
             ),
         )
@@ -81,7 +87,10 @@ class ReconModule(BaseModule):
             TextResource(
                 uri=AnyUrl("falcon://recon/exposed-data-records/search/fql-guide"),
                 name="falcon_search_recon_exposed_data_records_fql_guide",
-                description="Contains the guide for the `filter` param of the `falcon_search_recon_exposed_data_records` tool.",
+                description=(
+                    "Contains the guide for the `filter` param of the "
+                    "`falcon_search_recon_exposed_data_records` tool."
+                ),
                 text=SEARCH_RECON_EXPOSED_DATA_RECORDS_FQL_DOCUMENTATION,
             ),
         )
@@ -90,7 +99,10 @@ class ReconModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression. See `falcon://recon/notifications/search/fql-guide` for syntax.",
+            description=(
+                "FQL filter expression. See "
+                "`falcon://recon/notifications/search/fql-guide` for syntax."
+            ),
             examples=[
                 "status:'new'+rule_priority:'high'",
                 "item_site:'telegram.org'",
@@ -105,7 +117,10 @@ class ReconModule(BaseModule):
             default=10,
             ge=1,
             le=500,
-            description="Maximum number of notifications to return (default: 10; max: 500). offset + limit must not exceed 10,000.",
+            description=(
+                "Maximum number of notifications to return (default: 10; max: 500). "
+                "offset + limit must not exceed 10,000."
+            ),
         ),
         offset: int | None = Field(
             default=None,
@@ -124,7 +139,8 @@ class ReconModule(BaseModule):
             examples=["created_date|desc", "updated_date|asc"],
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Search Falcon Intelligence Recon notifications (also called recon alerts) and return their full details.
+        """Search Falcon Intelligence Recon notifications (also called recon alerts)
+        and return their full details.
 
         Use this for dark web matches, leaked credentials, typosquatting matches, and breach
         summaries triggered by your monitoring rules. Consult
@@ -133,13 +149,14 @@ class ReconModule(BaseModule):
         Operations (CAO). For endpoint, XDR, or NG-SIEM alerts, use `falcon_search_detections`
         instead. Returns full notification records with a nested `notification` object
         containing status, rule metadata, breach_summary, and item details.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
         logger.debug(
             "Searching recon notifications with filter=%s, q=%s, limit=%s, offset=%s, sort=%s",
             filter, q, limit, offset, sort,
         )
 
-        notification_ids = self._base_search_api_call(
+        notification_ids, pagination = self._base_search_with_meta(
             operation="QueryNotificationsV1",
             search_params={
                 "filter": filter,
@@ -157,7 +174,7 @@ class ReconModule(BaseModule):
             )
 
         if not notification_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation="GetNotificationsDetailedV1",
@@ -169,13 +186,17 @@ class ReconModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order; GetNotificationsDetailedV1 may reorder.
-        return self._reorder_by_ids(notification_ids, details, id_field="id")
+        details = self._reorder_by_ids(notification_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def search_recon_rules(
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression. See `falcon://recon/rules/search/fql-guide` for syntax.",
+            description=(
+                "FQL filter expression. See `falcon://recon/rules/search/fql-guide` "
+                "for syntax."
+            ),
             examples=[
                 "status:'active'+priority:'high'",
                 "topic:'SA_TYPOSQUATTING'",
@@ -190,7 +211,10 @@ class ReconModule(BaseModule):
             default=10,
             ge=1,
             le=500,
-            description="Maximum number of rules to return (default: 10; max: 500). offset + limit must not exceed 10,000.",
+            description=(
+                "Maximum number of rules to return (default: 10; max: 500). "
+                "offset + limit must not exceed 10,000."
+            ),
         ),
         offset: int | None = Field(
             default=None,
@@ -219,13 +243,14 @@ class ReconModule(BaseModule):
         constructing filter expressions. These monitoring rules power the external cyber risk
         monitoring capability of CrowdStrike Counter Adversary Operations (CAO). Returns full
         rule definitions including topic, priority, filter expressions, and notification settings.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
         logger.debug(
             "Searching recon rules with filter=%s, q=%s, limit=%s, offset=%s, sort=%s",
             filter, q, limit, offset, sort,
         )
 
-        rule_ids = self._base_search_api_call(
+        rule_ids, pagination = self._base_search_with_meta(
             operation="QueryRulesV1",
             search_params={
                 "filter": filter,
@@ -243,7 +268,7 @@ class ReconModule(BaseModule):
             )
 
         if not rule_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation="GetRulesV1",
@@ -255,13 +280,17 @@ class ReconModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order in case GetRulesV1 reorders results.
-        return self._reorder_by_ids(rule_ids, details, id_field="id")
+        details = self._reorder_by_ids(rule_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def search_recon_exposed_data_records(
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression. See `falcon://recon/exposed-data-records/search/fql-guide` for syntax.",
+            description=(
+                "FQL filter expression. See "
+                "`falcon://recon/exposed-data-records/search/fql-guide` for syntax."
+            ),
             examples=[
                 "domain:'example.com'+credential_status:'confirmed_active'",
                 "notification_id:'abc123def456'",
@@ -276,7 +305,10 @@ class ReconModule(BaseModule):
             default=10,
             ge=1,
             le=500,
-            description="Maximum number of records to return (default: 10; max: 500). offset + limit must not exceed 10,000.",
+            description=(
+                "Maximum number of records to return (default: 10; max: 500). "
+                "offset + limit must not exceed 10,000."
+            ),
         ),
         offset: int | None = Field(
             default=None,
@@ -303,13 +335,15 @@ class ReconModule(BaseModule):
         expressions. These records are part of the external cyber risk monitoring capability of
         CrowdStrike Counter Adversary Operations (CAO). Returns full records including credential
         fields, location data, and associated notification context.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
         logger.debug(
-            "Searching recon exposed-data records with filter=%s, q=%s, limit=%s, offset=%s, sort=%s",
+            "Searching recon exposed-data records with filter=%s, q=%s, limit=%s, "
+            "offset=%s, sort=%s",
             filter, q, limit, offset, sort,
         )
 
-        record_ids = self._base_search_api_call(
+        record_ids, pagination = self._base_search_with_meta(
             operation="QueryNotificationsExposedDataRecordsV1",
             search_params={
                 "filter": filter,
@@ -327,7 +361,7 @@ class ReconModule(BaseModule):
             )
 
         if not record_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation="GetNotificationsExposedDataRecordsV1",
@@ -339,4 +373,5 @@ class ReconModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order; the exposed-data details endpoint may reorder.
-        return self._reorder_by_ids(record_ids, details, id_field="id")
+        details = self._reorder_by_ids(record_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -144,7 +144,10 @@ class RTRModule(BaseModule):
         search_rtr_sessions_fql_resource = TextResource(
             uri=AnyUrl("falcon://rtr/sessions/search/fql-guide"),
             name="falcon_search_rtr_sessions_fql_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_rtr_sessions` tool.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_rtr_sessions` tool."
+            ),
             text=SEARCH_RTR_SESSIONS_FQL_DOCUMENTATION,
         )
 
@@ -156,7 +159,10 @@ class RTRModule(BaseModule):
         search_rtr_audit_sessions_fql_resource = TextResource(
             uri=AnyUrl("falcon://rtr/audit/sessions/search/fql-guide"),
             name="falcon_search_rtr_audit_sessions_fql_guide",
-            description="Contains the guide for the `filter` param of the `falcon_search_rtr_audit_sessions` tool.",
+            description=(
+                "Contains the guide for the `filter` param of the "
+                "`falcon_search_rtr_audit_sessions` tool."
+            ),
             text=SEARCH_RTR_AUDIT_SESSIONS_FQL_DOCUMENTATION,
         )
 
@@ -168,7 +174,10 @@ class RTRModule(BaseModule):
         aggregate_rtr_sessions_resource = TextResource(
             uri=AnyUrl("falcon://rtr/sessions/aggregate-guide"),
             name="falcon_aggregate_rtr_sessions_guide",
-            description="Explains how to summarize RTR session activity with the `falcon_aggregate_rtr_sessions` tool.",
+            description=(
+                "Explains how to summarize RTR session activity with the "
+                "`falcon_aggregate_rtr_sessions` tool."
+            ),
             text=AGGREGATE_RTR_SESSIONS_GUIDE,
         )
 
@@ -193,7 +202,10 @@ class RTRModule(BaseModule):
         self,
         filter: str | None = Field(
             default=None,
-            description="FQL filter expression. See `falcon://rtr/sessions/search/fql-guide` for syntax.",
+            description=(
+                "FQL filter expression. See `falcon://rtr/sessions/search/fql-guide` "
+                "for syntax."
+            ),
             examples=["hostname:'BRR-WB-LIB-22'", "aid:'2c5c4e7738...'"],
         ),
         limit: int = Field(
@@ -220,8 +232,9 @@ class RTRModule(BaseModule):
         Use this to find sessions by hostname, agent ID, user, or creation time. Consult
         falcon://rtr/sessions/search/fql-guide before constructing filter expressions.
         Returns session metadata including host info, commands executed, and status.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        session_ids = self._base_search_api_call(
+        session_ids, pagination = self._base_search_with_meta(
             operation="RTR_ListAllSessions",
             search_params={
                 "filter": filter,
@@ -238,7 +251,7 @@ class RTRModule(BaseModule):
             )
 
         if not session_ids:
-            return self._format_empty_response(filter)
+            return self._build_pagination_envelope([], pagination, filter)
 
         details = self._base_get_by_ids(
             operation="RTR_ListSessions",
@@ -251,7 +264,8 @@ class RTRModule(BaseModule):
             return [details]
 
         # Restore the query-step sort order in case RTR_ListSessions reorders results.
-        return self._reorder_by_ids(session_ids, details, id_field="id")
+        details = self._reorder_by_ids(session_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def search_audit_sessions(
         self,
@@ -291,8 +305,9 @@ class RTRModule(BaseModule):
         This is read-only audit visibility; it does not open sessions or run
         commands. Consult falcon://rtr/audit/sessions/search/fql-guide before
         constructing filter expressions.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        audit_sessions = self._base_search_api_call(
+        audit_sessions, pagination = self._base_search_with_meta(
             operation="RTRAuditSessions",
             search_params={
                 "filter": filter,
@@ -309,20 +324,23 @@ class RTRModule(BaseModule):
                 [audit_sessions], filter, SEARCH_RTR_AUDIT_SESSIONS_FQL_DOCUMENTATION
             )
 
-        if not audit_sessions:
-            return self._format_empty_response(filter)
-
-        return audit_sessions
+        return self._build_pagination_envelope(audit_sessions or [], pagination, filter)
 
     def aggregate_sessions(
         self,
         field: str = Field(
-            description="RTR session field to aggregate, such as `hostname`, `user_id`, `origin`, `base_command`, or `created_at`.",
+            description=(
+                "RTR session field to aggregate, such as `hostname`, `user_id`, "
+                "`origin`, `base_command`, or `created_at`."
+            ),
             examples=["base_command", "hostname", "user_id", "created_at"],
         ),
         aggregate_type: Literal["terms", "date_range"] = Field(
             default="terms",
-            description="Aggregation type to run. Use `terms` for top values and `date_range` for time buckets.",
+            description=(
+                "Aggregation type to run. Use `terms` for top values and "
+                "`date_range` for time buckets."
+            ),
         ),
         name: str = Field(
             default="rtr_session_aggregation",
@@ -346,7 +364,10 @@ class RTRModule(BaseModule):
         ),
         date_ranges: list[dict[str, str]] | None = Field(
             default=None,
-            description="Date ranges for date_range aggregations, for example `[{'from': 'now-7d', 'to': 'now'}]`.",
+            description=(
+                "Date ranges for date_range aggregations, for example "
+                "`[{'from': 'now-7d', 'to': 'now'}]`."
+            ),
             examples=[[{"from": "now-7d", "to": "now"}]],
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
@@ -479,15 +500,24 @@ class RTRModule(BaseModule):
     def execute_read_only_command(
         self,
         session_id: str = Field(
-            description="RTR session ID returned from falcon_init_rtr_session or falcon_search_rtr_sessions.",
+            description=(
+                "RTR session ID returned from falcon_init_rtr_session or "
+                "falcon_search_rtr_sessions."
+            ),
         ),
         base_command: str = Field(
-            description="Read-only RTR base command to execute, such as `ls`, `ps`, `cat`, `filehash`, or `reg`.",
+            description=(
+                "Read-only RTR base command to execute, such as `ls`, `ps`, `cat`, "
+                "`filehash`, or `reg`."
+            ),
             examples=["ls", "ps", "filehash"],
         ),
         command_string: str | None = Field(
             default=None,
-            description="Optional full command line to execute. Example: `cat C:\\Windows\\win.ini`.",
+            description=(
+                "Optional full command line to execute. Example: "
+                "`cat C:\\Windows\\win.ini`."
+            ),
         ),
         persist: bool = Field(
             default=False,
@@ -539,15 +569,24 @@ class RTRModule(BaseModule):
     def run_read_only_command_and_wait(
         self,
         session_id: str = Field(
-            description="RTR session ID returned from falcon_init_rtr_session or falcon_search_rtr_sessions.",
+            description=(
+                "RTR session ID returned from falcon_init_rtr_session or "
+                "falcon_search_rtr_sessions."
+            ),
         ),
         base_command: str = Field(
-            description="Read-only RTR base command to execute, such as `ls`, `ps`, `cat`, `filehash`, or `reg`.",
+            description=(
+                "Read-only RTR base command to execute, such as `ls`, `ps`, `cat`, "
+                "`filehash`, or `reg`."
+            ),
             examples=["ls", "ps", "filehash"],
         ),
         command_string: str | None = Field(
             default=None,
-            description="Optional full command line to execute. Example: `cat C:\\Windows\\win.ini`.",
+            description=(
+                "Optional full command line to execute. Example: "
+                "`cat C:\\Windows\\win.ini`."
+            ),
         ),
         persist: bool = Field(
             default=False,

--- a/falcon_mcp/modules/scheduled_reports.py
+++ b/falcon_mcp/modules/scheduled_reports.py
@@ -115,14 +115,15 @@ class ScheduledReportsModule(BaseModule):
             default=None,
             description="Free-text search for terms in id, name, description, type, status fields",
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for scheduled reports and searches in your CrowdStrike environment.
 
         Use this to find reports by status, type, creator, or creation date. Consult
         falcon://scheduled-reports/search/fql-guide before constructing filter expressions.
         Returns full report/search entity details including schedule configuration.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        report_ids = self._base_search_api_call(
+        report_ids, pagination = self._base_search_with_meta(
             operation="scheduled_reports_query",
             search_params={
                 "filter": filter,
@@ -132,27 +133,26 @@ class ScheduledReportsModule(BaseModule):
                 "q": q,
             },
             error_message="Failed to search for scheduled reports",
-            default_result=[],
         )
 
         if self._is_error(report_ids):
             return [report_ids]
 
-        # If we have report IDs, get the full details for each one
-        if report_ids:
-            details = self._base_get_by_ids(
-                operation="scheduled_reports_get",
-                ids=report_ids,
-                use_params=True,
-            )
+        if not report_ids:
+            return self._build_pagination_envelope([], pagination, filter)
 
-            if self._is_error(details):
-                return [details]
+        details = self._base_get_by_ids(
+            operation="scheduled_reports_get",
+            ids=report_ids,
+            use_params=True,
+        )
 
-            # Restore the query-step sort order if the get endpoint reorders results.
-            return self._reorder_by_ids(report_ids, details, id_field="id")
+        if self._is_error(details):
+            return [details]
 
-        return []
+        # Restore the query-step sort order if the get endpoint reorders results.
+        details = self._reorder_by_ids(report_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def launch_scheduled_report(
         self,
@@ -207,14 +207,15 @@ class ScheduledReportsModule(BaseModule):
             default=None,
             description="Property to sort by. Ex: created_on.asc, last_updated_on.desc",
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for report/search execution history.
 
         Use this to find executions by status, report ID, or completion date. Consult
         falcon://scheduled-reports/executions/search/fql-guide before constructing filter
         expressions. Returns full execution details including status and timestamps.
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions.
         """
-        execution_ids = self._base_search_api_call(
+        execution_ids, pagination = self._base_search_with_meta(
             operation="report_executions_query",
             search_params={
                 "filter": filter,
@@ -223,27 +224,26 @@ class ScheduledReportsModule(BaseModule):
                 "sort": sort,
             },
             error_message="Failed to search for report executions",
-            default_result=[],
         )
 
         if self._is_error(execution_ids):
             return [execution_ids]
 
-        # If we have execution IDs, get the full details for each one
-        if execution_ids:
-            details = self._base_get_by_ids(
-                operation="report_executions_get",
-                ids=execution_ids,
-                use_params=True,
-            )
+        if not execution_ids:
+            return self._build_pagination_envelope([], pagination, filter)
 
-            if self._is_error(details):
-                return [details]
+        details = self._base_get_by_ids(
+            operation="report_executions_get",
+            ids=execution_ids,
+            use_params=True,
+        )
 
-            # Restore the query-step sort order if the get endpoint reorders results.
-            return self._reorder_by_ids(execution_ids, details, id_field="id")
+        if self._is_error(details):
+            return [details]
 
-        return []
+        # Restore the query-step sort order if the get endpoint reorders results.
+        details = self._reorder_by_ids(execution_ids, details, id_field="id")
+        return self._build_pagination_envelope(details, pagination, filter)
 
     def download_report_execution(
         self,

--- a/falcon_mcp/modules/shield.py
+++ b/falcon_mcp/modules/shield.py
@@ -34,16 +34,16 @@ class ShieldModule(BaseModule):
     def _format_empty_or_error(
         self,
         results: list[Any],
+        pagination: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if results and "error" in results[0]:
             hint = "Query error occurred. Review your parameters using the query guide."
         else:
             hint = "No results matched your query. Review available parameters in the query guide."
-        return {
-            "results": results,
-            "query_guide": SHIELD_QUERY_DOCUMENTATION,
-            "hint": hint,
-        }
+        envelope = self._build_pagination_envelope(results, pagination)
+        envelope["query_guide"] = SHIELD_QUERY_DOCUMENTATION
+        envelope["hint"] = hint
+        return envelope
 
     def _search_with_docs(
         self,
@@ -51,16 +51,16 @@ class ShieldModule(BaseModule):
         search_params: dict[str, Any],
         error_message: str,
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        result = self._base_search_api_call(
+        result, pagination = self._base_search_with_meta(
             operation=operation,
             search_params=search_params,
             error_message=error_message,
         )
         if self._is_error(result):
-            return self._format_empty_or_error([result])
+            return self._format_empty_or_error([result], pagination)
         if not result:
-            return self._format_empty_or_error([])
-        return result
+            return self._format_empty_or_error([], pagination)
+        return self._build_pagination_envelope(result, pagination)
 
     def register_tools(self, server: FastMCP) -> None:
         self._add_tool(
@@ -217,7 +217,8 @@ class ShieldModule(BaseModule):
 
         Use this to find specific failing checks by status, impact, integration, or type; consult
         falcon://shield/search/query-guide for valid filter values. Returns check records containing
-        id, name, status, impact level, affected entity count, and remediation plan."""
+        id, name, status, impact level, affected entity count, and remediation plan.
+        """
         return self._search_with_docs(
             operation="GetSecurityChecksV3",
             search_params={
@@ -255,7 +256,8 @@ class ShieldModule(BaseModule):
         """Retrieve the specific entities (users, apps, or devices) that are violating a given Falcon Shield posture check.
 
         Use this after `search_shield_checks` to drill into which entities are failing a specific check. Returns entity
-        objects with entity name, type, and relevant security details."""
+        objects with entity name, type, and relevant security details.
+        """
         return self._search_with_docs(
             operation="GetSecurityCheckAffectedV3",
             search_params={"id": id, "limit": limit, "offset": offset},
@@ -307,7 +309,8 @@ class ShieldModule(BaseModule):
 
         Use this for a high-level overview of your SaaS security posture; for individual check records
         with remediation details, use `search_shield_checks` instead. Returns total check counts, overall
-        score percentage, and a breakdown of checks by status across connected SaaS applications."""
+        score percentage, and a breakdown of checks by status across connected SaaS applications.
+        """
         return self._search_with_docs(
             operation="GetMetricsV3",
             search_params={
@@ -332,7 +335,8 @@ class ShieldModule(BaseModule):
 
         Use this after `search_shield_checks` to understand the regulatory impact of a failing check.
         Returns compliance objects identifying the framework (e.g., SOC 2, CIS, NIST, PCI DSS),
-        control ID, and control description that the check satisfies."""
+        control ID, and control description that the check satisfies.
+        """
         return self._search_with_docs(
             operation="GetSecurityCheckComplianceV3",
             search_params={"id": id},
@@ -389,7 +393,8 @@ class ShieldModule(BaseModule):
 
         Use this to find configuration drift, degraded checks, integration failures, or active threats;
         use last_id from the last result for cursor-based pagination or offset for offset-based pagination.
-        Returns alert objects containing id, type, integration details, timestamp, and severity."""
+        Returns alert objects containing id, type, integration details, timestamp, and severity.
+        """
         return self._search_with_docs(
             operation="GetAlertsV3",
             search_params={
@@ -462,7 +467,8 @@ class ShieldModule(BaseModule):
         Use this to investigate user activity, threats, or IoC events across connected SaaS platforms;
         when filtering by integration_id, category, or actor, the date range must be within 24 hours.
         Returns activity event objects including timestamp, event name, actor identity, integration,
-        category, and location details."""
+        category, and location details. This endpoint does not report a total count, so `pagination.total`
+        is always null — page through results with `pagination.next`/`skip` rather than asking "how many"."""
         return self._search_with_docs(
             operation="GetActivityMonitorV3",
             search_params={
@@ -513,7 +519,8 @@ class ShieldModule(BaseModule):
         Use this to audit user access across your SaaS estate or identify over-privileged or stale accounts;
         for Shield platform administrators instead of SaaS app end-users, use `get_shield_system_users`.
         Returns user objects containing email, display name, connected application details, privilege status,
-        and exposure metrics."""
+        and exposure metrics.
+        """
         return self._search_with_docs(
             operation="GetUserInventoryV3",
             search_params={
@@ -564,7 +571,8 @@ class ShieldModule(BaseModule):
 
         Use this to identify unmanaged or unassociated devices in your SaaS estate; note that this returns
         devices from SaaS provider records, not Falcon sensor inventory — use `search_hosts` for that.
-        Returns device objects containing device name, owner email, compliance posture, and management status."""
+        Returns device objects containing device name, owner email, compliance posture, and management status.
+        """
         return self._search_with_docs(
             operation="GetDeviceInventoryV3",
             search_params={
@@ -640,7 +648,8 @@ class ShieldModule(BaseModule):
 
         Use this to audit app access across your SaaS estate; use the item_id from results with
         `get_shield_app_users` to see who authorized a specific app. Returns app objects containing
-        item_id, name, type, status, access_level, granted scopes, and user count."""
+        item_id, name, type, status, access_level, granted scopes, and user count.
+        """
         return self._search_with_docs(
             operation="GetAppInventory",
             search_params={
@@ -670,7 +679,8 @@ class ShieldModule(BaseModule):
         """Retrieve the users who have authorized or are associated with a specific third-party app in Falcon Shield.
 
         Use this after `search_shield_apps` to drill into a specific app's user population.
-        Returns user objects including email, display name, and granted permissions."""
+        Returns user objects including email, display name, and granted permissions.
+        """
         return self._search_with_docs(
             operation="GetAppInventoryUsers",
             search_params={"item_id": item_id},
@@ -756,7 +766,8 @@ class ShieldModule(BaseModule):
 
         Use this to identify overshared or externally exposed files such as Google Drive documents shared
         outside the organization. Returns resource objects containing resource name, type, owner, sharing
-        access level, password protection status, and last access/modification timestamps."""
+        access level, password protection status, and last access/modification timestamps.
+        """
         return self._search_with_docs(
             operation="GetAssetInventoryV3",
             search_params={
@@ -787,7 +798,8 @@ class ShieldModule(BaseModule):
 
         Call this first when starting a Shield investigation to discover available integration IDs,
         which are required as input to most other Shield tools. Returns integration objects containing
-        integration_id, SaaS platform name, connection health, and last sync time."""
+        integration_id, SaaS platform name, connection health, and last sync time.
+        """
         return self._search_with_docs(
             operation="GetIntegrationsV3",
             search_params={"saas_id": saas_id},
@@ -799,7 +811,8 @@ class ShieldModule(BaseModule):
 
         Use this to audit console-level admin accounts; for end-users of connected SaaS applications,
         use `search_shield_users` instead. Returns system-level user objects including email, role,
-        and MFA status."""
+        and MFA status.
+        """
         return self._search_with_docs(
             operation="GetSystemUsersV3",
             search_params={},
@@ -810,7 +823,8 @@ class ShieldModule(BaseModule):
         """List SaaS platforms supported by Falcon Shield for integration.
 
         Use this to discover which SaaS applications can be connected before setting up new integrations.
-        Returns supported SaaS platform objects including platform name and ID."""
+        Returns supported SaaS platform objects including platform name and ID.
+        """
         return self._search_with_docs(
             operation="GetSupportedSaasV3",
             search_params={},
@@ -847,7 +861,8 @@ class ShieldModule(BaseModule):
         """Retrieve Falcon Shield (SaaS Security) system audit logs; data is retained for 90 days.
 
         Use date range filters to narrow results, covering events such as integration creates, check
-        dismissals, and data syncs. Returns log objects containing timestamp, event type, actor, and details."""
+        dismissals, and data syncs. Returns log objects containing timestamp, event type, actor, and details.
+        """
         return self._search_with_docs(
             operation="GetSystemLogsV3",
             search_params={

--- a/falcon_mcp/modules/spotlight.py
+++ b/falcon_mcp/modules/spotlight.py
@@ -116,15 +116,16 @@ class SpotlightModule(BaseModule):
             """).strip(),
             examples=["cve", ["cve", "host_info"], ["cve", "host_info", "remediation", "evaluation_logic"]],
         ),
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for vulnerabilities in your CrowdStrike environment.
 
         Use this to find vulnerabilities by CVE severity, status, host, or remediation
         state. Consult falcon://spotlight/vulnerabilities/fql-guide before constructing
         filter expressions. Returns vulnerability details including CVE info, host context,
         and remediation guidance (based on facet selection).
+        Responses include `pagination.total` (the total number of records matching the filter, or null when the API does not report a count) — use it to answer "how many" questions. For cursor-based paging, use `pagination.next` as the `after` parameter on the next call.
         """
-        vulnerabilities = self._base_search_api_call(
+        vulnerabilities, pagination = self._base_search_with_meta(
             operation="combinedQueryVulnerabilities",
             search_params={
                 "filter": filter,
@@ -137,9 +138,7 @@ class SpotlightModule(BaseModule):
             error_message="Failed to search vulnerabilities",
         )
 
-        # If handle_api_response returns an error dict instead of a list,
-        # it means there was an error, so we return it wrapped in a list
         if self._is_error(vulnerabilities):
             return [vulnerabilities]
 
-        return vulnerabilities
+        return self._build_pagination_envelope(vulnerabilities or [], pagination, filter)

--- a/falcon_mcp/resources/shield.py
+++ b/falcon_mcp/resources/shield.py
@@ -64,7 +64,7 @@ created_by, ip, asn_name, country, browser, os, target, object_type, object, sta
 Use `GetSupportedSaasV3` via the API to get the current list of platforms available for integration.
 
 ## Pagination Notes
-- `meta.pagination.total` is always null — iterate until empty results
+- Activity Monitor (`GetActivityMonitorV3`): `meta.pagination.total` is always null — iterate until empty results
 - Activity Monitor: use `meta.pagination.next` as `to_date` and `meta.pagination.offset` as `skip`
 - Alerts: use `last_id` for cursor-based pagination (alternative to offset)
 - Activity Monitor has 24-hour date range limit when using integration_id/category/actor filters

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -688,6 +688,47 @@ def extract_registered_tool_names(module_cls: type) -> dict[str, str]:
     return registered
 
 
+def _extract_kwarg_string(block: str, kwarg: str) -> str:
+    """Extract a string-valued kwarg, joining adjacent/parenthesized literals.
+
+    Handles both `description="..."` single literals and reflowed
+    `description=(\n    "part one "\n    "part two"\n)` concatenations, which
+    Python joins into one string at runtime.
+    """
+    m = re.search(rf"{kwarg}\s*=\s*", block)
+    if not m:
+        return ""
+    rest = block[m.end() :]
+
+    # Parenthesized group: capture everything up to the matching close paren,
+    # then join every quoted literal inside it.
+    if rest.startswith("("):
+        depth = 0
+        for i, ch in enumerate(rest):
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    inner = rest[1:i]
+                    break
+        else:
+            inner = rest
+        pairs = re.findall(r'"([^"]*)"|\'([^\']*)\'', inner)
+        return "".join(dq or sq for dq, sq in pairs)
+
+    # Bare value: join only the leading run of adjacent string literals
+    # (implicit concatenation), stopping at the first non-literal token so we
+    # don't swallow later kwargs' strings.
+    literals: list[str] = []
+    scan = rest
+    lit = re.compile(r'^\s*(?:"([^"]*)"|\'([^\']*)\')')
+    while match := lit.match(scan):
+        literals.append(match.group(1) if match.group(1) is not None else match.group(2))
+        scan = scan[match.end() :]
+    return "".join(literals)
+
+
 def extract_resource_info(module_cls: type) -> list[dict[str, str]]:
     """Extract resource URIs and descriptions by inspecting register_resources."""
     try:
@@ -712,14 +753,14 @@ def extract_resource_info(module_cls: type) -> list[dict[str, str]]:
 
         uri_m = re.search(r'uri=AnyUrl\(["\']([^"\']+)["\']\)', block)
         name_m = re.search(r'name=["\']([^"\']+)["\']', block)
-        desc_m = re.search(r'description=["\']([^"\']+)["\']', block)
+        description = _extract_kwarg_string(block, "description")
 
         if uri_m:
             resources.append(
                 {
                     "uri": uri_m.group(1),
                     "name": name_m.group(1) if name_m else "",
-                    "description": desc_m.group(1) if desc_m else "",
+                    "description": description,
                 }
             )
 

--- a/tests/integration/utils/base_integration_test.py
+++ b/tests/integration/utils/base_integration_test.py
@@ -79,6 +79,17 @@ class BaseIntegrationTest:
             if isinstance(first_item, dict):
                 assert "error" not in first_item, error_msg
 
+    def _unwrap_results(self, result: Any) -> Any:
+        """Unwrap the `{"results": [...], "pagination": {...}}` envelope if present.
+
+        Search tools now return a paginated envelope dict instead of a bare list.
+        Non-search results (plain lists, error dicts without a "results" key) pass
+        through unchanged.
+        """
+        if isinstance(result, dict) and "results" in result:
+            return result["results"]
+        return result
+
     def assert_valid_list_response(
         self,
         result: Any,
@@ -87,12 +98,29 @@ class BaseIntegrationTest:
     ) -> None:
         """Assert that the result is a valid list response.
 
+        Accepts either a bare list or the `{"results": [...], "pagination": {...}}`
+        envelope now returned by search tools; also sanity-checks `pagination.total`
+        when the envelope is present.
+
         Args:
             result: The API response to check
             min_length: Minimum expected length of the list
             context: Optional context string for the error message
         """
         ctx = f" ({context})" if context else ""
+
+        if isinstance(result, dict) and "results" in result:
+            pagination = result.get("pagination")
+            if pagination is not None:
+                # `total` is always present but may be None when the API reports
+                # no count (see _build_pagination_envelope); only sanity-check a
+                # real number so the honest-None case doesn't raise TypeError.
+                total = pagination.get("total")
+                assert (
+                    total is None or total >= 0
+                ), f"Expected pagination.total >= 0{ctx}, got {total}"
+            result = result["results"]
+
         assert isinstance(result, list), f"Expected list response{ctx}, got {type(result)}"
         assert (
             len(result) >= min_length
@@ -110,12 +138,17 @@ class BaseIntegrationTest:
         1. Search returns entity IDs
         2. Get details returns full entity objects
 
+        Accepts either a bare list or the `{"results": [...], "pagination": {...}}`
+        envelope now returned by search tools.
+
         Args:
             result: The search results to check
             expected_fields: List of field names expected in each result
             context: Optional context string for the error message
         """
         ctx = f" ({context})" if context else ""
+
+        result = self._unwrap_results(result)
 
         assert isinstance(result, list), f"Expected list of results{ctx}"
         assert len(result) > 0, f"Expected at least one result to validate{ctx}"
@@ -140,12 +173,17 @@ class BaseIntegrationTest:
     ) -> None:
         """Assert that each result item has an ID field.
 
+        Accepts either a bare list or the `{"results": [...], "pagination": {...}}`
+        envelope now returned by search tools.
+
         Args:
             result: The results to check
             id_field: The name of the ID field to check for
             context: Optional context string for the error message
         """
         ctx = f" ({context})" if context else ""
+
+        result = self._unwrap_results(result)
 
         assert isinstance(result, list), f"Expected list of results{ctx}"
 
@@ -160,6 +198,9 @@ class BaseIntegrationTest:
     ) -> Optional[str]:
         """Extract the first ID from a list of results.
 
+        Accepts either a bare list or the `{"results": [...], "pagination": {...}}`
+        envelope now returned by search tools.
+
         Args:
             result: The results to extract from
             id_field: The name of the ID field
@@ -167,6 +208,8 @@ class BaseIntegrationTest:
         Returns:
             The first ID value, or None if not found
         """
+        result = self._unwrap_results(result)
+
         if not result or not isinstance(result, list):
             return None
 

--- a/tests/modules/test_base.py
+++ b/tests/modules/test_base.py
@@ -788,5 +788,66 @@ class TestBaseModuleReorderByIds(TestModules):
         self.assertEqual([e["id"] for e in result], ["a", "b", "c"])
 
 
+class TestBuildPaginationEnvelope(TestModules):
+    """Test cases for _build_pagination_envelope, focused on total honesty and cursors."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(ConcreteBaseModule)
+
+    def test_offset_pagination_round_trips(self):
+        """offset/limit/total from the API are surfaced verbatim; next is null."""
+        envelope = self.module._build_pagination_envelope(
+            [{"id": "a"}],
+            {"total": 42, "offset": 0, "limit": 10},
+            filter_used="name:'x'",
+        )
+        self.assertEqual(
+            envelope["pagination"],
+            {"total": 42, "offset": 0, "limit": 10, "next": None},
+        )
+        self.assertEqual(envelope["filter_used"], "name:'x'")
+
+    def test_cursor_after_maps_to_next(self):
+        """A non-null `after` cursor round-trips into `next`."""
+        envelope = self.module._build_pagination_envelope(
+            [{"id": "a"}],
+            {"total": 500, "after": "CURSOR_TOKEN"},
+        )
+        self.assertEqual(envelope["pagination"]["next"], "CURSOR_TOKEN")
+        self.assertEqual(envelope["pagination"]["total"], 500)
+        # No offset/limit keys when the API doesn't send them (cursor endpoints).
+        self.assertNotIn("offset", envelope["pagination"])
+        self.assertNotIn("limit", envelope["pagination"])
+
+    def test_missing_total_key_reports_none_not_page_size(self):
+        """A pagination dict without a `total` key reports None, never the page size."""
+        envelope = self.module._build_pagination_envelope(
+            [{"id": "a"}, {"id": "b"}],
+            {"offset": 0, "limit": 2},
+        )
+        self.assertIsNone(envelope["pagination"]["total"])
+
+    def test_no_meta_nonempty_page_reports_none(self):
+        """No pagination meta + a non-empty page: total is unknown, so None (not len)."""
+        envelope = self.module._build_pagination_envelope(
+            [{"id": "a"}, {"id": "b"}, {"id": "c"}],
+            None,
+        )
+        self.assertIsNone(envelope["pagination"]["total"])
+        self.assertIsNone(envelope["pagination"]["next"])
+
+    def test_no_meta_empty_page_reports_none(self):
+        """No pagination meta: the API gave no count, so total is None even when empty."""
+        envelope = self.module._build_pagination_envelope([], None)
+        self.assertIsNone(envelope["pagination"]["total"])
+
+    def test_filter_used_omitted_when_none(self):
+        """Tools with no filter param omit filter_used entirely."""
+        envelope = self.module._build_pagination_envelope([{"id": "a"}], {"total": 1})
+        self.assertNotIn("filter_used", envelope)
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/modules/test_cases.py
+++ b/tests/modules/test_cases.py
@@ -86,7 +86,10 @@ class TestCasesModule(TestModules):
         """Test two-step search: query for IDs then fetch full details."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["case-id-1", "case-id-2"]},
+            "body": {
+                "resources": ["case-id-1", "case-id-2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -111,10 +114,11 @@ class TestCasesModule(TestModules):
         second_call = self.mock_client.command.call_args_list[1]
         self.assertEqual(second_call[0][0], "entities_cases_post_v2")
 
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "case-id-1")
-        self.assertEqual(result[1]["id"], "case-id-2")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "case-id-1")
+        self.assertEqual(result["results"][1]["id"], "case-id-2")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_cases_reorders_to_match_sorted_ids(self):
         """When entities_cases_post_v2 returns cases out of order, the result is
@@ -140,9 +144,9 @@ class TestCasesModule(TestModules):
 
         result = self.module.search_cases(sort="created_timestamp.desc")
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "case-b")
-        self.assertEqual(result[1]["id"], "case-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "case-b")
+        self.assertEqual(result["results"][1]["id"], "case-a")
 
     def test_search_cases_empty_results(self):
         """Test that empty query results return clean empty response."""
@@ -155,7 +159,7 @@ class TestCasesModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "status:'nonexistent'")
         self.assertNotIn("fql_guide", result)
 

--- a/tests/modules/test_cloud.py
+++ b/tests/modules/test_cloud.py
@@ -49,7 +49,10 @@ class TestCloudModule(TestModules):
         """Test searching for kubernetes containers."""
         mock_response = {
             "status_code": 200,
-            "body": {"resources": ["container_1", "container_2"]},
+            "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 1, "total": 2}},
+                "resources": ["container_1", "container_2"],
+            },
         }
         self.mock_client.command.return_value = mock_response
 
@@ -63,7 +66,9 @@ class TestCloudModule(TestModules):
         self.assertEqual(first_call[0][0], "ReadContainerCombined")
         self.assertEqual(first_call[1]["parameters"]["filter"], "cloud_name:'AWS'")
         self.assertEqual(first_call[1]["parameters"]["limit"], 1)
-        self.assertEqual(result, ["container_1", "container_2"])
+        self.assertIn("results", result)
+        self.assertEqual(result["results"], ["container_1", "container_2"])
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_kubernetes_containers_errors(self):
         """Test searching for kubernetes containers with API error."""
@@ -75,9 +80,8 @@ class TestCloudModule(TestModules):
 
         result = self.module.search_kubernetes_containers(filter="invalid_filter")
 
-        self.assertIsInstance(result, dict)
-        self.assertIn("error", result)
-        self.assertIn("details", result)
+        self.assertIsInstance(result, list)
+        self.assertIn("error", result[0])
 
     def test_count_kubernetes_containers(self):
         """Test count for kubernetes containers returns an int."""
@@ -110,7 +114,7 @@ class TestCloudModule(TestModules):
 
     def test_search_images_vulnerabilities(self):
         """Test search for images vulnerabilities."""
-        mock_response = {"status_code": 200, "body": {"resources": ["cve_id_1"]}}
+        mock_response = {"status_code": 200, "body": {"meta": {"pagination": {"offset": 0, "limit": 1, "total": 1}}, "resources": ["cve_id_1"]}}
         self.mock_client.command.return_value = mock_response
 
         result = self.module.search_images_vulnerabilities(
@@ -123,7 +127,9 @@ class TestCloudModule(TestModules):
         self.assertEqual(first_call[0][0], "ReadCombinedVulnerabilities")
         self.assertEqual(first_call[1]["parameters"]["filter"], "cvss_score:>5")
         self.assertEqual(first_call[1]["parameters"]["limit"], 1)
-        self.assertEqual(result, ["cve_id_1"])
+        self.assertIn("results", result)
+        self.assertEqual(result["results"], ["cve_id_1"])
+        self.assertEqual(result["pagination"]["total"], 1)
 
     def test_search_images_vulnerabilities_errors(self):
         """Test search for images vulnerabilities with API error."""
@@ -135,16 +141,15 @@ class TestCloudModule(TestModules):
 
         result = self.module.search_kubernetes_containers(sort="1|1")
 
-        self.assertIsInstance(result, dict)
-        self.assertIn("error", result)
-        self.assertIn("details", result)
+        self.assertIsInstance(result, list)
+        self.assertIn("error", result[0])
 
     def test_search_cspm_assets_success(self):
         """Test searching for CSPM assets with two-step pattern."""
         # Mock query response (returns IDs)
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["asset_1", "asset_2", "asset_3"]},
+            "body": {"resources": ["asset_1", "asset_2", "asset_3"], "meta": {"pagination": {"offset": 0, "limit": 10, "total": 3}}},
         }
         # Mock get response (returns full details)
         get_response = {
@@ -182,10 +187,11 @@ class TestCloudModule(TestModules):
         )
 
         # Verify result is full details, not just IDs
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 3)
-        self.assertIn("cloud_provider", result[0])
-        self.assertIn("resource_type", result[0])
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 3)
+        self.assertIn("cloud_provider", result["results"][0])
+        self.assertIn("resource_type", result["results"][0])
+        self.assertEqual(result["pagination"]["total"], 3)
 
     def test_search_cspm_assets_reorders_to_match_sorted_ids(self):
         """When cloud_security_assets_entities_get returns assets out of order,
@@ -209,15 +215,15 @@ class TestCloudModule(TestModules):
             filter=None, limit=10
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "asset-b")
-        self.assertEqual(result[1]["id"], "asset-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "asset-b")
+        self.assertEqual(result["results"][1]["id"], "asset-a")
 
     def test_search_cspm_assets_batching(self):
         """Test CSPM assets search handles >100 IDs with batching."""
         # Mock 250 IDs
         asset_ids = [f"asset_{i}" for i in range(250)]
-        query_response = {"status_code": 200, "body": {"resources": asset_ids}}
+        query_response = {"status_code": 200, "body": {"resources": asset_ids, "meta": {"pagination": {"offset": 0, "limit": 1000, "total": 250}}}}
 
         # Mock 3 batches (100 + 100 + 50)
         batch1_assets = [
@@ -272,11 +278,13 @@ class TestCloudModule(TestModules):
         )
 
         # Verify all 250 assets returned
-        self.assertEqual(len(result), 250)
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 250)
+        self.assertEqual(result["pagination"]["total"], 250)
 
         # Verify reorder restores query-step order across batches even though
         # batch2 was returned reversed.
-        self.assertEqual([r["id"] for r in result], asset_ids)
+        self.assertEqual([r["id"] for r in result["results"]], asset_ids)
 
     def test_search_cspm_assets_error_returns_fql_guide(self):
         """Test CSPM assets search returns FQL guide on error."""
@@ -304,7 +312,7 @@ class TestCloudModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "cloud_provider:'NonExistent'")
         self.assertNotIn("fql_guide", result)
 
@@ -440,14 +448,14 @@ class TestCloudModule(TestModules):
             },
         }
 
-        query_response = {"status_code": 200, "body": {"resources": ["asset_1"]}}
+        query_response = {"status_code": 200, "body": {"resources": ["asset_1"], "meta": {"pagination": {"offset": 0, "limit": 1, "total": 1}}}}
         get_response = {"status_code": 200, "body": {"resources": [bloated_asset]}}
         self.mock_client.command.side_effect = [query_response, get_response]
 
         result = self.module.search_cspm_assets(limit=1)
 
-        self.assertEqual(len(result), 1)
-        asset = result[0]
+        self.assertEqual(len(result["results"]), 1)
+        asset = result["results"][0]
 
         # Useful fields preserved
         self.assertEqual(asset["id"], "cid|aws|123|us-east-1|AWS::EC2::Instance|i-abc")
@@ -498,14 +506,14 @@ class TestCloudModule(TestModules):
             "region": "us-east-1",
         }
 
-        query_response = {"status_code": 200, "body": {"resources": ["asset_1"]}}
+        query_response = {"status_code": 200, "body": {"resources": ["asset_1"], "meta": {"pagination": {"offset": 0, "limit": 1, "total": 1}}}}
         get_response = {"status_code": 200, "body": {"resources": [minimal_asset]}}
         self.mock_client.command.side_effect = [query_response, get_response]
 
         result = self.module.search_cspm_assets(limit=1)
 
-        self.assertEqual(len(result), 1)
-        asset = result[0]
+        self.assertEqual(len(result["results"]), 1)
+        asset = result["results"][0]
         self.assertEqual(asset["id"], "asset_1")
         self.assertEqual(asset["resource_type"], "AWS::S3::Bucket")
         self.assertNotIn("cloud_context", asset)
@@ -516,7 +524,7 @@ class TestCloudModule(TestModules):
         """Test searching for IOM findings with two-step pattern."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["iom_1", "iom_2"]},
+            "body": {"resources": ["iom_1", "iom_2"], "meta": {"pagination": {"offset": 0, "limit": 10, "total": 2}}},
         }
         get_response = {
             "status_code": 200,
@@ -546,9 +554,10 @@ class TestCloudModule(TestModules):
         self.assertEqual(second_call[1]["parameters"]["ids"], ["iom_1", "iom_2"])
 
         # Verify full details returned
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertIn("severity", result[0])
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertIn("severity", result["results"][0])
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_iom_findings_reorders_to_match_sorted_ids(self):
         """When cspm_evaluations_iom_entities returns findings out of order,
@@ -572,9 +581,9 @@ class TestCloudModule(TestModules):
             filter=None, limit=10
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "iom-b")
-        self.assertEqual(result[1]["id"], "iom-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "iom-b")
+        self.assertEqual(result["results"][1]["id"], "iom-a")
 
     def test_search_iom_findings_error_returns_fql_guide(self):
         """Test IOM search returns FQL guide on error."""
@@ -600,14 +609,14 @@ class TestCloudModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "severity:'nonexistent'")
         self.assertNotIn("fql_guide", result)
 
     def test_search_iom_findings_batching(self):
         """Test IOM search handles >100 IDs with batching."""
         iom_ids = [f"iom_{i}" for i in range(150)]
-        query_response = {"status_code": 200, "body": {"resources": iom_ids}}
+        query_response = {"status_code": 200, "body": {"resources": iom_ids, "meta": {"pagination": {"offset": 0, "limit": 200, "total": 150}}}}
 
         batch1 = {"status_code": 200, "body": {"resources": [{"id": f"iom_{i}"} for i in range(100)]}}
         batch2 = {"status_code": 200, "body": {"resources": [{"id": f"iom_{i}"} for i in reversed(range(100, 150))]}}
@@ -617,9 +626,10 @@ class TestCloudModule(TestModules):
         result = self.module.search_iom_findings(limit=200)
 
         self.assertEqual(self.mock_client.command.call_count, 3)
-        self.assertEqual(len(result), 150)
+        self.assertEqual(len(result["results"]), 150)
+        self.assertEqual(result["pagination"]["total"], 150)
         # Reorder restores query-step order across batches even though batch2 was reversed.
-        self.assertEqual([r["id"] for r in result], iom_ids)
+        self.assertEqual([r["id"] for r in result["results"]], iom_ids)
 
     def test_search_iom_findings_batch_error_fails_fast(self):
         """Test IOM search wraps a step-2 (entities) error in a list."""
@@ -654,7 +664,7 @@ class TestCloudModule(TestModules):
         """Test searching for suppression rules with two-step pattern."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["rule_1", "rule_2"]},
+            "body": {"resources": ["rule_1", "rule_2"], "meta": {"pagination": {"offset": 0, "limit": 10, "total": 2}}},
         }
         get_response = {
             "status_code": 200,
@@ -679,8 +689,9 @@ class TestCloudModule(TestModules):
         second_call = self.mock_client.command.call_args_list[1]
         self.assertEqual(second_call[1]["override"], "GET,/cloud-policies/entities/suppression-rules/v1")
 
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_suppression_rules_empty(self):
         """Test suppression rules search with no results."""
@@ -689,7 +700,8 @@ class TestCloudModule(TestModules):
 
         result = self.module.search_cspm_suppression_rules()
 
-        self.assertEqual(result, [])
+        self.assertEqual(result["results"], [])
+        self.assertIsNone(result["pagination"]["total"])
 
     def test_search_suppression_rules_reorders_to_match_sorted_ids(self):
         """When GetSuppressionRules returns rules out of order, the result is
@@ -711,9 +723,9 @@ class TestCloudModule(TestModules):
 
         result = self.module.search_cspm_suppression_rules(limit=10)
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "rule_2")
-        self.assertEqual(result[1]["id"], "rule_1")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "rule_2")
+        self.assertEqual(result["results"][1]["id"], "rule_1")
 
     def test_create_suppression_rule_success(self):
         """Test creating a suppression rule."""
@@ -870,9 +882,9 @@ class TestCloudModule(TestModules):
             filter="severity:'critical'", limit=10, offset=None, sort=None
         )
         self.assertEqual(self.mock_client.command.call_args[0][0], "combined_cloud_risks")
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "risk-1")
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "risk-1")
 
     def test_search_cloud_risks_empty(self):
         """Test search_cloud_risks returns empty list when no results."""
@@ -883,8 +895,8 @@ class TestCloudModule(TestModules):
         result = self.module.search_cloud_risks(
             filter=None, limit=100, offset=None, sort=None
         )
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 0)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["results"]), 0)
 
     def test_search_cloud_risks_api_error(self):
         """Test search_cloud_risks returns error dict on API failure."""
@@ -895,8 +907,8 @@ class TestCloudModule(TestModules):
         result = self.module.search_cloud_risks(
             filter="invalid!", limit=10, offset=None, sort=None
         )
-        self.assertIsInstance(result, dict)
-        self.assertIn("error", result)
+        self.assertIsInstance(result, list)
+        self.assertIn("error", result[0])
 
     def test_search_cloud_risks_passes_all_params(self):
         """Test search_cloud_risks passes filter, sort, limit, offset to API."""
@@ -933,8 +945,8 @@ class TestCloudModule(TestModules):
             "ListCloudGroupsExternal",
             parameters={"limit": 100},
         )
-        self.assertIsInstance(result, list)
-        self.assertEqual(result[0]["id"], "grp-1")
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"][0]["id"], "grp-1")
 
     def test_search_cloud_groups_with_filter(self):
         """Test search_cloud_groups passes filter param."""

--- a/tests/modules/test_correlation_rules.py
+++ b/tests/modules/test_correlation_rules.py
@@ -118,10 +118,10 @@ class TestCorrelationRulesModule(TestModules):
         self.assertEqual(call_args[1]["parameters"]["offset"], 0)
         self.assertEqual(call_args[1]["parameters"]["sort"], "last_updated_on.desc")
 
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["rule_id"], "r1")
-        self.assertEqual(result[1]["rule_id"], "r2")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["rule_id"], "r1")
+        self.assertEqual(result["results"][1]["rule_id"], "r2")
 
     def test_search_with_filter(self):
         """Test that filter param is passed through to the API call."""
@@ -148,7 +148,7 @@ class TestCorrelationRulesModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "name:'nonexistent'")
         self.assertNotIn("fql_guide", result)
 

--- a/tests/modules/test_custom_ioa.py
+++ b/tests/modules/test_custom_ioa.py
@@ -83,8 +83,8 @@ class TestCustomIOAModule(TestModules):
         self.assertNotIn("offset", call_args[1]["parameters"])
         self.assertNotIn("sort", call_args[1]["parameters"])
         self.assertNotIn("q", call_args[1]["parameters"])
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "rg-001")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "rg-001")
 
     def test_search_ioa_rule_groups_empty_returns_fql_guide(self):
         """Test that empty results return clean empty response."""
@@ -97,7 +97,7 @@ class TestCustomIOAModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "name:'nonexistent'")
         self.assertNotIn("fql_guide", result)
 

--- a/tests/modules/test_data_protection.py
+++ b/tests/modules/test_data_protection.py
@@ -50,7 +50,10 @@ class TestDataProtectionModule(TestModules):
         """Test searching classifications with successful two-step response."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["cls-id-1", "cls-id-2"]},
+            "body": {
+                "resources": ["cls-id-1", "cls-id-2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         get_response = {
             "status_code": 200,
@@ -76,9 +79,10 @@ class TestDataProtectionModule(TestModules):
         )
 
         self.assertEqual(self.mock_client.command.call_count, 2)
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["name"], "Credit Card Detection")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["name"], "Credit Card Detection")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_classifications_reorders_to_match_sorted_ids(self):
         """When the get step returns classifications out of order, the result is
@@ -102,9 +106,9 @@ class TestDataProtectionModule(TestModules):
             filter=None, limit=100, offset=0, sort="created_at.desc"
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "cls-id-b")
-        self.assertEqual(result[1]["id"], "cls-id-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "cls-id-b")
+        self.assertEqual(result["results"][1]["id"], "cls-id-a")
 
     def test_search_classifications_empty_results(self):
         """Test that empty search returns clean empty response."""
@@ -120,7 +124,7 @@ class TestDataProtectionModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "name:~'nonexistent'")
         self.assertNotIn("fql_guide", result)
 
@@ -149,7 +153,10 @@ class TestDataProtectionModule(TestModules):
         """Test searching policies with platform_name and two-step response."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["pol-id-1"]},
+            "body": {
+                "resources": ["pol-id-1"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
+            },
         }
         get_response = {
             "status_code": 200,
@@ -171,9 +178,10 @@ class TestDataProtectionModule(TestModules):
         )
 
         self.assertEqual(self.mock_client.command.call_count, 2)
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["platform_name"], "win")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["results"][0]["platform_name"], "win")
+        self.assertEqual(result["pagination"]["total"], 1)
 
     def test_search_policies_reorders_to_match_sorted_ids(self):
         """When the get step returns policies out of order, the result is
@@ -197,9 +205,9 @@ class TestDataProtectionModule(TestModules):
             platform_name="win", filter=None, limit=100, offset=0, sort="created_at.desc"
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "pol-id-b")
-        self.assertEqual(result[1]["id"], "pol-id-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "pol-id-b")
+        self.assertEqual(result["results"][1]["id"], "pol-id-a")
 
     def test_search_policies_passes_platform_name(self):
         """Test that platform_name is sent to the query API."""
@@ -231,7 +239,7 @@ class TestDataProtectionModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertNotIn("fql_guide", result)
 
     def test_search_policies_error_response(self):
@@ -259,7 +267,10 @@ class TestDataProtectionModule(TestModules):
         """Test searching content patterns with successful two-step response."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["cp-id-1", "cp-id-2"]},
+            "body": {
+                "resources": ["cp-id-1", "cp-id-2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         get_response = {
             "status_code": 200,
@@ -287,9 +298,10 @@ class TestDataProtectionModule(TestModules):
         )
 
         self.assertEqual(self.mock_client.command.call_count, 2)
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["type"], "predefined")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["type"], "predefined")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_content_patterns_reorders_to_match_sorted_ids(self):
         """When the get step returns content patterns out of order, the result is
@@ -313,9 +325,9 @@ class TestDataProtectionModule(TestModules):
             filter=None, limit=100, offset=0, sort="created_at.desc"
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "cp-id-b")
-        self.assertEqual(result[1]["id"], "cp-id-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "cp-id-b")
+        self.assertEqual(result["results"][1]["id"], "cp-id-a")
 
     def test_search_content_patterns_empty_results(self):
         """Test that empty content pattern search returns clean empty response."""
@@ -331,7 +343,7 @@ class TestDataProtectionModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertNotIn("fql_guide", result)
 
     def test_search_content_patterns_error_response(self):

--- a/tests/modules/test_detections.py
+++ b/tests/modules/test_detections.py
@@ -38,7 +38,10 @@ class TestDetectionsModule(TestModules):
         # Setup mock responses for both API calls
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["detection1", "detection2"]},
+            "body": {
+                "resources": ["detection1", "detection2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -67,15 +70,21 @@ class TestDetectionsModule(TestModules):
             },
         )
 
-        # Verify result is raw empty list (not FQL-wrapped - query succeeded)
-        self.assertEqual(result, [])
+        # Verify result is paginated envelope with empty results
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+        self.assertIn("pagination", result)
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_detections_with_details(self):
-        """Test searching for detections with details - success returns raw list."""
+        """Test searching for detections with details - success returns envelope."""
         # Setup mock responses
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["detection1", "detection2"]},
+            "body": {
+                "resources": ["detection1", "detection2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -109,11 +118,13 @@ class TestDetectionsModule(TestModules):
             },
         )
 
-        # Verify result is raw list of detections (no wrapping)
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["composite_id"], "detection1")
-        self.assertEqual(result[1]["composite_id"], "detection2")
+        # Verify result is paginated envelope
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["composite_id"], "detection1")
+        self.assertEqual(result["results"][1]["composite_id"], "detection2")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_detections_reorders_to_match_sorted_ids(self):
         """When PostEntitiesAlertsV2 returns entities out of order, the result is
@@ -140,9 +151,9 @@ class TestDetectionsModule(TestModules):
 
         result = self.module.search_detections(sort="severity.desc")
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["composite_id"], "high-sev")
-        self.assertEqual(result[1]["composite_id"], "low-sev")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["composite_id"], "high-sev")
+        self.assertEqual(result["results"][1]["composite_id"], "low-sev")
 
     def test_search_detections_error(self):
         """Test searching for detections with API error returns FQL guide."""
@@ -183,14 +194,16 @@ class TestDetectionsModule(TestModules):
     def test_search_detections_empty_results(self):
         """Test that an empty query result returns a clean empty response (no FQL guide)."""
         self.mock_client.command.side_effect = [
-            {"status_code": 200, "body": {"resources": []}},
+            {"status_code": 200, "body": {"resources": [], "meta": {"pagination": {"offset": 0, "limit": 100, "total": 0}}}},
         ]
 
         result = self.module.search_detections(filter="status:'new'")
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIn("pagination", result)
+        self.assertEqual(result["pagination"]["total"], 0)
+        self.assertIsNone(result["pagination"]["next"])
         self.assertNotIn("fql_guide", result)
 
     def test_get_detection_details(self):
@@ -233,7 +246,10 @@ class TestDetectionsModule(TestModules):
         # Setup mock responses for both API calls
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["detection1", "detection2"]},
+            "body": {
+                "resources": ["detection1", "detection2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -258,10 +274,12 @@ class TestDetectionsModule(TestModules):
             },
         )
 
-        # Verify result is raw list (success = no wrapping)
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["composite_id"], "detection1")
+        # Verify result is paginated envelope
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["results"][0]["composite_id"], "detection1")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_get_detection_details_include_hidden_false(self):
         """Test getting detection details with include_hidden=False."""
@@ -285,17 +303,6 @@ class TestDetectionsModule(TestModules):
         expected_result = [{"id": "detection1", "name": "Test Detection 1"}]
         self.assertEqual(result, expected_result)
 
-
-    def test_format_empty_response(self):
-        """Test that empty results return a clean response without FQL guide."""
-        result = self.module._format_empty_response(
-            filter_used="status:'nonexistent'",
-        )
-
-        self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
-        self.assertEqual(result["filter_used"], "status:'nonexistent'")
-        self.assertNotIn("fql_guide", result)
 
     def test_format_fql_error_response_error(self):
         """Test that error responses include FQL guide."""

--- a/tests/modules/test_discover.py
+++ b/tests/modules/test_discover.py
@@ -3,7 +3,7 @@ Unit tests for the Discover module.
 """
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from mcp.server import FastMCP
 
@@ -40,66 +40,50 @@ class TestDiscoverModule(unittest.TestCase):
             str(self.module.resources[1]), "falcon://discover/hosts/fql-guide"
         )
 
-    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
-    @patch("falcon_mcp.modules.discover.handle_api_response")
-    def test_search_applications(self, mock_handle_response, mock_prepare_params):
+    def test_search_applications(self):
         """Test search_applications method."""
-        # Setup mocks
-        mock_prepare_params.return_value = {"filter": "name:'Chrome'"}
-        mock_response = MagicMock()
-        self.client.command.return_value = mock_response
-        mock_handle_response.return_value = [{"id": "app1", "name": "Chrome"}]
-
-        # Call the method
-        result = self.module.search_applications(filter="name:'Chrome'")
-
-        # Assertions
-        # Don't check the exact arguments, just verify it was called once
-        self.assertEqual(mock_prepare_params.call_count, 1)
-        self.client.command.assert_called_once_with(
-            "combined_applications", parameters={"filter": "name:'Chrome'"}
-        )
-        mock_handle_response.assert_called_once_with(
-            mock_response,
-            operation="combined_applications",
-            error_message="Failed to search applications",
-            default_result=[],
-        )
-        self.assertEqual(result, [{"id": "app1", "name": "Chrome"}])
-
-    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
-    @patch("falcon_mcp.modules.discover.handle_api_response")
-    def test_search_applications_with_error(self, mock_handle_response, mock_prepare_params):
-        """Test search_applications method when an error occurs."""
-        # Setup mocks
-        mock_prepare_params.return_value = {"filter": "name:'Chrome'"}
-        mock_response = MagicMock()
-        self.client.command.return_value = mock_response
-        error_response = {"error": "API Error", "message": "Something went wrong"}
-        mock_handle_response.return_value = error_response
-
-        # Call the method
-        result = self.module.search_applications(filter="name:'Chrome'")
-
-        # Assertions
-        self.assertEqual(result, [error_response])
-
-    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
-    @patch("falcon_mcp.modules.discover.handle_api_response")
-    def test_search_applications_with_all_params(self, mock_handle_response, mock_prepare_params):
-        """Test search_applications method with all parameters."""
-        # Setup mocks
-        mock_prepare_params.return_value = {
-            "filter": "name:'Chrome'",
-            "facet": "host_info",
-            "limit": 50,
-            "sort": "name.asc",
+        mock_response = {
+            "status_code": 200,
+            "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
+                "resources": [{"id": "app1", "name": "Chrome"}],
+            },
         }
-        mock_response = MagicMock()
         self.client.command.return_value = mock_response
-        mock_handle_response.return_value = [{"id": "app1", "name": "Chrome"}]
 
-        # Call the method
+        result = self.module.search_applications(filter="name:'Chrome'")
+
+        first_call = self.client.command.call_args_list[0]
+        self.assertEqual(first_call[0][0], "combined_applications")
+        self.assertEqual(first_call[1]["parameters"]["filter"], "name:'Chrome'")
+        self.assertEqual(result["results"], [{"id": "app1", "name": "Chrome"}])
+        self.assertEqual(result["pagination"]["total"], 1)
+        self.assertEqual(result["filter_used"], "name:'Chrome'")
+
+    def test_search_applications_with_error(self):
+        """Test search_applications method when an error occurs."""
+        mock_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Something went wrong"}]},
+        }
+        self.client.command.return_value = mock_response
+
+        result = self.module.search_applications(filter="name:'Chrome'")
+
+        self.assertIsInstance(result, list)
+        self.assertIn("error", result[0])
+
+    def test_search_applications_with_all_params(self):
+        """Test search_applications method with all parameters."""
+        mock_response = {
+            "status_code": 200,
+            "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 50, "total": 1}},
+                "resources": [{"id": "app1", "name": "Chrome"}],
+            },
+        }
+        self.client.command.return_value = mock_response
+
         result = self.module.search_applications(
             filter="name:'Chrome'",
             facet="host_info",
@@ -107,101 +91,84 @@ class TestDiscoverModule(unittest.TestCase):
             sort="name.asc",
         )
 
-        # Assertions
-        # Don't check the exact arguments, just verify it was called once
-        self.assertEqual(mock_prepare_params.call_count, 1)
-        self.client.command.assert_called_once_with(
-            "combined_applications",
-            parameters={
-                "filter": "name:'Chrome'",
-                "facet": "host_info",
-                "limit": 50,
-                "sort": "name.asc",
-            },
-        )
-        self.assertEqual(result, [{"id": "app1", "name": "Chrome"}])
+        first_call = self.client.command.call_args_list[0]
+        self.assertEqual(first_call[0][0], "combined_applications")
+        params = first_call[1]["parameters"]
+        self.assertEqual(params["filter"], "name:'Chrome'")
+        self.assertEqual(params["facet"], "host_info")
+        self.assertEqual(params["limit"], 50)
+        self.assertEqual(params["sort"], "name.asc")
+        self.assertEqual(result["results"], [{"id": "app1", "name": "Chrome"}])
 
-    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
-    @patch("falcon_mcp.modules.discover.handle_api_response")
-    def test_search_unmanaged_assets(self, mock_handle_response, mock_prepare_params):
+    def test_search_unmanaged_assets(self):
         """Test search_unmanaged_assets method."""
-        # Setup mocks
-        mock_prepare_params.return_value = {"filter": "entity_type:'unmanaged'+platform_name:'Windows'"}
-        mock_response = MagicMock()
-        self.client.command.return_value = mock_response
-        mock_handle_response.return_value = [{"device_id": "host1", "hostname": "PC-001"}]
-
-        # Call the method
-        result = self.module.search_unmanaged_assets(filter="platform_name:'Windows'")
-
-        # Assertions
-        # Don't check the exact arguments, just verify it was called once
-        self.assertEqual(mock_prepare_params.call_count, 1)
-        self.client.command.assert_called_once_with(
-            "combined_hosts", parameters={"filter": "entity_type:'unmanaged'+platform_name:'Windows'"}
-        )
-        mock_handle_response.assert_called_once_with(
-            mock_response,
-            operation="combined_hosts",
-            error_message="Failed to search unmanaged assets",
-            default_result=[],
-        )
-        self.assertEqual(result, [{"device_id": "host1", "hostname": "PC-001"}])
-
-    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
-    @patch("falcon_mcp.modules.discover.handle_api_response")
-    def test_search_unmanaged_assets_without_filter(self, mock_handle_response, mock_prepare_params):
-        """Test search_unmanaged_assets method without user filter."""
-        # Setup mocks
-        mock_prepare_params.return_value = {"filter": "entity_type:'unmanaged'"}
-        mock_response = MagicMock()
-        self.client.command.return_value = mock_response
-        mock_handle_response.return_value = [{"device_id": "host1", "hostname": "PC-001"}]
-
-        # Call the method with no filter
-        result = self.module.search_unmanaged_assets()
-
-        # Assertions
-        # Don't check the exact arguments, just verify it was called once
-        self.assertEqual(mock_prepare_params.call_count, 1)
-        self.client.command.assert_called_once_with(
-            "combined_hosts", parameters={"filter": "entity_type:'unmanaged'"}
-        )
-        self.assertEqual(result, [{"device_id": "host1", "hostname": "PC-001"}])
-
-    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
-    @patch("falcon_mcp.modules.discover.handle_api_response")
-    def test_search_unmanaged_assets_with_error(self, mock_handle_response, mock_prepare_params):
-        """Test search_unmanaged_assets method when an error occurs."""
-        # Setup mocks
-        mock_prepare_params.return_value = {"filter": "entity_type:'unmanaged'+platform_name:'Windows'"}
-        mock_response = MagicMock()
-        self.client.command.return_value = mock_response
-        error_response = {"error": "API Error", "message": "Something went wrong"}
-        mock_handle_response.return_value = error_response
-
-        # Call the method
-        result = self.module.search_unmanaged_assets(filter="platform_name:'Windows'")
-
-        # Assertions
-        self.assertEqual(result, [error_response])
-
-    @patch("falcon_mcp.modules.discover.prepare_api_parameters")
-    @patch("falcon_mcp.modules.discover.handle_api_response")
-    def test_search_unmanaged_assets_with_all_params(self, mock_handle_response, mock_prepare_params):
-        """Test search_unmanaged_assets method with all parameters."""
-        # Setup mocks
-        mock_prepare_params.return_value = {
-            "filter": "entity_type:'unmanaged'+criticality:'Critical'",
-            "limit": 50,
-            "offset": 10,
-            "sort": "hostname.asc",
+        mock_response = {
+            "status_code": 200,
+            "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
+                "resources": [{"device_id": "host1", "hostname": "PC-001"}],
+            },
         }
-        mock_response = MagicMock()
         self.client.command.return_value = mock_response
-        mock_handle_response.return_value = [{"device_id": "host1", "hostname": "PC-001"}]
 
-        # Call the method
+        result = self.module.search_unmanaged_assets(filter="platform_name:'Windows'")
+
+        first_call = self.client.command.call_args_list[0]
+        self.assertEqual(first_call[0][0], "combined_hosts")
+        self.assertEqual(
+            first_call[1]["parameters"]["filter"],
+            "entity_type:'unmanaged'+platform_name:'Windows'",
+        )
+        self.assertEqual(
+            result["results"], [{"device_id": "host1", "hostname": "PC-001"}]
+        )
+
+    def test_search_unmanaged_assets_without_filter(self):
+        """Test search_unmanaged_assets method without user filter."""
+        mock_response = {
+            "status_code": 200,
+            "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
+                "resources": [{"device_id": "host1", "hostname": "PC-001"}],
+            },
+        }
+        self.client.command.return_value = mock_response
+
+        result = self.module.search_unmanaged_assets(filter=None)
+
+        first_call = self.client.command.call_args_list[0]
+        self.assertEqual(first_call[0][0], "combined_hosts")
+        self.assertEqual(
+            first_call[1]["parameters"]["filter"], "entity_type:'unmanaged'"
+        )
+        self.assertEqual(
+            result["results"], [{"device_id": "host1", "hostname": "PC-001"}]
+        )
+
+    def test_search_unmanaged_assets_with_error(self):
+        """Test search_unmanaged_assets method when an error occurs."""
+        mock_response = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Something went wrong"}]},
+        }
+        self.client.command.return_value = mock_response
+
+        result = self.module.search_unmanaged_assets(filter="platform_name:'Windows'")
+
+        self.assertIsInstance(result, list)
+        self.assertIn("error", result[0])
+
+    def test_search_unmanaged_assets_with_all_params(self):
+        """Test search_unmanaged_assets method with all parameters."""
+        mock_response = {
+            "status_code": 200,
+            "body": {
+                "meta": {"pagination": {"offset": 10, "limit": 50, "total": 1}},
+                "resources": [{"device_id": "host1", "hostname": "PC-001"}],
+            },
+        }
+        self.client.command.return_value = mock_response
+
         result = self.module.search_unmanaged_assets(
             filter="criticality:'Critical'",
             limit=50,
@@ -209,19 +176,18 @@ class TestDiscoverModule(unittest.TestCase):
             sort="hostname.asc",
         )
 
-        # Assertions
-        # Don't check the exact arguments, just verify it was called once
-        self.assertEqual(mock_prepare_params.call_count, 1)
-        self.client.command.assert_called_once_with(
-            "combined_hosts",
-            parameters={
-                "filter": "entity_type:'unmanaged'+criticality:'Critical'",
-                "limit": 50,
-                "offset": 10,
-                "sort": "hostname.asc",
-            },
+        first_call = self.client.command.call_args_list[0]
+        self.assertEqual(first_call[0][0], "combined_hosts")
+        params = first_call[1]["parameters"]
+        self.assertEqual(
+            params["filter"], "entity_type:'unmanaged'+criticality:'Critical'"
         )
-        self.assertEqual(result, [{"device_id": "host1", "hostname": "PC-001"}])
+        self.assertEqual(params["limit"], 50)
+        self.assertEqual(params["offset"], 10)
+        self.assertEqual(params["sort"], "hostname.asc")
+        self.assertEqual(
+            result["results"], [{"device_id": "host1", "hostname": "PC-001"}]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/modules/test_dynamic.py
+++ b/tests/modules/test_dynamic.py
@@ -261,7 +261,7 @@ class TestExecuteFalconTool(unittest.TestCase):
         self.assertEqual(len(result), 20)
 
     def test_execute_empty_list_returns_normalized_dict(self):
-        """Empty list results are returned as {results:[], total_count:0, hint:...}."""
+        """Empty list results are returned as {results:[], pagination:{total:0,next:None}, hint:...}."""
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {"resources": []},
@@ -276,7 +276,8 @@ class TestExecuteFalconTool(unittest.TestCase):
         self.assertIsInstance(result, dict)
         assert isinstance(result, dict)  # narrow type for Pyright
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total_count"], 0)
+        self.assertEqual(result["pagination"]["total"], 0)
+        self.assertIsNone(result["pagination"]["next"])
         self.assertIn("hint", result)
         self.assertIn("No records returned", result["hint"])
 

--- a/tests/modules/test_exclusions.py
+++ b/tests/modules/test_exclusions.py
@@ -133,8 +133,8 @@ class TestExclusionsModule(TestModules):
                 second_call = self.mock_client.command.call_args_list[1]
                 self.assertEqual(first_call[0][0], ops[0])
                 self.assertEqual(second_call[0][0], ops[1])
-                self.assertEqual(len(result), 2)
-                self.assertEqual(result[0]["id"], "excl-1")
+                self.assertEqual(len(result["results"]), 2)
+                self.assertEqual(result["results"][0]["id"], "excl-1")
 
     def test_search_exclusions_reorders_to_match_sorted_ids(self):
         """When the get step returns exclusions out of order, the result is
@@ -162,9 +162,9 @@ class TestExclusionsModule(TestModules):
             offset=0,
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "excl-b")
-        self.assertEqual(result[1]["id"], "excl-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "excl-b")
+        self.assertEqual(result["results"][1]["id"], "excl-a")
 
     def test_search_invalid_type(self):
         """An invalid exclusion_type returns an error response, not a crash."""
@@ -181,7 +181,7 @@ class TestExclusionsModule(TestModules):
         self.assertEqual(self.mock_client.command.call_count, 0)
 
     def test_search_empty_returns_fql_guide(self):
-        """Empty query results include the FQL guide context."""
+        """Empty query results include pagination context."""
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {"resources": []},
@@ -195,7 +195,7 @@ class TestExclusionsModule(TestModules):
         )
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertIn("fql_guide", result)
+        self.assertIn("pagination", result)
 
     def test_search_error_returns_fql_guide(self):
         """Query errors include the FQL guide context."""

--- a/tests/modules/test_firewall.py
+++ b/tests/modules/test_firewall.py
@@ -64,7 +64,10 @@ class TestFirewallModule(TestModules):
         """Test searching firewall rules and fetching full details."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["rule-id-1", "rule-id-2"]},
+            "body": {
+                "resources": ["rule-id-1", "rule-id-2"],
+                "meta": {"pagination": {"offset": 0, "limit": 20, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -98,7 +101,9 @@ class TestFirewallModule(TestModules):
 
         self.assertEqual(second_call[0][0], "get_rules")
         self.assertEqual(second_call[1]["parameters"]["ids"], ["rule-id-1", "rule-id-2"])
-        self.assertEqual(len(result), 2)
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_firewall_rules_reorders_to_match_sorted_ids(self):
         """When get_rules returns rules out of order, the result is reordered
@@ -127,9 +132,9 @@ class TestFirewallModule(TestModules):
             after=None,
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "rule-id-b")
-        self.assertEqual(result[1]["id"], "rule-id-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "rule-id-b")
+        self.assertEqual(result["results"][1]["id"], "rule-id-a")
 
     def test_search_firewall_rules_empty_with_filter(self):
         """Test rule search empty results with filter returns clean empty response."""
@@ -149,7 +154,7 @@ class TestFirewallModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "name:'DoesNotExist*'")
         self.assertNotIn("fql_guide", result)
 
@@ -157,7 +162,10 @@ class TestFirewallModule(TestModules):
         """Test searching firewall rule groups and fetching full details."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["group-id-1"]},
+            "body": {
+                "resources": ["group-id-1"],
+                "meta": {"pagination": {"offset": 0, "limit": 10, "total": 1}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -181,8 +189,9 @@ class TestFirewallModule(TestModules):
         self.assertEqual(self.mock_client.command.call_count, 2)
         self.assertEqual(self.mock_client.command.call_args_list[0][0][0], "query_rule_groups")
         self.assertEqual(self.mock_client.command.call_args_list[1][0][0], "get_rule_groups")
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["id"], "group-id-1")
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["results"][0]["id"], "group-id-1")
+        self.assertEqual(result["pagination"]["total"], 1)
 
     def test_search_firewall_rule_groups_reorders_to_match_sorted_ids(self):
         """When get_rule_groups returns groups out of order, the result is reordered
@@ -211,15 +220,18 @@ class TestFirewallModule(TestModules):
             after=None,
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "group-id-b")
-        self.assertEqual(result[1]["id"], "group-id-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "group-id-b")
+        self.assertEqual(result["results"][1]["id"], "group-id-a")
 
     def test_search_firewall_policy_rules_success(self):
         """Test searching policy rules and fetching full rule details."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["rule-id-10"]},
+            "body": {
+                "resources": ["rule-id-10"],
+                "meta": {"pagination": {"offset": 0, "limit": 10, "total": 1}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -245,7 +257,8 @@ class TestFirewallModule(TestModules):
         self.assertEqual(first_call[0][0], "query_policy_rules")
         self.assertEqual(first_call[1]["parameters"]["id"], "policy-1")
         self.assertEqual(self.mock_client.command.call_args_list[1][0][0], "get_rules")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["pagination"]["total"], 1)
 
     def test_search_firewall_policy_rules_reorders_to_match_sorted_ids(self):
         """When get_rules returns policy rules out of order, the result is reordered
@@ -274,9 +287,9 @@ class TestFirewallModule(TestModules):
             q=None,
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "rule-id-b")
-        self.assertEqual(result[1]["id"], "rule-id-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "rule-id-b")
+        self.assertEqual(result["results"][1]["id"], "rule-id-a")
 
     def test_create_firewall_rule_group_success(self):
         """Test creating a firewall rule group with convenience fields."""

--- a/tests/modules/test_host_groups.py
+++ b/tests/modules/test_host_groups.py
@@ -42,6 +42,7 @@ class TestHostGroupsModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
                 "resources": [
                     {
                         "id": "group-1",
@@ -64,15 +65,16 @@ class TestHostGroupsModule(TestModules):
             sort="name.asc",
         )
 
-        # Combined search is a SINGLE command call (no two-step query->get)
         self.assertEqual(self.mock_client.command.call_count, 1)
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "queryCombinedHostGroups")
         self.assertEqual(call_args[1]["parameters"]["filter"], "group_type:'static'")
         self.assertEqual(call_args[1]["parameters"]["sort"], "name.asc")
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "group-1")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "group-1")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_host_groups_empty_results_returns_fql_guide(self):
         """Test host group search empty results return clean empty response."""
@@ -85,7 +87,7 @@ class TestHostGroupsModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "name:'nonexistent'")
         self.assertNotIn("fql_guide", result)
 
@@ -109,6 +111,7 @@ class TestHostGroupsModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
                 "resources": [
                     {"device_id": "device-1", "hostname": "PC-1"},
                     {"device_id": "device-2", "hostname": "PC-2"},
@@ -132,8 +135,10 @@ class TestHostGroupsModule(TestModules):
             call_args[1]["parameters"]["filter"], "platform_name:'Windows'"
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["device_id"], "device-1")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["device_id"], "device-1")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_host_group_members_error(self):
         """Test member search error returns wrapped error."""

--- a/tests/modules/test_hosts.py
+++ b/tests/modules/test_hosts.py
@@ -35,7 +35,10 @@ class TestHostsModule(TestModules):
         # Setup mock responses for both API calls
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["device1", "device2"]},
+            "body": {
+                "resources": ["device1", "device2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -60,18 +63,22 @@ class TestHostsModule(TestModules):
         self.assertEqual(second_call[0][0], "PostDeviceDetailsV2")
         self.assertEqual(second_call[1]["body"]["ids"], ["device1", "device2"])
 
-        # Verify result structure
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["device_id"], "device1")
-        self.assertEqual(result[1]["device_id"], "device2")
+        # Verify result envelope
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["device_id"], "device1")
+        self.assertEqual(result["results"][1]["device_id"], "device2")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_hosts_with_details(self):
         """Test searching for hosts with details."""
         # Setup mock responses
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["device1", "device2"]},
+            "body": {
+                "resources": ["device1", "device2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -109,20 +116,12 @@ class TestHostsModule(TestModules):
             "PostDeviceDetailsV2", body={"ids": ["device1", "device2"]}
         )
 
-        # Verify result
-        expected_result = [
-            {
-                "device_id": "device1",
-                "hostname": "TEST-HOST-1",
-                "platform_name": "Windows",
-            },
-            {
-                "device_id": "device2",
-                "hostname": "TEST-HOST-2",
-                "platform_name": "Linux",
-            },
-        ]
-        self.assertEqual(result, expected_result)
+        # Verify result envelope
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["device_id"], "device1")
+        self.assertEqual(result["results"][1]["device_id"], "device2")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_hosts_error(self):
         """Test searching for hosts with API error."""
@@ -144,14 +143,16 @@ class TestHostsModule(TestModules):
     def test_search_hosts_no_results(self):
         """Test searching for hosts with no results."""
         # Setup mock response with empty resources
-        mock_response = {"status_code": 200, "body": {"resources": []}}
+        mock_response = {"status_code": 200, "body": {"resources": [], "meta": {"pagination": {"offset": 0, "limit": 100, "total": 0}}}}
         self.mock_client.command.return_value = mock_response
 
         # Call search_hosts
         result = self.module.search_hosts(filter="hostname:'NONEXISTENT'")
 
-        # Verify result is empty list
-        self.assertEqual(result, [])
+        # Verify result is empty envelope
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+        self.assertIn("pagination", result)
         # Only one API call should be made (QueryDevicesByFilter)
         self.assertEqual(self.mock_client.command.call_count, 1)
 
@@ -178,7 +179,9 @@ class TestHostsModule(TestModules):
         )
 
         # Verify result
-        self.assertEqual(result, [])
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+        self.assertIn("pagination", result)
 
     def test_search_hosts_reorders_to_match_sorted_ids(self):
         """When PostDeviceDetailsV2 returns devices out of order, the result is
@@ -205,9 +208,9 @@ class TestHostsModule(TestModules):
 
         result = self.module.search_hosts(sort="last_seen.desc")
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["device_id"], "device2")
-        self.assertEqual(result[1]["device_id"], "device1")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["device_id"], "device2")
+        self.assertEqual(result["results"][1]["device_id"], "device1")
 
     def test_get_host_details(self):
         """Test getting host details."""
@@ -332,7 +335,10 @@ class TestHostsModule(TestModules):
         # Setup mock responses
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["win-host-1", "win-host-2"]},
+            "body": {
+                "resources": ["win-host-1", "win-host-2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -356,10 +362,10 @@ class TestHostsModule(TestModules):
         # Call search_hosts
         result = self.module.search_hosts(filter="platform_name:'Windows'")
 
-        # Verify result
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["platform_name"], "Windows")
-        self.assertEqual(result[1]["platform_name"], "Windows")
+        # Verify result envelope
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["platform_name"], "Windows")
+        self.assertEqual(result["results"][1]["platform_name"], "Windows")
 
         # Verify filter was applied correctly
         first_call = self.mock_client.command.call_args_list[0]
@@ -370,7 +376,13 @@ class TestHostsModule(TestModules):
     def test_search_hosts_linux_platform(self):
         """Test searching for Linux hosts."""
         # Setup mock responses
-        query_response = {"status_code": 200, "body": {"resources": ["linux-host-1"]}}
+        query_response = {
+            "status_code": 200,
+            "body": {
+                "resources": ["linux-host-1"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
+            },
+        }
         details_response = {
             "status_code": 200,
             "body": {
@@ -388,9 +400,9 @@ class TestHostsModule(TestModules):
         # Call search_hosts
         result = self.module.search_hosts(filter="platform_name:'Linux'")
 
-        # Verify result
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["platform_name"], "Linux")
+        # Verify result envelope
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["results"][0]["platform_name"], "Linux")
 
         # Verify filter was applied correctly
         first_call = self.mock_client.command.call_args_list[0]
@@ -399,14 +411,14 @@ class TestHostsModule(TestModules):
     def test_search_hosts_mac_platform_no_results(self):
         """Test searching for Mac hosts with no results."""
         # Setup mock response with empty resources
-        mock_response = {"status_code": 200, "body": {"resources": []}}
+        mock_response = {"status_code": 200, "body": {"resources": [], "meta": {"pagination": {"offset": 0, "limit": 100, "total": 0}}}}
         self.mock_client.command.return_value = mock_response
 
         # Call search_hosts
         result = self.module.search_hosts(filter="platform_name:'Mac'")
 
-        # Verify result
-        self.assertEqual(len(result), 0)
+        # Verify result envelope
+        self.assertEqual(len(result["results"]), 0)
 
         # Verify filter was applied correctly
         first_call = self.mock_client.command.call_args_list[0]

--- a/tests/modules/test_intel.py
+++ b/tests/modules/test_intel.py
@@ -70,9 +70,9 @@ class TestIntelModule(TestModules):
         )
 
         # Verify result contains expected values
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "actor1")
-        self.assertEqual(result[1]["id"], "actor2")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "actor1")
+        self.assertEqual(result["results"][1]["id"], "actor2")
 
     def test_search_actors_empty_response(self):
         """Test searching actors with empty response."""
@@ -88,8 +88,9 @@ class TestIntelModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "QueryIntelActorEntities")
 
-        # Verify result is an empty list
-        self.assertEqual(result, [])
+        # Verify result is an empty envelope
+        self.assertIn("results", result)
+        self.assertEqual(result["results"], [])
 
     def test_search_actors_error(self):
         """Test searching actors with API error."""
@@ -158,9 +159,9 @@ class TestIntelModule(TestModules):
         )
 
         # Verify result contains expected values
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "indicator1")
-        self.assertEqual(result[1]["id"], "indicator2")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "indicator1")
+        self.assertEqual(result["results"][1]["id"], "indicator2")
 
     def test_query_indicator_entities_empty_response(self):
         """Test querying indicator entities with empty response."""
@@ -176,8 +177,9 @@ class TestIntelModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "QueryIntelIndicatorEntities")
 
-        # Verify result is an empty list
-        self.assertEqual(result, [])
+        # Verify result is an empty envelope
+        self.assertIn("results", result)
+        self.assertEqual(result["results"], [])
 
     def test_query_indicator_entities_error(self):
         """Test querying indicator entities with API error."""
@@ -242,9 +244,9 @@ class TestIntelModule(TestModules):
         )
 
         # Verify result contains expected values
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "report1")
-        self.assertEqual(result[1]["id"], "report2")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "report1")
+        self.assertEqual(result["results"][1]["id"], "report2")
 
     def test_query_report_entities_empty_response(self):
         """Test querying report entities with empty response."""
@@ -260,8 +262,9 @@ class TestIntelModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "QueryIntelReportEntities")
 
-        # Verify result is an empty list
-        self.assertEqual(result, [])
+        # Verify result is an empty envelope
+        self.assertIn("results", result)
+        self.assertEqual(result["results"], [])
 
     def test_query_report_entities_error(self):
         """Test querying report entities with API error."""

--- a/tests/modules/test_ioc.py
+++ b/tests/modules/test_ioc.py
@@ -38,7 +38,10 @@ class TestIOCModule(TestModules):
         """Test searching IOCs and fetching full details."""
         search_response = {
             "status_code": 200,
-            "body": {"resources": ["ioc-id-1", "ioc-id-2"]},
+            "body": {
+                "resources": ["ioc-id-1", "ioc-id-2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -71,8 +74,10 @@ class TestIOCModule(TestModules):
         self.assertEqual(second_call[0][0], "indicator_get_v1")
         self.assertEqual(second_call[1]["parameters"]["ids"], ["ioc-id-1", "ioc-id-2"])
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "ioc-id-1")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "ioc-id-1")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_iocs_reorders_to_match_sorted_ids(self):
         """When indicator_get_v1 returns IOCs out of order, the result is reordered
@@ -99,9 +104,9 @@ class TestIOCModule(TestModules):
             sort="modified_on.desc",
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "ioc-id-b")
-        self.assertEqual(result[1]["id"], "ioc-id-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "ioc-id-b")
+        self.assertEqual(result["results"][1]["id"], "ioc-id-a")
 
     def test_search_iocs_empty_results_returns_fql_guide(self):
         """Test IOC search empty results return clean empty response."""
@@ -114,7 +119,7 @@ class TestIOCModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "value:'nothing-here'")
         self.assertNotIn("fql_guide", result)
 

--- a/tests/modules/test_policies.py
+++ b/tests/modules/test_policies.py
@@ -122,6 +122,7 @@ class TestPoliciesModule(TestModules):
         return {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 50, "total": 2}},
                 "resources": [
                     {"id": "pol-1", "name": "a", "platform_name": "Windows"},
                     {"id": "pol-2", "name": "b", "platform_name": "Windows"},
@@ -132,7 +133,10 @@ class TestPoliciesModule(TestModules):
     def _query_then_get_responses(self):
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["pol-1", "pol-2"]},
+            "body": {
+                "resources": ["pol-1", "pol-2"],
+                "meta": {"pagination": {"offset": 0, "limit": 50, "total": 2}},
+            },
         }
         get_response = {
             "status_code": 200,
@@ -180,8 +184,9 @@ class TestPoliciesModule(TestModules):
                     self.assertEqual(self.mock_client.command.call_count, 1)
                     self.assertEqual(calls[0][0][0], ops[0])  # combined op
 
-                self.assertEqual(len(result), 2)
-                self.assertEqual(result[0]["id"], "pol-1")
+                self.assertIn("results", result)
+                self.assertEqual(len(result["results"]), 2)
+                self.assertEqual(result["results"][0]["id"], "pol-1")
 
     def test_search_device_control_reorders_to_match_sorted_ids(self):
         """When getDeviceControlPoliciesV2 returns policies out of order, the
@@ -209,9 +214,9 @@ class TestPoliciesModule(TestModules):
             sort="name.asc",
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "pol-2")
-        self.assertEqual(result[1]["id"], "pol-1")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "pol-2")
+        self.assertEqual(result["results"][1]["id"], "pol-1")
 
     def test_search_invalid_type(self):
         """An invalid policy_type returns an error and makes no API call."""
@@ -266,13 +271,14 @@ class TestPoliciesModule(TestModules):
         )
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertIn("fql_guide", result)
+        self.assertIn("pagination", result)
+        self.assertIsNone(result["pagination"]["total"])
 
     def test_search_device_control_empty_returns_fql_guide(self):
-        """Empty device_control (two-step) results also include the FQL guide.
+        """Empty device_control (two-step) results return a clean empty envelope.
 
         The two-step path has its own empty-result branch (after the query op
-        returns no IDs); it must return the FQL guide dict, not a bare list.
+        returns no IDs); it must return the pagination envelope, not a bare list.
         """
         self.mock_client.command.return_value = {
             "status_code": 200,
@@ -289,7 +295,7 @@ class TestPoliciesModule(TestModules):
         self.assertEqual(self.mock_client.command.call_count, 1)
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertIn("fql_guide", result)
+        self.assertIn("pagination", result)
 
     def test_search_policy_members_per_type(self):
         """Each type calls its members op and passes the policy id through."""
@@ -300,6 +306,7 @@ class TestPoliciesModule(TestModules):
                 self.mock_client.command.return_value = {
                     "status_code": 200,
                     "body": {
+                        "meta": {"pagination": {"offset": 0, "limit": 50, "total": 1}},
                         "resources": [
                             {"device_id": "h1", "hostname": "host-1"},
                         ]
@@ -316,7 +323,7 @@ class TestPoliciesModule(TestModules):
                 call = self.mock_client.command.call_args_list[0]
                 self.assertEqual(call[0][0], ops[3])  # members op
                 self.assertEqual(call[1]["parameters"]["id"], "pol-123")
-                self.assertEqual(result[0]["device_id"], "h1")
+                self.assertEqual(result["results"][0]["device_id"], "h1")
 
     def test_search_policy_members_missing_id(self):
         """Members search without an id returns a guiding error, no API call."""

--- a/tests/modules/test_quarantine.py
+++ b/tests/modules/test_quarantine.py
@@ -64,7 +64,10 @@ class TestQuarantineModule(TestModules):
         """Test search flow returns full quarantine metadata."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["qf-1", "qf-2"]},
+            "body": {
+                "resources": ["qf-1", "qf-2"],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
+            },
         }
         get_response = {
             "status_code": 200,
@@ -101,8 +104,9 @@ class TestQuarantineModule(TestModules):
 
         self.assertEqual(second_call[0][0], "GetQuarantineFiles")
         self.assertEqual(second_call[1]["body"], {"ids": ["qf-1", "qf-2"]})
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[1]["status"], "quarantined")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][1]["status"], "quarantined")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_quarantined_files_reorders_to_match_sorted_ids(self):
         """When GetQuarantineFiles returns files out of order, the result is
@@ -129,9 +133,9 @@ class TestQuarantineModule(TestModules):
             sort="date_updated|desc",
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "qf-b")
-        self.assertEqual(result[1]["id"], "qf-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "qf-b")
+        self.assertEqual(result["results"][1]["id"], "qf-a")
 
     def test_search_quarantined_files_error_returns_fql_guide(self):
         """Test quarantine search returns FQL guide on filter error."""
@@ -159,7 +163,7 @@ class TestQuarantineModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "status:'nonexistent'")
         self.assertNotIn("fql_guide", result)
 

--- a/tests/modules/test_recon.py
+++ b/tests/modules/test_recon.py
@@ -45,7 +45,10 @@ class TestReconModule(TestModules):
         """Test two-step search pattern: QueryNotificationsV1 → GetNotificationsDetailedV1."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["notif1", "notif2"]},
+            "body": {
+                "resources": ["notif1", "notif2"],
+                "meta": {"pagination": {"offset": 0, "limit": 10, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -73,9 +76,11 @@ class TestReconModule(TestModules):
             parameters={"ids": ["notif1", "notif2"]},
         )
 
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "notif1")
+        self.assertIsInstance(result, dict)
+        self.assertIn("pagination", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "notif1")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_recon_notifications_reorders_to_match_sorted_ids(self):
         """When GetNotificationsDetailedV1 returns notifications out of order, the
@@ -101,9 +106,9 @@ class TestReconModule(TestModules):
 
         result = self.module.search_recon_notifications(sort="created_date.desc")
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "notif-b")
-        self.assertEqual(result[1]["id"], "notif-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "notif-b")
+        self.assertEqual(result["results"][1]["id"], "notif-a")
 
     def test_search_recon_notifications_empty(self):
         """Test that empty query results return the empty-response dict (no fql_guide)."""
@@ -159,7 +164,10 @@ class TestReconModule(TestModules):
         """Test two-step search pattern: QueryRulesV1 → GetRulesV1."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["rule1", "rule2"]},
+            "body": {
+                "resources": ["rule1", "rule2"],
+                "meta": {"pagination": {"offset": 0, "limit": 5, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -185,9 +193,11 @@ class TestReconModule(TestModules):
             parameters={"ids": ["rule1", "rule2"]},
         )
 
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "rule1")
+        self.assertIsInstance(result, dict)
+        self.assertIn("pagination", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "rule1")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_recon_rules_reorders_to_match_sorted_ids(self):
         """When GetRulesV1 returns rules out of order, the result is reordered
@@ -211,9 +221,9 @@ class TestReconModule(TestModules):
             filter=None, limit=5, sort="created_date.desc"
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "rule-b")
-        self.assertEqual(result[1]["id"], "rule-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "rule-b")
+        self.assertEqual(result["results"][1]["id"], "rule-a")
 
     def test_search_recon_rules_empty(self):
         """Test that empty rule query returns the empty-response dict."""
@@ -249,7 +259,10 @@ class TestReconModule(TestModules):
         """Test two-step pattern: QueryNotificationsExposedDataRecordsV1 → GetNotificationsExposedDataRecordsV1."""
         query_response = {
             "status_code": 200,
-            "body": {"resources": ["rec1", "rec2"]},
+            "body": {
+                "resources": ["rec1", "rec2"],
+                "meta": {"pagination": {"offset": 0, "limit": 10, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -277,9 +290,11 @@ class TestReconModule(TestModules):
             parameters={"ids": ["rec1", "rec2"]},
         )
 
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["email"], "user@example.com")
+        self.assertIsInstance(result, dict)
+        self.assertIn("pagination", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["email"], "user@example.com")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_recon_exposed_data_records_reorders_to_match_sorted_ids(self):
         """When GetNotificationsExposedDataRecordsV1 returns records out of order,
@@ -303,9 +318,9 @@ class TestReconModule(TestModules):
             filter=None, limit=10, sort="created_date.desc"
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "rec-b")
-        self.assertEqual(result[1]["id"], "rec-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "rec-b")
+        self.assertEqual(result["results"][1]["id"], "rec-a")
 
     def test_search_recon_exposed_data_records_empty(self):
         """Test that empty exposed-data query returns the empty-response dict."""

--- a/tests/modules/test_rtr.py
+++ b/tests/modules/test_rtr.py
@@ -103,7 +103,10 @@ class TestRTRModule(TestModules):
         """Test searching RTR sessions fetches details after IDs are returned."""
         search_response = {
             "status_code": 200,
-            "body": {"resources": ["session-1", "session-2"]},
+            "body": {
+                "resources": ["session-1", "session-2"],
+                "meta": {"pagination": {"offset": 0, "limit": 25, "total": 2}},
+            },
         }
         details_response = {
             "status_code": 200,
@@ -136,8 +139,10 @@ class TestRTRModule(TestModules):
         self.assertEqual(second_call[0][0], "RTR_ListSessions")
         self.assertEqual(second_call[1]["body"]["ids"], ["session-1", "session-2"])
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "session-1")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "session-1")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_sessions_reorders_to_match_sorted_ids(self):
         """When RTR_ListSessions returns sessions out of order, the result is
@@ -164,9 +169,9 @@ class TestRTRModule(TestModules):
             sort="created_at.desc",
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "session-b")
-        self.assertEqual(result[1]["id"], "session-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "session-b")
+        self.assertEqual(result["results"][1]["id"], "session-a")
 
     def test_search_audit_sessions(self):
         """Test searching RTR audit sessions."""
@@ -179,7 +184,8 @@ class TestRTRModule(TestModules):
                         "hostname": "BRR-WB-LIB-22",
                         "user_id": "user@example.com",
                     }
-                ]
+                ],
+                "meta": {"pagination": {"offset": 0, "limit": 25, "total": 1}},
             },
         }
 
@@ -201,7 +207,9 @@ class TestRTRModule(TestModules):
                 "with_command_info": True,
             },
         )
-        self.assertEqual(result[0]["id"], "audit-session-1")
+        self.assertIn("results", result)
+        self.assertEqual(result["results"][0]["id"], "audit-session-1")
+        self.assertEqual(result["pagination"]["total"], 1)
 
     def test_search_audit_sessions_error_returns_fql_guide(self):
         """Test audit search with API error returns the RTR audit FQL guide."""
@@ -241,7 +249,7 @@ class TestRTRModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "created_at:>'2099-01-01T00:00:00Z'")
         self.assertNotIn("fql_guide", result)
 
@@ -593,7 +601,7 @@ class TestRTRModule(TestModules):
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result["results"], [])
-        self.assertEqual(result["total"], 0)
+        self.assertIsNone(result["pagination"]["total"])
         self.assertEqual(result["filter_used"], "hostname:'nonexistent'")
         self.assertNotIn("fql_guide", result)
 

--- a/tests/modules/test_scheduled_reports.py
+++ b/tests/modules/test_scheduled_reports.py
@@ -45,7 +45,8 @@ class TestScheduledReportsModule(TestModules):
                 "resources": [
                     "report-id-1",
                     "report-id-2",
-                ]
+                ],
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 2}},
             },
         }
         get_response = {
@@ -101,11 +102,13 @@ class TestScheduledReportsModule(TestModules):
         )
 
         # Verify result contains full details
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "report-id-1")
-        self.assertEqual(result[0]["name"], "Weekly Host Report")
-        self.assertEqual(result[1]["id"], "report-id-2")
-        self.assertEqual(result[1]["name"], "Daily Vulnerability Scan")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "report-id-1")
+        self.assertEqual(result["results"][0]["name"], "Weekly Host Report")
+        self.assertEqual(result["results"][1]["id"], "report-id-2")
+        self.assertEqual(result["results"][1]["name"], "Daily Vulnerability Scan")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_scheduled_reports_reorders_to_match_sorted_ids(self):
         """When scheduled_reports_get returns reports out of order, the result is
@@ -133,9 +136,9 @@ class TestScheduledReportsModule(TestModules):
             q=None,
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "report-id-b")
-        self.assertEqual(result[1]["id"], "report-id-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "report-id-b")
+        self.assertEqual(result["results"][1]["id"], "report-id-a")
 
     def test_search_scheduled_reports_empty(self):
         """Test searching scheduled reports with empty response."""
@@ -146,8 +149,9 @@ class TestScheduledReportsModule(TestModules):
         # Call search_scheduled_reports
         result = self.module.search_scheduled_reports()
 
-        # Verify result is empty list
-        self.assertEqual(result, [])
+        # Verify result is an empty envelope
+        self.assertEqual(result["results"], [])
+        self.assertIsNone(result["pagination"]["total"])
 
     def test_search_scheduled_reports_error(self):
         """Test searching scheduled reports with API error."""
@@ -206,7 +210,8 @@ class TestScheduledReportsModule(TestModules):
                 "resources": [
                     "execution-id-1",
                     "execution-id-2",
-                ]
+                ],
+                "meta": {"pagination": {"offset": 10, "limit": 50, "total": 2}},
             },
         }
         get_response = {
@@ -260,9 +265,11 @@ class TestScheduledReportsModule(TestModules):
         )
 
         # Verify result contains full details
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "execution-id-1")
-        self.assertEqual(result[0]["status"], "DONE")
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "execution-id-1")
+        self.assertEqual(result["results"][0]["status"], "DONE")
+        self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_report_executions_reorders_to_match_sorted_ids(self):
         """When report_executions_get returns executions out of order, the result
@@ -289,9 +296,9 @@ class TestScheduledReportsModule(TestModules):
             sort="created_on.desc",
         )
 
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["id"], "execution-id-b")
-        self.assertEqual(result[1]["id"], "execution-id-a")
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["id"], "execution-id-b")
+        self.assertEqual(result["results"][1]["id"], "execution-id-a")
 
     def test_download_report_execution_csv_format(self):
         """Test downloading CSV format report returns decoded string content.

--- a/tests/modules/test_shield.py
+++ b/tests/modules/test_shield.py
@@ -158,6 +158,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [
                     {"id": "check-1", "name": "MFA Enabled", "status": "Failed", "impact": 3}
                 ]
@@ -171,8 +172,8 @@ class TestShieldModule(TestModules):
         self.assertEqual(call_args[0][0], "GetSecurityChecksV3")
         self.assertEqual(call_args[1]["parameters"]["status"], "Failed")
         self.assertEqual(call_args[1]["parameters"]["impact"], "High")
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["id"], "check-1")
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["results"][0]["id"], "check-1")
 
     def test_search_shield_checks_empty_results(self):
         self.mock_client.command.return_value = {
@@ -205,6 +206,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [
                     {"entity_name": "user@example.com", "type": "user", "dismissed": False}
                 ]
@@ -216,7 +218,7 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetSecurityCheckAffectedV3")
         self.assertEqual(call_args[1]["parameters"]["id"], "check-1")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     def test_get_shield_check_affected_entities_empty(self):
         self.mock_client.command.return_value = {
@@ -235,6 +237,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [{"total_security_checks_count": 50, "total_score_percentage": 72}]
             },
         }
@@ -244,7 +247,7 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetMetricsV3")
         self.assertEqual(call_args[1]["parameters"]["impact"], "Medium")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     # --- Functional tests: get_shield_check_compliance ---
 
@@ -252,6 +255,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [
                     {"standard": "SOC 2", "control": "CC6.1", "requirement": "Logical access"}
                 ]
@@ -263,7 +267,7 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetSecurityCheckComplianceV3")
         self.assertEqual(call_args[1]["parameters"]["id"], "check-1")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     # --- Functional tests: search_shield_alerts ---
 
@@ -278,7 +282,7 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetAlertsV3")
         self.assertEqual(call_args[1]["parameters"]["type"], "configuration_drift")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     def test_search_shield_alerts_threat_type(self):
         self.mock_client.command.return_value = {
@@ -290,7 +294,7 @@ class TestShieldModule(TestModules):
 
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[1]["parameters"]["type"], "Threat")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     def test_search_shield_alerts_empty(self):
         self.mock_client.command.return_value = {
@@ -316,7 +320,7 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetActivityMonitorV3")
         self.assertEqual(call_args[1]["parameters"]["category"], "Events")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     # --- Functional tests: search_shield_users ---
 
@@ -331,7 +335,7 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetUserInventoryV3")
         self.assertEqual(call_args[1]["parameters"]["privileged_only"], True)
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     # --- Functional tests: search_shield_devices ---
 
@@ -339,6 +343,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [
                     {"device_name": "laptop-01", "os": "macOS", "globally_compliant": True}
                 ]
@@ -349,7 +354,7 @@ class TestShieldModule(TestModules):
 
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetDeviceInventoryV3")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     # --- Functional tests: search_shield_apps ---
 
@@ -357,6 +362,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [{"app_name": "Slack", "app_type": "oauth", "access_level": "high"}]
             },
         }
@@ -366,12 +372,13 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetAppInventory")
         self.assertEqual(call_args[1]["parameters"]["type"], "oauth")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     def test_search_shield_apps_with_offset(self):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [{"app_name": "Slack", "app_type": "oauth", "access_level": "high"}]
             },
         }
@@ -381,7 +388,7 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetAppInventory")
         self.assertEqual(call_args[1]["parameters"]["offset"], 10)
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     # --- Functional tests: get_shield_app_users ---
 
@@ -389,6 +396,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [{"username": "user@example.com", "permission_grant_id": "grant-1"}]
             },
         }
@@ -398,7 +406,7 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetAppInventoryUsers")
         self.assertEqual(call_args[1]["parameters"]["item_id"], "integration-1|||app-1")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     # --- Functional tests: search_shield_data_shares ---
 
@@ -413,7 +421,7 @@ class TestShieldModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetAssetInventoryV3")
         self.assertEqual(call_args[1]["parameters"]["resource_type"], "XLSX")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     # --- Functional tests: get_shield_integrations ---
 
@@ -421,6 +429,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [
                     {"id": "int-1", "alias": "Production Google", "saas_name": "Google Workspace"}
                 ]
@@ -431,7 +440,7 @@ class TestShieldModule(TestModules):
 
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetIntegrationsV3")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     # --- Functional tests: get_shield_system_users ---
 
@@ -439,6 +448,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [{"email": "admin@cs.com", "role": "admin", "mfa_enabled": True}]
             },
         }
@@ -447,7 +457,7 @@ class TestShieldModule(TestModules):
 
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetSystemUsersV3")
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     # --- Functional tests: get_shield_supported_saas ---
 
@@ -455,6 +465,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [{"id": "google", "name": "Google Workspace"}]
             },
         }
@@ -463,8 +474,8 @@ class TestShieldModule(TestModules):
 
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "GetSupportedSaasV3")
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["id"], "google")
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["results"][0]["id"], "google")
 
     def test_get_shield_supported_saas_empty(self):
         self.mock_client.command.return_value = {
@@ -483,6 +494,7 @@ class TestShieldModule(TestModules):
         self.mock_client.command.return_value = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [
                     {"timestamp": "2026-04-29T10:00:00Z", "event_type": "integration_created"}
                 ]
@@ -498,7 +510,7 @@ class TestShieldModule(TestModules):
         self.assertEqual(call_args[1]["parameters"]["from_date"], "2026-04-01")
         self.assertEqual(call_args[1]["parameters"]["to_date"], "2026-04-30")
         self.assertEqual(call_args[1]["parameters"]["limit"], 50)
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
     def test_get_shield_system_logs_empty(self):
         self.mock_client.command.return_value = {
@@ -635,7 +647,7 @@ class TestShieldModule(TestModules):
         self.assertEqual(
             call_args[1]["parameters"]["check_type"], "Falcon Shield Security Check"
         )
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result["results"]), 1)
 
 
 if __name__ == "__main__":

--- a/tests/modules/test_spotlight.py
+++ b/tests/modules/test_spotlight.py
@@ -35,6 +35,7 @@ class TestSpotlightModule(TestModules):
         mock_response = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [
                     {
                         "cve_id": "CVE-2023-12345",
@@ -60,17 +61,18 @@ class TestSpotlightModule(TestModules):
         self.assertEqual(self.mock_client.command.call_count, 1)
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "combinedQueryVulnerabilities")
-        
+
         # Check that the parameters dictionary contains the expected filter
         params = call_args[1]["parameters"]
         self.assertEqual(params["filter"], "status:'open'")
 
         # Verify result contains expected values
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["cve_id"], "CVE-2023-12345")
-        self.assertEqual(result[0]["severity"], "HIGH")
-        self.assertEqual(result[0]["status"], "open")
-        self.assertEqual(result[0]["cvss_base_score"], 8.5)
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["results"][0]["cve_id"], "CVE-2023-12345")
+        self.assertEqual(result["results"][0]["severity"], "HIGH")
+        self.assertEqual(result["results"][0]["status"], "open")
+        self.assertEqual(result["results"][0]["cvss_base_score"], 8.5)
 
     def test_search_vulnerabilities_forwards_sort(self):
         """The sort parameter is forwarded to combinedQueryVulnerabilities.
@@ -92,12 +94,32 @@ class TestSpotlightModule(TestModules):
         self.assertEqual(call_args[0][0], "combinedQueryVulnerabilities")
         self.assertEqual(call_args[1]["parameters"]["sort"], "created_timestamp|desc")
 
+    def test_search_vulnerabilities_cursor_paging(self):
+        """A cursor response surfaces the `after` token as `pagination.next`.
+
+        Spotlight is the cursor-paged tool: the API returns `meta.pagination.after`,
+        which must round-trip into the envelope's `next` field so a client can page.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "meta": {"pagination": {"total": 500, "after": "NEXT_PAGE_TOKEN"}},
+                "resources": [{"cve_id": "CVE-2023-12345", "status": "open"}],
+            },
+        }
+
+        result = self.module.search_vulnerabilities(filter="status:'open'")
+
+        self.assert_pagination(result, total=500, has_next=True)
+        self.assertEqual(result["pagination"]["next"], "NEXT_PAGE_TOKEN")
+
     def test_search_vulnerabilities_no_filter(self):
         """Test searching vulnerabilities with no filter parameter."""
         # Setup mock response with sample vulnerability data
         mock_response = {
             "status_code": 200,
             "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 1}},
                 "resources": [
                     {
                         "cve_id": "CVE-2023-12345",
@@ -118,8 +140,8 @@ class TestSpotlightModule(TestModules):
         self.assertEqual(call_args[0][0], "combinedQueryVulnerabilities")
 
         # Verify result contains expected values
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["cve_id"], "CVE-2023-12345")
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["results"][0]["cve_id"], "CVE-2023-12345")
 
     def test_search_vulnerabilities_with_single_facet(self):
         """Test that a single facet string is forwarded unchanged to the API."""
@@ -134,7 +156,7 @@ class TestSpotlightModule(TestModules):
 
         params = call_args[1]["parameters"]
         self.assertEqual(params["facet"], "cve")
-        self.assertEqual(result, [])
+        self.assertEqual(result["results"], [])
 
     def test_search_vulnerabilities_with_multiple_facets(self):
         """Test that a list of facets is forwarded intact (no joining/mangling)."""
@@ -152,7 +174,7 @@ class TestSpotlightModule(TestModules):
 
         params = call_args[1]["parameters"]
         self.assertEqual(params["facet"], ["cve", "host_info", "remediation"])
-        self.assertEqual(result, [])
+        self.assertEqual(result["results"], [])
 
     def test_search_vulnerabilities_facet_empty_list(self):
         """Test that an empty facet list is forwarded as-is (no facets requested)."""
@@ -187,7 +209,13 @@ class TestSpotlightModule(TestModules):
     def test_search_vulnerabilities_empty_response(self):
         """Test searching vulnerabilities with empty response."""
         # Setup mock response with empty resources
-        mock_response = {"status_code": 200, "body": {"resources": []}}
+        mock_response = {
+            "status_code": 200,
+            "body": {
+                "meta": {"pagination": {"offset": 0, "limit": 100, "total": 0}},
+                "resources": [],
+            },
+        }
         self.mock_client.command.return_value = mock_response
 
         # Call search_vulnerabilities
@@ -198,8 +226,9 @@ class TestSpotlightModule(TestModules):
         call_args = self.mock_client.command.call_args
         self.assertEqual(call_args[0][0], "combinedQueryVulnerabilities")
 
-        # Verify result is an empty list
-        self.assertEqual(result, [])
+        # Verify result has empty results list
+        self.assertIn("results", result)
+        self.assertEqual(result["results"], [])
 
     def test_search_vulnerabilities_error(self):
         """Test searching vulnerabilities with API error."""

--- a/tests/modules/utils/test_modules.py
+++ b/tests/modules/utils/test_modules.py
@@ -83,3 +83,18 @@ class TestModules(unittest.TestCase):
                 self.assertEqual(call.kwargs.get("annotations"), expected_annotations)
                 return
         self.fail(f"Tool {tool_name} not found in registered tools")
+
+    def assert_pagination(self, result, total, has_next=False):
+        """Verify the `pagination` key of a search-tool response envelope.
+
+        Args:
+            result: The dict returned by a search tool (must contain "pagination")
+            total: Expected value of pagination["total"]
+            has_next: Whether pagination["next"] is expected to be non-None
+        """
+        self.assertIn("pagination", result)
+        self.assertEqual(result["pagination"]["total"], total)
+        if has_next:
+            self.assertIsNotNone(result["pagination"].get("next"))
+        else:
+            self.assertIsNone(result["pagination"].get("next"))


### PR DESCRIPTION
Search tools now return a structured envelope with results, pagination (total/offset/limit/next), and filter_used instead of the old ad-hoc empty-response shape. This gives callers a consistent place to read how many records matched, where they are in the result set, and the cursor for the next page, across every search module. A new `_base_search_with_meta` grabs `body.meta.pagination` before the hydration step throws it away, and `_build_pagination_envelope` assembles the response the same way everywhere.

The total reflects exactly what the API reports: a number when the API provides a count, and null when it doesn't, so callers can tell a real count apart from an unknown one and answer "how many" only when the data actually supports it. I checked against the live API which operations report a total and updated the docstrings to match. Shield's activity monitor is the one operation that omits a total, so its docstring calls that out and the Shield resource note is scoped to just that operation.

While wiring this up I also fixed two things the change surfaced: the doc generator was silently blanking resource descriptions whenever a `description=` literal had been reflowed across multiple lines, and the integration-test list-response helper would raise a TypeError on a null total. Both are handled now, and the module docs are regenerated to match.

Closes #234 