### PR TITLE
docs(server): document --api-key and warn on unauthenticated non-loopback bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,19 @@ docker pull quay.io/crowdstrike/falcon-mcp:latest
 # Run with .env file (stdio transport)
 docker run -i --rm --env-file /path/to/.env quay.io/crowdstrike/falcon-mcp:latest
 
-# Run with streamable-http transport
+# Run with streamable-http transport (add --api-key when the port is reachable beyond localhost)
 docker run --rm -p 8000:8000 --env-file /path/to/.env \
-  quay.io/crowdstrike/falcon-mcp:latest --transport streamable-http --host 0.0.0.0
+  quay.io/crowdstrike/falcon-mcp:latest \
+  --transport streamable-http --host 0.0.0.0 --api-key your-secret-key
 ```
+
+> [!CAUTION]
+> HTTP transports have no authentication by default. Binding to a non-loopback address (`--host 0.0.0.0`)
+> exposes an unauthenticated server that anyone who can reach the port can drive with your CrowdStrike
+> credentials. Keep the default loopback bind for local use and set `--api-key` whenever you bind wider.
+> Managed runtimes such as AWS Bedrock AgentCore and Google Cloud Run sit behind their own network
+> security layer, so this does not apply to them. See the
+> [Configuration guide](https://developer.crowdstrike.com/falcon-mcp/getting-started/configuration/#http-transport-security).
 
 See the [Docker Deployment guide](https://developer.crowdstrike.com/falcon-mcp/deployment/docker/) for building locally, custom ports, and advanced configurations.
 

--- a/docs/deployment/amazon-bedrock.md
+++ b/docs/deployment/amazon-bedrock.md
@@ -48,11 +48,10 @@ The MCP Server requires internet connectivity to communicate with CrowdStrike's 
 > [!CAUTION]
 > `FALCON_MCP_STATELESS_HTTP` must be set to `true` for proper operation in AgentCore's stateless container environment.
 
-> [!NOTE]
-> `FALCON_MCP_HOST=0.0.0.0` is correct here: AgentCore runs the container behind its own managed network
-> security layer, so the server is not directly exposed to the public internet the way a self-managed
-> `0.0.0.0` bind would be. `FALCON_MCP_API_KEY` is optional in this environment and adds defense in depth
-> if you want callers to present an `x-api-key` header as well.
+`FALCON_MCP_HOST=0.0.0.0` is correct here: AgentCore runs the container behind its own managed network
+security layer, so the server is not directly exposed to the public internet the way a self-managed
+`0.0.0.0` bind would be. `FALCON_MCP_API_KEY` is optional in this environment and adds defense in depth
+if you want callers to present an `x-api-key` header as well.
 
 ## Verify Deployment
 

--- a/docs/deployment/amazon-bedrock.md
+++ b/docs/deployment/amazon-bedrock.md
@@ -48,6 +48,12 @@ The MCP Server requires internet connectivity to communicate with CrowdStrike's 
 > [!CAUTION]
 > `FALCON_MCP_STATELESS_HTTP` must be set to `true` for proper operation in AgentCore's stateless container environment.
 
+> [!NOTE]
+> `FALCON_MCP_HOST=0.0.0.0` is correct here: AgentCore runs the container behind its own managed network
+> security layer, so the server is not directly exposed to the public internet the way a self-managed
+> `0.0.0.0` bind would be. `FALCON_MCP_API_KEY` is optional in this environment and adds defense in depth
+> if you want callers to present an `x-api-key` header as well.
+
 ## Verify Deployment
 
 After deployment, verify connectivity by invoking the `falcon_check_connectivity` tool:

--- a/docs/deployment/amazon-bedrock.md
+++ b/docs/deployment/amazon-bedrock.md
@@ -48,6 +48,8 @@ The MCP Server requires internet connectivity to communicate with CrowdStrike's 
 > [!CAUTION]
 > `FALCON_MCP_STATELESS_HTTP` must be set to `true` for proper operation in AgentCore's stateless container environment.
 
+<!-- -->
+
 > [!NOTE]
 > `FALCON_MCP_HOST=0.0.0.0`: AgentCore runs the container behind its own managed network
 > security layer, so the server is not directly exposed to the public internet the way a self-managed

--- a/docs/deployment/amazon-bedrock.md
+++ b/docs/deployment/amazon-bedrock.md
@@ -48,10 +48,11 @@ The MCP Server requires internet connectivity to communicate with CrowdStrike's 
 > [!CAUTION]
 > `FALCON_MCP_STATELESS_HTTP` must be set to `true` for proper operation in AgentCore's stateless container environment.
 
-`FALCON_MCP_HOST=0.0.0.0` is correct here: AgentCore runs the container behind its own managed network
-security layer, so the server is not directly exposed to the public internet the way a self-managed
-`0.0.0.0` bind would be. `FALCON_MCP_API_KEY` is optional in this environment and adds defense in depth
-if you want callers to present an `x-api-key` header as well.
+> [!NOTE]
+> `FALCON_MCP_HOST=0.0.0.0`: AgentCore runs the container behind its own managed network
+> security layer, so the server is not directly exposed to the public internet the way a self-managed
+> `0.0.0.0` bind would be. `FALCON_MCP_API_KEY` is optional in this environment and adds defense in depth
+> if you want callers to present an `x-api-key` header as well.
 
 ## Verify Deployment
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -67,9 +67,26 @@ docker run -i --rm \
 ```
 
 > [!NOTE]
-> When using HTTP transports in Docker, always set `--host 0.0.0.0` to allow external connections to the container.
+> When using HTTP transports in Docker, always set `--host 0.0.0.0` so the server accepts connections
+> from outside the container. This binds to all interfaces *inside* the container; what the endpoint is
+> actually reachable from is controlled by how you publish the port (`-p`), the container network, and
+> any load balancer in front of it.
 >
 > The `-i` flag is required when using the default stdio transport.
+
+> [!CAUTION]
+> The HTTP transports have no authentication by default. Whenever the published port is reachable
+> beyond the local host, set `--api-key` (or the `FALCON_MCP_API_KEY` environment variable) so callers
+> must send a matching `x-api-key` header — otherwise anyone who can reach the port can drive the server
+> with your CrowdStrike credentials:
+>
+> ```bash
+> docker run --rm -p 8000:8000 --env-file /path/to/.env \
+>   quay.io/crowdstrike/falcon-mcp:latest \
+>   --transport streamable-http --host 0.0.0.0 --api-key your-secret-key
+> ```
+>
+> See [HTTP Transport Security](/falcon-mcp/getting-started/configuration/#http-transport-security).
 
 ## Building Locally (Development)
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -74,19 +74,18 @@ docker run -i --rm \
 >
 > The `-i` flag is required when using the default stdio transport.
 
-> [!CAUTION]
-> The HTTP transports have no authentication by default. Whenever the published port is reachable
-> beyond the local host, set `--api-key` (or the `FALCON_MCP_API_KEY` environment variable) so callers
-> must send a matching `x-api-key` header — otherwise anyone who can reach the port can drive the server
-> with your CrowdStrike credentials:
->
-> ```bash
-> docker run --rm -p 8000:8000 --env-file /path/to/.env \
->   quay.io/crowdstrike/falcon-mcp:latest \
->   --transport streamable-http --host 0.0.0.0 --api-key your-secret-key
-> ```
->
-> See [HTTP Transport Security](/falcon-mcp/getting-started/configuration/#http-transport-security).
+The HTTP transports have no authentication by default. Whenever the published port is reachable beyond
+the local host, set `--api-key` (or the `FALCON_MCP_API_KEY` environment variable) so callers must send
+a matching `x-api-key` header, otherwise anyone who can reach the port can drive the server with your
+CrowdStrike credentials:
+
+```bash
+docker run --rm -p 8000:8000 --env-file /path/to/.env \
+  quay.io/crowdstrike/falcon-mcp:latest \
+  --transport streamable-http --host 0.0.0.0 --api-key your-secret-key
+```
+
+See [HTTP Transport Security](/falcon-mcp/getting-started/configuration/#http-transport-security).
 
 ## Building Locally (Development)
 

--- a/docs/development/integration-testing.md
+++ b/docs/development/integration-testing.md
@@ -36,7 +36,7 @@ cp .env.dev.example .env
 
 ### API Scopes
 
-Your API client must have the appropriate scopes for the modules you're testing. See the main [README.md](../../README.md#modules) for the complete scope mapping.
+Your API client must have the appropriate scopes for the modules you're testing. See the [Module Overview](/falcon-mcp/modules/overview/) for the complete scope mapping.
 
 ## Running Integration Tests
 
@@ -242,7 +242,7 @@ If tests fail with 403 errors:
 
 1. Check your API client has the required scopes
 2. Some endpoints require additional permissions (e.g., write access)
-3. See [API Scopes](../../README.md#modules) for requirements
+3. See the [Module Overview](/falcon-mcp/modules/overview/) for scope requirements
 
 ## Adding New Integration Tests
 

--- a/docs/development/module-development.md
+++ b/docs/development/module-development.md
@@ -297,7 +297,7 @@ git commit -m "test(modules): add comprehensive tests for [module-name] module"
 git commit -m "docs(modules): update [module-name] module documentation"
 ```
 
-See the main [CONTRIBUTING.md](../../.github/CONTRIBUTING.md) guide for complete conventional commits guidelines.
+See the main [Contributing Guide](https://github.com/CrowdStrike/falcon-mcp/blob/main/.github/CONTRIBUTING.md) for complete conventional commits guidelines.
 
 ## Best Practices
 

--- a/docs/development/resource-development.md
+++ b/docs/development/resource-development.md
@@ -273,7 +273,7 @@ git commit -m "test(resources): add validation tests for resource content"
 git commit -m "chore(resources): update resource registration patterns"
 ```
 
-See the main [CONTRIBUTING.md](../../.github/CONTRIBUTING.md) guide for complete conventional commits guidelines.
+See the main [Contributing Guide](https://github.com/CrowdStrike/falcon-mcp/blob/main/.github/CONTRIBUTING.md) for complete conventional commits guidelines.
 
 ## Conclusion
 

--- a/docs/examples/basic-usage.md
+++ b/docs/examples/basic-usage.md
@@ -93,11 +93,14 @@ from falcon_mcp.server import FalconMCPServer
 def main() -> None:
     load_dotenv()
 
-    # Custom host/port for external access
+    # Custom host/port for external access.
+    # Binding to 0.0.0.0 exposes the server on the network with no auth by default,
+    # so set api_key to require an x-api-key header from callers.
     server = FalconMCPServer(
         debug=os.environ.get("DEBUG", "").lower() == "true",
         host="0.0.0.0",
         port=8080,
+        api_key=os.environ.get("FALCON_MCP_API_KEY"),
     )
 
     # Run — listens at http://0.0.0.0:8080/mcp

--- a/docs/examples/mcp-config.md
+++ b/docs/examples/mcp-config.md
@@ -75,20 +75,8 @@ Limit which modules are loaded to reduce tool count:
 
 ## Remote HTTP Server
 
-If running the server on a remote host or in Docker:
-
-```json
-{
-  "mcpServers": {
-    "falcon-mcp-remote": {
-      "type": "streamable-http",
-      "url": "http://your-server:8000/mcp"
-    }
-  }
-}
-```
-
-For authenticated endpoints (with `--api-key`):
+If running the server on a remote host or in Docker, send the API key you configured with `--api-key`
+in the `x-api-key` header:
 
 ```json
 {
@@ -99,6 +87,21 @@ For authenticated endpoints (with `--api-key`):
       "headers": {
         "x-api-key": "your-api-key"
       }
+    }
+  }
+}
+```
+
+Only drop the `headers` block when the endpoint is unauthenticated — for example a loopback-only
+server, or one already fronted by a managed runtime that handles auth (AWS Bedrock AgentCore, Google
+Cloud Run):
+
+```json
+{
+  "mcpServers": {
+    "falcon-mcp-remote": {
+      "type": "streamable-http",
+      "url": "http://your-server:8000/mcp"
     }
   }
 }

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -86,10 +86,54 @@ falcon-mcp
 
 ## HTTP Transport Security
 
-When running HTTP transports (`sse` or `streamable-http`), protect the endpoint with an API key:
+The HTTP transports (`sse` and `streamable-http`) have no authentication by default. The server binds
+to loopback (`127.0.0.1`) unless you tell it otherwise, so out of the box it is only reachable from the
+local host.
+
+Binding to a non-loopback address such as `--host 0.0.0.0` (or `FALCON_MCP_HOST=0.0.0.0`) exposes the
+server on the network. With no API key set, anyone who can reach the port can invoke every tool using
+your CrowdStrike credentials. The server logs a warning at startup when it binds beyond loopback
+without an API key (it does not refuse to start). Set `--api-key` whenever you bind beyond loopback:
 
 ```bash
-falcon-mcp --transport streamable-http --api-key your-secret-key
+falcon-mcp --transport streamable-http --host 0.0.0.0 --api-key your-secret-key
 ```
 
-This is a self-generated key (any secure string you create) that ensures only authorized clients with the matching key can access the MCP server. It is separate from your CrowdStrike API credentials.
+The key is a self-generated value (any secure string you create) that callers must send in the
+`x-api-key` header; requests without a matching key are rejected with `401 Unauthorized`. It is
+separate from your CrowdStrike API credentials. You can also supply it via the `FALCON_MCP_API_KEY`
+environment variable.
+
+Clients pass the key in an `x-api-key` header. In an MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "falcon-mcp-remote": {
+      "type": "streamable-http",
+      "url": "http://your-server:8000/mcp",
+      "headers": {
+        "x-api-key": "your-secret-key"
+      }
+    }
+  }
+}
+```
+
+Or when calling the endpoint directly:
+
+```bash
+curl http://your-server:8000/mcp \
+  -H "x-api-key: your-secret-key" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"example","version":"1.0"}}}'
+```
+
+**Recommendations:**
+
+- Keep the default loopback bind (`127.0.0.1`) for local single-machine use.
+- Set `--api-key` any time you bind to a non-loopback address or publish the port to a network.
+- Managed runtimes such as AWS Bedrock AgentCore and Google Cloud Run sit behind their own network
+  security layer (IAM, private networking), so the open-bind concern does not apply there. `--api-key`
+  remains available on those platforms as optional defense in depth.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -26,7 +26,7 @@ falcon-mcp --transport streamable-http
 Run with streamable-http on a custom port:
 
 ```bash
-falcon-mcp --transport streamable-http --host 0.0.0.0 --port 8080
+falcon-mcp --transport streamable-http --host 0.0.0.0 --port 8080 --api-key your-secret-key
 ```
 
 Run with stateless HTTP mode (for scalable deployments like AWS AgentCore):
@@ -40,6 +40,13 @@ Run with API key authentication:
 ```bash
 falcon-mcp --transport streamable-http --api-key your-secret-key
 ```
+
+> [!CAUTION]
+> HTTP transports have no authentication by default. Binding to a non-loopback address such as
+> `--host 0.0.0.0` exposes an unauthenticated server that anyone who can reach the port can drive with
+> your CrowdStrike credentials. Keep the default loopback bind (`127.0.0.1`) for local use, and set
+> `--api-key` whenever you bind wider. See
+> [HTTP Transport Security](/falcon-mcp/getting-started/configuration/#http-transport-security).
 
 ## Module Selection
 

--- a/docs/usage/editor-integration.md
+++ b/docs/usage/editor-integration.md
@@ -126,13 +126,17 @@ For clients that connect via URL (SSE or streamable-http), start the server firs
 
 ```bash
 # SSE
-falcon-mcp --transport sse --host 0.0.0.0 --port 8000
+falcon-mcp --transport sse --host 0.0.0.0 --port 8000 --api-key your-secret-key
 ```
 
 ```bash
 # Streamable HTTP
-falcon-mcp --transport streamable-http --host 0.0.0.0 --port 8000
+falcon-mcp --transport streamable-http --host 0.0.0.0 --port 8000 --api-key your-secret-key
 ```
+
+`--host 0.0.0.0` exposes the server on the network, so set `--api-key` and send it as the `x-api-key`
+header from your client. Omit both to keep the server on the default loopback bind for local-only use.
+See [HTTP Transport Security](/falcon-mcp/getting-started/configuration/#http-transport-security).
 
 Then configure your client with:
 

--- a/docs/usage/transports.md
+++ b/docs/usage/transports.md
@@ -5,6 +5,13 @@
 
 The Falcon MCP Server supports three transport methods. Choose based on your deployment scenario.
 
+> [!CAUTION]
+> The HTTP transports (`sse` and `streamable-http`) have no authentication by default. Binding to a
+> non-loopback address such as `--host 0.0.0.0` exposes an unauthenticated server — anyone who can
+> reach the port can invoke every tool using your CrowdStrike credentials. Bind to loopback
+> (`127.0.0.1`, the default) for local use, and set `--api-key` whenever you bind wider. See
+> [HTTP Transport Security](/falcon-mcp/getting-started/configuration/#http-transport-security).
+
 ## stdio (Default)
 
 The simplest transport. The MCP client manages the server process directly via stdin/stdout.
@@ -30,8 +37,11 @@ falcon-mcp --transport sse
 Custom host/port:
 
 ```bash
-falcon-mcp --transport sse --host 0.0.0.0 --port 8080
+falcon-mcp --transport sse --host 0.0.0.0 --port 8080 --api-key your-secret-key
 ```
+
+Binding to `0.0.0.0` reaches the network, so pair it with `--api-key` to require callers to send a
+matching `x-api-key` header.
 
 **Best for:** Web-based clients and environments where subprocess management isn't available.
 
@@ -49,8 +59,11 @@ falcon-mcp --transport streamable-http
 Custom host/port:
 
 ```bash
-falcon-mcp --transport streamable-http --host 0.0.0.0 --port 8080
+falcon-mcp --transport streamable-http --host 0.0.0.0 --port 8080 --api-key your-secret-key
 ```
+
+Binding to `0.0.0.0` reaches the network, so pair it with `--api-key` to require callers to send a
+matching `x-api-key` header.
 
 Stateless mode (required for AWS AgentCore and other scalable deployments):
 
@@ -63,7 +76,14 @@ falcon-mcp --transport streamable-http --stateless-http
 **Client compatibility:** Claude Desktop, MCP Inspector.
 
 > [!NOTE]
-> When using HTTP transports in Docker, always set `--host 0.0.0.0` to allow external connections to the container.
+> When using HTTP transports in Docker, always set `--host 0.0.0.0` to allow external connections to
+> the container. The container port is still only reachable by whatever you expose it to (a published
+> `-p` port, another container, a load balancer), so control that exposure and add `--api-key` when the
+> endpoint is reachable beyond the local host.
+>
+> Managed runtimes such as AWS Bedrock AgentCore and Google Cloud Run sit behind their own network
+> security layer (IAM, private networking), so the open-bind concern above does not apply to them —
+> `--api-key` remains available there as optional defense in depth.
 
 ## Client Compatibility
 

--- a/examples/streamable_http_usage.py
+++ b/examples/streamable_http_usage.py
@@ -25,13 +25,17 @@ def main() -> None:
     # server.run("streamable-http")
     #   -> http://127.0.0.1:8000/mcp
 
-    # Example 2: Custom host/port for external access
+    # Example 2: Custom host/port for external access.
+    # Binding to 0.0.0.0 exposes the server on the network with no auth by default,
+    # so set api_key (any secure string you choose) to require callers to send a
+    # matching x-api-key header. Prefer the FALCON_MCP_API_KEY env var over hardcoding.
     server = FalconMCPServer(
         # You can override the base URL if needed
         # base_url="https://api.us-2.crowdstrike.com",
         debug=os.environ.get("DEBUG", "").lower() == "true",
         host="0.0.0.0",
         port=8080,
+        api_key=os.environ.get("FALCON_MCP_API_KEY"),
     )
     server.run("streamable-http")
 

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -30,6 +30,10 @@ logger = get_logger(__name__)
 # Type alias for transport options
 TransportType = Literal["stdio", "sse", "streamable-http"]
 
+# Hosts that keep the server reachable only from the local machine. Binding to
+# anything else exposes it on the network, where an unauthenticated endpoint is a risk.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
 
 class FalconMCPServer:
     """Main server class for the Falcon MCP server."""
@@ -244,6 +248,16 @@ class FalconMCPServer:
         if self.api_key:
             app = auth_middleware(app, self.api_key)
             logger.info("API key authentication enabled")
+        elif self.host not in _LOOPBACK_HOSTS:
+            logger.warning(
+                "Server is binding to %s without --api-key: the endpoint is reachable "
+                "on the network and has no authentication. Anyone who can reach %s:%d can "
+                "invoke every tool using your Falcon credentials. Set --api-key "
+                "(or FALCON_MCP_API_KEY) when binding beyond loopback.",
+                self.host,
+                self.host,
+                self.port,
+            )
         uvicorn.run(
             app,
             host=self.host,

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -250,10 +250,9 @@ class FalconMCPServer:
             logger.info("API key authentication enabled")
         elif self.host not in _LOOPBACK_HOSTS:
             logger.warning(
-                "Server is binding to %s without --api-key: the endpoint is reachable "
+                "Server is binding to %s:%d without --api-key: the endpoint is reachable "
                 "on the network and has no authentication. Set --api-key "
                 "(or FALCON_MCP_API_KEY) when binding beyond loopback.",
-                self.host,
                 self.host,
                 self.port,
             )

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -251,8 +251,7 @@ class FalconMCPServer:
         elif self.host not in _LOOPBACK_HOSTS:
             logger.warning(
                 "Server is binding to %s without --api-key: the endpoint is reachable "
-                "on the network and has no authentication. Anyone who can reach %s:%d can "
-                "invoke every tool using your Falcon credentials. Set --api-key "
+                "on the network and has no authentication. Set --api-key "
                 "(or FALCON_MCP_API_KEY) when binding beyond loopback.",
                 self.host,
                 self.host,

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -227,6 +227,84 @@ class TestLogging:
         assert not auth_log_found, f"Unexpected auth log found: {info_calls}"
 
 
+class TestOpenBindWarning:
+    """Test the non-loopback bind warning emitted when no API key is set."""
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.uvicorn")
+    @patch("falcon_mcp.server.logger")
+    def test_warns_on_non_loopback_without_api_key(
+        self, mock_logger, _mock_uvicorn, mock_registry, mock_client_class
+    ):
+        """Binding to 0.0.0.0 with no api_key logs a warning (but does not halt)."""
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        server = FalconMCPServer(host="0.0.0.0")
+        server.run(transport="streamable-http")
+
+        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+        assert any("no authentication" in call for call in warning_calls), (
+            f"Expected open-bind warning, got: {warning_calls}"
+        )
+        # Warning path must not prevent the server from starting.
+        _mock_uvicorn.run.assert_called_once()
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.uvicorn")
+    @patch("falcon_mcp.server.logger")
+    def test_no_warning_on_loopback(
+        self, mock_logger, _mock_uvicorn, mock_registry, mock_client_class
+    ):
+        """The default loopback bind does not trigger the open-bind warning."""
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        server = FalconMCPServer()  # default host 127.0.0.1, no api_key
+        server.run(transport="streamable-http")
+
+        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+        assert not any("no authentication" in call for call in warning_calls), (
+            f"Unexpected open-bind warning on loopback: {warning_calls}"
+        )
+
+    @patch("falcon_mcp.server.FalconClient")
+    @patch("falcon_mcp.server.registry")
+    @patch("falcon_mcp.server.uvicorn")
+    @patch("falcon_mcp.server.logger")
+    def test_no_warning_on_non_loopback_with_api_key(
+        self, mock_logger, _mock_uvicorn, mock_registry, mock_client_class
+    ):
+        """Setting api_key suppresses the open-bind warning even on 0.0.0.0."""
+        from falcon_mcp.server import FalconMCPServer
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client_class.return_value = mock_client
+        mock_registry.get_module_names.return_value = []
+        mock_registry.get_available_modules.return_value = {}
+
+        server = FalconMCPServer(host="0.0.0.0", api_key="test-key")
+        server.run(transport="streamable-http")
+
+        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+        assert not any("no authentication" in call for call in warning_calls), (
+            f"Unexpected open-bind warning when api_key set: {warning_calls}"
+        )
+
+
 class TestTrailingSlashMiddlewareApplication:
     """Test that trailing slash middleware is correctly applied to HTTP transports."""
 


### PR DESCRIPTION
The HTTP transports have no authentication by default, and nothing stopped you from binding to `--host 0.0.0.0` and quietly standing up an unauthenticated server that anyone on the network could drive with your Falcon credentials. The `--api-key` option to guard against this already existed, but the docs mostly pointed people at the open-bind pattern and never showed how a client actually sends the key, so it was easy to miss.

The server now logs a warning at startup when it binds beyond loopback without an API key. It names the host and port, points at `--api-key`, and then starts normally, so it's a warning and not a hard stop. Loopback binds and any bind that already has a key stay quiet. AWS Bedrock AgentCore and similar managed runtimes sit behind their own network layer, those should be generally unaffected.

The rest is doc and example cleanup. Every `--host 0.0.0.0` example now pairs with `--api-key` so the secure pattern is the one people copy, there's a single HTTP Transport Security section that covers both the server flag and the client side (the `x-api-key` header, shown in an MCP client config and a curl call), and the remote-client config now leads with the authenticated version instead of burying it under the open one.

I validated the behavior against a running server: open bind with no key warns and still starts, loopback stays silent, a key suppresses the warning, and the documented curl returns 200 with the header. Full unit suite passes.