### PR TITLE
feat(modules/ngsiem): add CQL authoring guidance to search tool

### DIFF
--- a/docs/modules/ngsiem.md
+++ b/docs/modules/ngsiem.md
@@ -19,18 +19,25 @@ Running search queries against CrowdStrike's Next-Gen SIEM via the asynchronous 
 
 Execute a CQL (CrowdStrike Query Language) query against CrowdStrike Next-Gen SIEM.
 
-Use this to search security events, logs, and telemetry. CQL is a pipe-based
-language (`filter | command | command`); build the query from the LogScale
-references cited in the query_string parameter. Start from a tag or field
-filter (e.g. `#event_simpleName=ProcessRollup2`, `UserName=*`) and keep the
-time range tight before adding pipes like `groupBy([...], function=count())`
-or `sort()`. Returns matching event records, or an error dict if the job fails
-or times out. Note: the API does not return detailed CQL parser diagnostics on
-a malformed query, so get the query structure right from the references rather
-than relying on error feedback. Search times out after FALCON_MCP_NGSIEM_TIMEOUT
-seconds (default: 300).
+Use this to search security events, logs, and telemetry with CQL. CQL is a
+pipe-based language (`filter | command | command`): start from a tag or field
+filter (e.g. `#event_simpleName=ProcessRollup2`, `UserName=*`) and pipe into
+commands like `groupBy([...], function=count())` and `sort()`; keep the time
+range tight. Consult `falcon://ngsiem/search/cql-guide` to construct the query —
+it has the pipe model, core commands, and working examples (distinct count, time
+bucketing, regex match, filtering on an aggregate). Returns matching event
+records, or an error/empty dict carrying the CQL guide when the job fails,
+times out, or returns no rows. Note: the API does not return detailed CQL parser
+diagnostics — a malformed query may error or silently return unexpected/empty
+results rather than a helpful message, so a result is not proof the query parsed
+as intended. Search times out after FALCON_MCP_NGSIEM_TIMEOUT seconds
+(default: 300).
 
 **Example prompts:**
 
 - "Run this CQL query for the last 24 hours: #event_simpleName=ProcessRollup2"
 - "Search NGSIEM for DNS events from January 2025"
+
+## Resources
+
+- **`falcon://ngsiem/search/cql-guide`**: Contains the CQL authoring guide for the `query_string` param of the `falcon_search_ngsiem` tool.

--- a/docs/modules/ngsiem.md
+++ b/docs/modules/ngsiem.md
@@ -17,12 +17,18 @@ Running search queries against CrowdStrike's Next-Gen SIEM via the asynchronous 
 
 **Required scopes:** `NGSIEM:read`, `NGSIEM:write`
 
-Execute a CQL query against CrowdStrike Next-Gen SIEM.
+Execute a CQL (CrowdStrike Query Language) query against CrowdStrike Next-Gen SIEM.
 
-Use this to search security events, logs, and telemetry; callers must supply
-a complete, valid CQL query — this tool does not assist with query construction.
-Returns matching event records, or an error dict if the job fails or times out.
-Search times out after FALCON_MCP_NGSIEM_TIMEOUT seconds (default: 300).
+Use this to search security events, logs, and telemetry. CQL is a pipe-based
+language (`filter | command | command`); build the query from the LogScale
+references cited in the query_string parameter. Start from a tag or field
+filter (e.g. `#event_simpleName=ProcessRollup2`, `UserName=*`) and keep the
+time range tight before adding pipes like `groupBy([...], function=count())`
+or `sort()`. Returns matching event records, or an error dict if the job fails
+or times out. Note: the API does not return detailed CQL parser diagnostics on
+a malformed query, so get the query structure right from the references rather
+than relying on error feedback. Search times out after FALCON_MCP_NGSIEM_TIMEOUT
+seconds (default: 300).
 
 **Example prompts:**
 

--- a/falcon_mcp/dynamic.py
+++ b/falcon_mcp/dynamic.py
@@ -15,7 +15,7 @@ from pydantic import Field
 
 from falcon_mcp.common.fql import FQL_FILTER_HINT_SUFFIX
 from falcon_mcp.common.logging import get_logger
-from falcon_mcp.filter_hints import FILTER_HINTS
+from falcon_mcp.filter_hints import FILTER_HINTS, QUERY_STRING_HINTS
 from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS, BaseModule
 
 logger = get_logger(__name__)
@@ -117,6 +117,14 @@ class DynamicToolCatalog:
             desc = params_summary["filter"]["description"]
             separator = " " if desc.endswith(".") else ". "
             params_summary["filter"]["description"] = desc + separator + FQL_FILTER_HINT_SUFFIX
+
+        # CQL tools use a `query_string` param instead of an FQL `filter`; inject the
+        # curated CQL hint there so dynamic mode reaches the model the same way.
+        cql_hint = QUERY_STRING_HINTS.get(entry.tool.name)
+        if cql_hint and "query_string" in params_summary:
+            desc = params_summary["query_string"]["description"]
+            separator = " " if desc.endswith(".") else ". "
+            params_summary["query_string"]["description"] = desc + separator + cql_hint
 
         annotations = entry.tool.annotations
         return {

--- a/falcon_mcp/filter_hints.py
+++ b/falcon_mcp/filter_hints.py
@@ -269,3 +269,20 @@ FILTER_HINTS: dict[str, str] = {
         "cve.exploit_status, created_timestamp (UTC datetime)."
     ),
 }
+
+
+# Curated inline CQL hints for tools that take a `query_string` (CQL) parameter
+# instead of an FQL `filter`. Injected onto the query_string param description in
+# dynamic mode, mirroring FILTER_HINTS for FQL filters.
+QUERY_STRING_HINTS: dict[str, str] = {
+    # === NGSIEM ===
+    "falcon_search_ngsiem": (
+        "CQL is pipe-based: `filter | command | command` — not SQL or Splunk SPL "
+        "(no SELECT/WHERE/stats/`| limit`). Start from a tag filter "
+        "`#event_simpleName=ProcessRollup2`, then pipe into `groupBy([field], "
+        "function=count())`, `sort(_count, order=desc)`, and `head(n)` to cap raw "
+        "events. For distinct count, time bucketing, regex/contains match, or "
+        "filtering on an aggregate, see `falcon://ngsiem/search/cql-guide`."
+    ),
+}
+

--- a/falcon_mcp/modules/ngsiem.py
+++ b/falcon_mcp/modules/ngsiem.py
@@ -11,13 +11,28 @@ from datetime import datetime
 from typing import Any
 
 from mcp.server import FastMCP
-from pydantic import Field
+from mcp.server.fastmcp.resources import TextResource
+from pydantic import AnyUrl, Field
 
 from falcon_mcp.common.errors import _format_error_response, handle_api_response
 from falcon_mcp.common.logging import get_logger
 from falcon_mcp.modules.base import BaseModule
+from falcon_mcp.resources.ngsiem import SEARCH_NGSIEM_CQL_DOCUMENTATION
 
 logger = get_logger(__name__)
+
+# Hint appended to error/empty responses steering the model to the CQL guide.
+_CQL_ERROR_HINT = (
+    "Review the CQL guide above and correct your query. CQL is a pipe-based "
+    "language (filter | command | command) — not SQL or Splunk SPL. Consult "
+    "`falcon://ngsiem/search/cql-guide` for the syntax and working examples."
+)
+_CQL_EMPTY_HINT = (
+    "0 events returned. This can mean no data matched, but it is also how the API "
+    "reports an invalid query (it free-text-matches malformed CQL rather than "
+    "erroring). If this is unexpected, review the CQL guide above and verify your "
+    "query syntax and field names. Consult `falcon://ngsiem/search/cql-guide`."
+)
 
 # Configurable polling settings
 POLL_INTERVAL_SECONDS = int(os.environ.get("FALCON_MCP_NGSIEM_POLL_INTERVAL", "5"))
@@ -52,20 +67,66 @@ class NGSIEMModule(BaseModule):
             name="search_ngsiem",
         )
 
+    def register_resources(self, server: FastMCP) -> None:
+        """Register resources with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        search_ngsiem_cql_resource = TextResource(
+            uri=AnyUrl("falcon://ngsiem/search/cql-guide"),
+            name="falcon_search_ngsiem_cql_guide",
+            description="Contains the CQL authoring guide for the `query_string` param of the `falcon_search_ngsiem` tool.",
+            text=SEARCH_NGSIEM_CQL_DOCUMENTATION,
+        )
+
+        self._add_resource(
+            server,
+            search_ngsiem_cql_resource,
+        )
+
+    def _format_cql_error_response(
+        self,
+        error_response: dict[str, Any],
+        query_string: str,
+    ) -> dict[str, Any]:
+        """Augment an error response with the CQL guide and a repair hint.
+
+        Reaches the model with the full CQL authoring guide exactly when its query
+        failed, so it can correct the syntax and retry. Mirrors
+        `_format_fql_error_response` but for CQL (the API returns no CQL parser
+        diagnostics, so the guide is the only actionable signal).
+
+        Args:
+            error_response: The error dict produced by the shared error handlers
+            query_string: The CQL query that was attempted
+
+        Returns:
+            The error dict with `cql_guide`, `hint`, and `query_used` added
+        """
+        error_response["query_used"] = query_string
+        error_response["cql_guide"] = SEARCH_NGSIEM_CQL_DOCUMENTATION
+        error_response["hint"] = _CQL_ERROR_HINT
+        return error_response
+
     async def search_ngsiem(
         self,
         query_string: str = Field(
             description=(
-                "The CQL (CrowdStrike Query Language) query string to execute. "
-                "CQL is a pipe-based language: `filter | command | command`. "
-                "Ex: '#event_simpleName=ProcessRollup2 | head(5)' or "
+                "The CQL (CrowdStrike Query Language) query to execute. "
+                "Consult `falcon://ngsiem/search/cql-guide` to construct this query. "
+                "CQL is pipe-based: `filter | command | command` — not SQL or Splunk "
+                "SPL (do not use SELECT/WHERE/stats/`| limit`). Build a query by "
+                "starting from a tag or field filter and piping into commands. "
+                "Common building blocks: tag filter `#event_simpleName=ProcessRollup2`; "
+                "field match `UserName=*`; aggregate `groupBy([ComputerName], function=count())`; "
+                "order `sort(_count, order=desc)`; limit raw events `head(5)`. "
+                "Examples: '#event_simpleName=ProcessRollup2 | head(5)' and "
                 "'#event_simpleName=ProcessRollup2 | groupBy([ComputerName], function=count()) "
                 "| sort(_count, order=desc)'. "
-                "For CQL syntax and functions, consult the LogScale references: "
-                "grammar subset for generating queries "
-                "(https://library.humio.com/lql-grammar/syntax-grammar-guide.html), "
-                "syntax (https://library.humio.com/data-analysis/syntax.html), and "
-                "functions (https://library.humio.com/data-analysis/functions.html)."
+                "For anything beyond these building blocks (distinct count, time "
+                "bucketing, regex/contains match, filtering on an aggregate), read "
+                "`falcon://ngsiem/search/cql-guide` — it has working examples."
             ),
         ),
         start: str = Field(
@@ -78,12 +139,16 @@ class NGSIEMModule(BaseModule):
         repository: str = Field(
             default="search-all",
             description=(
-                "Repository to search. Valid options: "
-                "search-all (default - all event data), "
+                "Repository (or view) to search. Defaults to search-all (all event "
+                "data). Which repositories exist depends on the users tenant and its "
+                "configuration, so this is not a closed list. Common repositories/views: "
+                "search-all (all event data), "
                 "investigate_view (endpoint events), "
+                "xdr (XDR data), "
                 "third-party (third-party source events), "
                 "falcon_for_it_view (Falcon for IT data), "
-                "forensics_view (Falcon Forensics triage data)"
+                "forensics_view (Falcon Forensics triage data). "
+                "Custom and other built-in repositories/views can also be passed by name."
             ),
         ),
         end: str | None = Field(
@@ -98,16 +163,19 @@ class NGSIEMModule(BaseModule):
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Execute a CQL (CrowdStrike Query Language) query against CrowdStrike Next-Gen SIEM.
 
-        Use this to search security events, logs, and telemetry. CQL is a pipe-based
-        language (`filter | command | command`); build the query from the LogScale
-        references cited in the query_string parameter. Start from a tag or field
-        filter (e.g. `#event_simpleName=ProcessRollup2`, `UserName=*`) and keep the
-        time range tight before adding pipes like `groupBy([...], function=count())`
-        or `sort()`. Returns matching event records, or an error dict if the job fails
-        or times out. Note: the API does not return detailed CQL parser diagnostics on
-        a malformed query, so get the query structure right from the references rather
-        than relying on error feedback. Search times out after FALCON_MCP_NGSIEM_TIMEOUT
-        seconds (default: 300).
+        Use this to search security events, logs, and telemetry with CQL. CQL is a
+        pipe-based language (`filter | command | command`): start from a tag or field
+        filter (e.g. `#event_simpleName=ProcessRollup2`, `UserName=*`) and pipe into
+        commands like `groupBy([...], function=count())` and `sort()`; keep the time
+        range tight. Consult `falcon://ngsiem/search/cql-guide` to construct the query —
+        it has the pipe model, core commands, and working examples (distinct count, time
+        bucketing, regex match, filtering on an aggregate). Returns matching event
+        records, or an error/empty dict carrying the CQL guide when the job fails,
+        times out, or returns no rows. Note: the API does not return detailed CQL parser
+        diagnostics — a malformed query may error or silently return unexpected/empty
+        results rather than a helpful message, so a result is not proof the query parsed
+        as intended. Search times out after FALCON_MCP_NGSIEM_TIMEOUT seconds
+        (default: 300).
         """
         # Step 1: Start the search job
         # Note: FalconPy uber class passes body unchanged; API expects camelCase keys
@@ -128,20 +196,22 @@ class NGSIEMModule(BaseModule):
 
         start_status = start_response.get("status_code")
         if start_status != 200:
-            return handle_api_response(
+            error_response = handle_api_response(
                 start_response,
                 operation="StartSearchV1",
                 error_message="Failed to start NGSIEM search",
                 default_result=[],
             )
+            return self._format_cql_error_response(error_response, query_string)
 
         job_id = start_response.get("body", {}).get("id")
         if not job_id:
-            return _format_error_response(
+            error_response = _format_error_response(
                 message="Failed to start NGSIEM search: no job ID returned",
                 details=start_response.get("body", {}),
                 operation="StartSearchV1",
             )
+            return self._format_cql_error_response(error_response, query_string)
 
         logger.debug("NGSIEM search job started: %s", job_id)
 
@@ -159,17 +229,29 @@ class NGSIEMModule(BaseModule):
 
             poll_status = poll_response.get("status_code")
             if poll_status != 200:
-                return handle_api_response(
+                error_response = handle_api_response(
                     poll_response,
                     operation="GetSearchStatusV1",
                     error_message="Failed to poll NGSIEM search status",
                     default_result=[],
                 )
+                return self._format_cql_error_response(error_response, query_string)
 
             body = poll_response.get("body", {})
             if body.get("done"):
                 logger.debug("NGSIEM search job completed: %s", job_id)
-                return body.get("events", [])
+                events = body.get("events", [])
+                if not events:
+                    # The API free-text-matches invalid CQL and returns 200 with an
+                    # empty list, so an empty result is the most common silent-failure
+                    # signal. Return the guide + hint so the model can self-correct.
+                    return {
+                        "results": [],
+                        "query_used": query_string,
+                        "cql_guide": SEARCH_NGSIEM_CQL_DOCUMENTATION,
+                        "hint": _CQL_EMPTY_HINT,
+                    }
+                return events
 
         # Step 3: Timeout — attempt cleanup
         logger.warning("NGSIEM search job timed out: %s", job_id)
@@ -179,9 +261,10 @@ class NGSIEMModule(BaseModule):
             id=job_id,
         )
 
-        return _format_error_response(
+        error_response = _format_error_response(
             message=f"NGSIEM search timed out after {TIMEOUT_SECONDS} seconds. "
             "Try narrowing your query or reducing the time range.",
             details={"job_id": job_id, "timeout_seconds": TIMEOUT_SECONDS},
             operation="GetSearchStatusV1",
         )
+        return self._format_cql_error_response(error_response, query_string)

--- a/falcon_mcp/modules/ngsiem.py
+++ b/falcon_mcp/modules/ngsiem.py
@@ -56,10 +56,16 @@ class NGSIEMModule(BaseModule):
         self,
         query_string: str = Field(
             description=(
-                "The CQL query string to execute. "
-                "This tool executes pre-written CQL queries - it does NOT help construct queries. "
-                "Users must provide a complete, valid CQL query. "
-                "Example: '#event_simpleName=ProcessRollup2' or 'source=firewall | count()'"
+                "The CQL (CrowdStrike Query Language) query string to execute. "
+                "CQL is a pipe-based language: `filter | command | command`. "
+                "Ex: '#event_simpleName=ProcessRollup2 | head(5)' or "
+                "'#event_simpleName=ProcessRollup2 | groupBy([ComputerName], function=count()) "
+                "| sort(_count, order=desc)'. "
+                "For CQL syntax and functions, consult the LogScale references: "
+                "grammar subset for generating queries "
+                "(https://library.humio.com/lql-grammar/syntax-grammar-guide.html), "
+                "syntax (https://library.humio.com/data-analysis/syntax.html), and "
+                "functions (https://library.humio.com/data-analysis/functions.html)."
             ),
         ),
         start: str = Field(
@@ -90,12 +96,18 @@ class NGSIEMModule(BaseModule):
             examples={"2025-01-01T00:00:00Z"},
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Execute a CQL query against CrowdStrike Next-Gen SIEM.
+        """Execute a CQL (CrowdStrike Query Language) query against CrowdStrike Next-Gen SIEM.
 
-        Use this to search security events, logs, and telemetry; callers must supply
-        a complete, valid CQL query — this tool does not assist with query construction.
-        Returns matching event records, or an error dict if the job fails or times out.
-        Search times out after FALCON_MCP_NGSIEM_TIMEOUT seconds (default: 300).
+        Use this to search security events, logs, and telemetry. CQL is a pipe-based
+        language (`filter | command | command`); build the query from the LogScale
+        references cited in the query_string parameter. Start from a tag or field
+        filter (e.g. `#event_simpleName=ProcessRollup2`, `UserName=*`) and keep the
+        time range tight before adding pipes like `groupBy([...], function=count())`
+        or `sort()`. Returns matching event records, or an error dict if the job fails
+        or times out. Note: the API does not return detailed CQL parser diagnostics on
+        a malformed query, so get the query structure right from the references rather
+        than relying on error feedback. Search times out after FALCON_MCP_NGSIEM_TIMEOUT
+        seconds (default: 300).
         """
         # Step 1: Start the search job
         # Note: FalconPy uber class passes body unchanged; API expects camelCase keys

--- a/falcon_mcp/resources/ngsiem.py
+++ b/falcon_mcp/resources/ngsiem.py
@@ -1,0 +1,124 @@
+"""
+Contains NGSIEM resources.
+"""
+
+SEARCH_NGSIEM_CQL_DOCUMENTATION = """# CQL (CrowdStrike Query Language) authoring guide for `falcon_search_ngsiem`
+
+This tool **executes** a CQL query you supply against CrowdStrike Next-Gen SIEM. It
+does not generate CQL for you. Use this guide to construct a valid query before
+calling the tool.
+
+CQL is the LogScale/Humio query language. It is a pipe-based, left-to-right data
+pipeline — NOT SQL and NOT Splunk SPL. Do not use `SELECT`, `WHERE`, `stats`,
+`| top`, `| limit N`, or `event_type = X`. Those are the most common mistakes.
+
+## The pipe model
+
+A query is a chain of stages joined by `|`, read left to right:
+
+```
+<filter> | <command> | <command> | ...
+```
+
+Each stage takes the events from the stage before it and transforms them. Start by
+filtering to the events you want, then pipe into aggregation, sorting, and limiting.
+
+## Core building blocks
+
+- **Tag filter** — restrict to an event type by its tag field:
+  `#event_simpleName=ProcessRollup2`
+- **Field match** — match on a field value: `UserName=admin`, `ComputerName=*`.
+  Combine filters with a space (implicit AND): `#event_simpleName=ProcessRollup2 ComputerName=DC01`
+- **Field creation / assignment** — create a new field with `:=`:
+  `total := count()` inside a command, or `field := expression`.
+- **`groupBy([fields], function=...)`** — aggregate. Group by one or more fields and
+  apply an aggregate function. The result columns are the group fields plus the
+  function output (default column name `_count` for `count()`):
+  `groupBy([ComputerName], function=count())`
+- **`sort(field, order=desc)`** — order rows. Order is `asc` or `desc`. `sort()` also
+  takes an optional `limit=`: `sort(_count, order=desc, limit=5)`.
+- **`head(n)`** — keep `n` events, **oldest first**. Use `tail(n)` for the most recent
+  `n` events, or `sort(@timestamp, order=desc, limit=n)` to order by newest. To cap raw
+  results, use `head(n)`/`tail(n)` — NOT `| limit n`.
+- **`tail(n)`** — keep the most recent `n` events.
+
+## Worked examples
+
+Build from these. They cover the shapes that are easy to get wrong.
+
+**A sample of events (cap the count):**
+```
+#event_simpleName=ProcessRollup2 | head(20)
+```
+(`head` returns oldest-first; for the most recent events use `tail(20)` or
+`sort(@timestamp, order=desc, limit=20)`.)
+
+**Top N by count (group, then sort, then limit):**
+```
+#event_simpleName=ProcessRollup2 | groupBy([ComputerName], function=count(as=process_count)) | sort(process_count, order=desc, limit=5)
+```
+
+**Two-level grouping (count per pair of fields):**
+```
+#event_simpleName=ProcessRollup2 | groupBy([ComputerName, FileName], function=count(as=cnt)) | sort(cnt, order=desc, limit=10)
+```
+
+**Distinct count** — count unique values of a field. Use the `count()` function with
+the field as its first (positional) argument and `distinct=true` (NOT SQL
+`COUNT(DISTINCT ...)`):
+```
+#event_simpleName=ProcessRollup2 | count(ComputerName, distinct=true, as=distinct_hosts)
+```
+
+**Filter on an aggregate** — compute a count, then keep only groups above a
+threshold. The filter goes AFTER the `groupBy`, matching on the aggregate's output
+column (a bare field-comparison stage, not a `WHERE` clause):
+```
+#event_simpleName=ProcessRollup2 | groupBy([ComputerName], function=count(as=cnt)) | cnt > 100 | sort(cnt, order=desc)
+```
+
+**Time bucketing / time series** — bucket events into fixed intervals with
+`bucket()` (aka `timeChart`-style). `bucket()` splits the time range into `buckets`
+or by `span`, applying an aggregate per bucket:
+```
+#event_simpleName=ProcessRollup2 | bucket(span=5m, function=count())
+```
+
+**Case-insensitive substring match** — match a field against a regex with
+`field=/pattern/i` (the `i` flag makes it case-insensitive). To match a FileName
+containing `powershell` case-insensitively, then show 10 events:
+```
+#event_simpleName=ProcessRollup2 FileName=/powershell/i | head(10)
+```
+
+**Regex match on a field** — `field=/pattern/` matches the field against a regex. Add
+`i` after the closing slash for case-insensitive matching. (The `=~` operator is
+something else — it pipes a field into a function like `wildcard()`, not a bare regex.)
+
+## Important caveat: no useful parser error on failure
+
+The API does NOT return a detailed CQL parser diagnostic. A malformed query may come
+back with a generic error, or — worse — the API free-text-matches the raw query text
+and returns HTTP 200 with unrelated rows or an empty result. **A result is not proof
+your query parsed as intended.** Because of this:
+
+- Do NOT rely on a "run it, read the parser error, repair" loop — the error signal is
+  not reliable here.
+- Construct the query correctly up front using the shapes above.
+- If a query returns unexpected rows or zero rows, re-check the syntax against this
+  guide (SPL/SQL-isms and a missing/incorrect `#tag` filter are the usual causes)
+  rather than assuming the data simply isn't there.
+
+## Authoritative external references
+
+For constructs beyond the building blocks above, CrowdStrike publishes the full
+LogScale reference. These links are optional depth, not required reading:
+
+- CQL grammar subset (built for programmatically generating queries):
+  <https://library.humio.com/lql-grammar/syntax-grammar-guide.html>
+- Query language syntax: <https://library.humio.com/data-analysis/syntax.html>
+- Query functions reference: <https://library.humio.com/data-analysis/functions.html>
+- Getting started: <https://library.humio.com/logscale-getting-started/beginner-introduction.html>
+- Real community queries and parsers to crib from:
+  <https://github.com/CrowdStrike/logscale-community-content>
+"""

--- a/tests/modules/test_dynamic.py
+++ b/tests/modules/test_dynamic.py
@@ -10,10 +10,11 @@ from unittest.mock import MagicMock, patch
 
 from falcon_mcp import registry
 from falcon_mcp.dynamic import DynamicMode, DynamicToolCatalog
-from falcon_mcp.filter_hints import FILTER_HINTS
+from falcon_mcp.filter_hints import FILTER_HINTS, QUERY_STRING_HINTS
 from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.modules.detections import DetectionsModule
 from falcon_mcp.modules.hosts import HostsModule
+from falcon_mcp.modules.ngsiem import NGSIEMModule
 
 _T = TypeVar("_T")
 
@@ -145,6 +146,43 @@ class TestDynamicToolCatalog(unittest.TestCase):
         detail_result = next(r for r in results if r["name"] == "falcon_get_detection_details")
         ids_param = detail_result["parameters"]["ids"]
         self.assertNotIn("examples", ids_param)
+
+    def test_format_entry_appends_cql_hint_to_query_string(self):
+        """The NGSIEM CQL hint is injected onto the query_string param, not filter."""
+        modules: dict[str, BaseModule] = {"ngsiem": NGSIEMModule(self.mock_client)}
+        catalog = DynamicToolCatalog(modules)
+        results = catalog.search(query="search_ngsiem")
+        ngsiem_result = next(r for r in results if r["name"] == "falcon_search_ngsiem")
+        params = ngsiem_result["parameters"]
+        # NGSIEM has no FQL filter param — the hint lands on query_string.
+        self.assertNotIn("filter", params)
+        query_desc = params["query_string"]["description"]
+        self.assertIn("pipe-based", query_desc)
+        self.assertIn("falcon://ngsiem/search/cql-guide", query_desc)
+
+    def test_query_string_hints_no_orphan_keys(self):
+        """Every QUERY_STRING_HINTS key maps to a tool with a query_string param."""
+        from falcon_mcp.client import FalconClient
+
+        mock_client = MagicMock(spec=FalconClient)
+        all_modules = {
+            name: cls(mock_client)
+            for name, cls in registry.get_available_modules().items()
+        }
+        catalog = DynamicToolCatalog(all_modules)
+        for hint_key in QUERY_STRING_HINTS:
+            entry = catalog.entries.get(hint_key)
+            self.assertIsNotNone(
+                entry,
+                f"QUERY_STRING_HINTS has orphan key '{hint_key}' — no matching tool found.",
+            )
+            assert entry is not None  # narrow for type checker
+            properties = entry.tool.parameters.get("properties", {})
+            self.assertIn(
+                "query_string",
+                properties,
+                f"QUERY_STRING_HINTS key '{hint_key}' maps to a tool without a query_string param.",
+            )
 
     def test_filter_hints_registry_covers_search_tools(self):
         """Verify that all tools with FQL filter params have hints registered."""

--- a/tests/modules/test_ngsiem.py
+++ b/tests/modules/test_ngsiem.py
@@ -25,6 +25,13 @@ class TestNGSIEMModule(TestModules):
         ]
         self.assert_tools_registered(expected_tools)
 
+    def test_register_resources(self):
+        """Test registering resources with the server."""
+        expected_resources = [
+            "falcon_search_ngsiem_cql_guide",
+        ]
+        self.assert_resources_registered(expected_resources)
+
     @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
     def test_search_ngsiem_success(self, mock_sleep):
         """Test search that completes on first poll returns events list."""
@@ -138,6 +145,11 @@ class TestNGSIEMModule(TestModules):
         self.assertIsInstance(result, dict)
         self.assertIn("error", result)
         self.assertIn("Failed to start NGSIEM search", result["error"])
+        # Verify the CQL guide + repair hint reach the model on failure
+        self.assertIn("cql_guide", result)
+        self.assertIn("CQL", result["cql_guide"])
+        self.assertIn("hint", result)
+        self.assertEqual(result["query_used"], "aid=abc123")
 
     @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
     def test_search_ngsiem_poll_error(self, mock_sleep):
@@ -163,6 +175,10 @@ class TestNGSIEMModule(TestModules):
         self.assertIsInstance(result, dict)
         self.assertIn("error", result)
         self.assertIn("Failed to poll NGSIEM search status", result["error"])
+        # Verify the CQL guide + repair hint reach the model on failure
+        self.assertIn("cql_guide", result)
+        self.assertIn("hint", result)
+        self.assertEqual(result["query_used"], "aid=abc123")
 
     @patch("falcon_mcp.modules.ngsiem.TIMEOUT_SECONDS", 10)
     @patch("falcon_mcp.modules.ngsiem.POLL_INTERVAL_SECONDS", 5)
@@ -210,6 +226,10 @@ class TestNGSIEMModule(TestModules):
         self.assertIn("details", result)
         self.assertEqual(result["details"]["job_id"], "job-timeout")
         self.assertEqual(result["details"]["timeout_seconds"], 10)
+        # Verify the CQL guide + repair hint reach the model on timeout
+        self.assertIn("cql_guide", result)
+        self.assertIn("hint", result)
+        self.assertEqual(result["query_used"], "aid=abc123")
 
     @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
     def test_search_ngsiem_with_optional_params(self, mock_sleep):
@@ -242,9 +262,12 @@ class TestNGSIEMModule(TestModules):
         params = first_call[1]
         self.assertEqual(params["repository"], "investigate_view")
 
-        # Verify result
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 0)
+        # Verify empty result returns the dict envelope carrying the CQL guide + hint
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["results"], [])
+        self.assertIn("cql_guide", result)
+        self.assertIn("hint", result)
+        self.assertEqual(result["query_used"], "aid=abc123")
 
     @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
     def test_search_ngsiem_default_repository(self, mock_sleep):
@@ -310,8 +333,9 @@ class TestNGSIEMModule(TestModules):
         first_call = self.mock_client.command.call_args_list[0]
         self.assertEqual(first_call[1]["body"]["queryString"], special_query)
 
-        # Should still return valid result
-        self.assertIsInstance(result, list)
+        # Empty events now return the dict envelope; the query is echoed back verbatim
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["query_used"], special_query)
 
     @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
     def test_search_ngsiem_missing_job_id(self, mock_sleep):
@@ -336,6 +360,10 @@ class TestNGSIEMModule(TestModules):
         self.assertIsInstance(result, dict)
         self.assertIn("error", result)
         self.assertIn("no job ID", result["error"])
+        # Verify the CQL guide + repair hint reach the model on failure
+        self.assertIn("cql_guide", result)
+        self.assertIn("hint", result)
+        self.assertEqual(result["query_used"], "aid=abc123")
 
 
 class TestNGSIEMModuleConfig(unittest.TestCase):


### PR DESCRIPTION
The `falcon_search_ngsiem` tool runs CQL that the caller hands it — it doesn't write the query. Until now it gave callers nothing to go on for constructing one, so it was easy to send invalid CQL, and because the API quietly free-text-matches bad queries into a 200, those look like they worked when they didn't (issue #472).

This adds CQL authoring guidance to the tool. The `query_string` description now carries the pipe model and the common building blocks inline. A `falcon://ngsiem/search/cql-guide` resource is registered for depth, and the full guide gets injected into the tool's error and empty-result responses so it lands in front of the caller right when a query fails. Dynamic mode picks up a compact CQL hint on `query_string`, mirroring how FQL tools get their filter hints.

Every example in the guide is validated against the live NG-SIEM API and the CrowdStrike community-content repo. Worth calling out a few that are easy to get wrong: regex is `field=/re/i` rather than `=~`, `head()` returns the oldest events so you want `tail()` for the most recent, and distinct count is the positional `count(field, distinct=true)` form.

One unrelated cleanup came out of this too: the `repository` parameter listed its values as though they were the only valid ones. `xdr` and others work fine and the real set depends on the tenant, so it now reads as common examples instead of a closed list.

Closes #472