### PR TITLE
feat(server): add concurrent request handling

### DIFF
--- a/falcon_mcp/client.py
+++ b/falcon_mcp/client.py
@@ -4,11 +4,15 @@ Falcon API Client for MCP Server
 This module provides the Falcon API client and authentication utilities for the Falcon MCP server.
 """
 
+import functools
 import os
 import platform
 import sys
+import threading
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
+
+import anyio
 
 # Import the APIHarnessV2 from FalconPy
 from falconpy import APIHarnessV2  # type: ignore[import-untyped]
@@ -82,6 +86,12 @@ class FalconClient:
         # Initialize the Falcon API client using APIHarnessV2
         self.client = APIHarnessV2(**api_params)
 
+        # Serializes the stale-token refresh path. Concurrent tool calls run their
+        # blocking FalconPy work on separate threads (see command_async); without this
+        # lock, several threads could observe a stale token at once and each fire its
+        # own POST /oauth2/token. The lock guards only the refresh, never the API call.
+        self._token_lock = threading.Lock()
+
         logger.debug("Initialized Falcon client with base URL: %s", self.base_url)
         if self.member_cid:
             logger.debug("Flight Control member_cid: %s", self.member_cid)
@@ -148,6 +158,29 @@ class FalconClient:
         result: bool = self.client.token_valid
         return result
 
+    def _ensure_token_fresh(self) -> None:
+        """Refresh a stale bearer token exactly once across concurrent callers.
+
+        FalconPy refreshes lazily inside ``command`` (it reads ``auth_headers``,
+        which calls ``login()`` when the token is stale). Under concurrency several
+        offloaded threads can see a stale token simultaneously and each POST
+        ``/oauth2/token``. This serializes the refresh with a double-checked lock:
+        the fast path takes no lock when the token is valid, and only the first
+        thread through the lock performs the login while the rest reuse its result.
+        """
+        client = self.client
+        # Fast path: a valid token needs no lock. `refreshable` guards clients that
+        # cannot self-refresh (e.g. token supplied directly).
+        if not getattr(client, "token_stale", False) or not getattr(
+            client, "refreshable", False
+        ):
+            return
+
+        with self._token_lock:
+            # Re-check under the lock: another thread may have refreshed already.
+            if getattr(client, "token_stale", False):
+                client.login()
+
     def command(self, operation: str, **kwargs: Any) -> dict[str, Any]:
         """Execute a Falcon API command.
 
@@ -158,8 +191,29 @@ class FalconClient:
         Returns:
             dict[str, Any]: The API response
         """
+        self._ensure_token_fresh()
         result: dict[str, Any] = self.client.command(operation, **kwargs)
         return result
+
+    async def command_async(self, operation: str, **kwargs: Any) -> dict[str, Any]:
+        """Execute a Falcon API command off the event loop.
+
+        Runs the blocking FalconPy call on a worker thread so the asyncio event
+        loop stays free to service other in-flight requests. Async handlers (e.g.
+        ngsiem) should await this instead of calling the sync ``command`` directly;
+        sync handlers are offloaded automatically by the tool wrapper in
+        ``BaseModule._add_tool``.
+
+        Args:
+            operation: The API operation to execute
+            **kwargs: Additional arguments to pass to the API
+
+        Returns:
+            dict[str, Any]: The API response
+        """
+        return await anyio.to_thread.run_sync(
+            functools.partial(self.command, operation, **kwargs)
+        )
 
     def get_user_agent(self) -> str:
         """Get RFC-compliant user agent string for API requests.

--- a/falcon_mcp/client.py
+++ b/falcon_mcp/client.py
@@ -159,14 +159,23 @@ class FalconClient:
         return result
 
     def _ensure_token_fresh(self) -> None:
-        """Refresh a stale bearer token exactly once across concurrent callers.
+        """Collapse concurrent stale-token refreshes into a single login.
 
-        FalconPy refreshes lazily inside ``command`` (it reads ``auth_headers``,
-        which calls ``login()`` when the token is stale). Under concurrency several
+        FalconPy refreshes lazily inside `command` (it reads `auth_headers`,
+        which calls `login()` when the token is stale). Under concurrency several
         offloaded threads can see a stale token simultaneously and each POST
-        ``/oauth2/token``. This serializes the refresh with a double-checked lock:
+        `/oauth2/token`. This serializes the refresh with a double-checked lock:
         the fast path takes no lock when the token is valid, and only the first
-        thread through the lock performs the login while the rest reuse its result.
+        thread through the lock logs in while the rest observe the fresh token and
+        skip.
+
+        The collapse depends on `login()` clearing `token_stale`, so it holds only
+        when the refresh succeeds. If login fails (revoked or wrong credentials,
+        network failure) the token stays stale and each waiting thread retries in
+        turn — N serial attempts rather than N parallel ones. That trades added
+        latency for not hammering the token endpoint; the credentials are already
+        broken in that state, and `command` still returns the API's 401 to the
+        caller.
         """
         client = self.client
         # Fast path: a valid token needs no lock. `refreshable` guards clients that
@@ -200,9 +209,11 @@ class FalconClient:
 
         Runs the blocking FalconPy call on a worker thread so the asyncio event
         loop stays free to service other in-flight requests. Async handlers (e.g.
-        ngsiem) should await this instead of calling the sync ``command`` directly;
+        ngsiem) should await this instead of calling the sync `command` directly;
         sync handlers are offloaded automatically by the tool wrapper in
-        ``BaseModule._add_tool``.
+        `BaseModule._add_tool`. The thread-pool cap and cancellation semantics
+        described on `offload_to_thread` apply here too — both share the same
+        default anyio limiter.
 
         Args:
             operation: The API operation to execute

--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -33,17 +33,31 @@ READ_ONLY_ANNOTATIONS = ToolAnnotations(
 def offload_to_thread(method: Callable[..., Any]) -> Callable[..., Any]:
     """Wrap a sync tool handler so it runs on a worker thread, not the event loop.
 
-    Falcon tool handlers are synchronous and call blocking, ``requests``-based
+    Falcon tool handlers are synchronous and call blocking, `requests`-based
     FalconPy. Run inline on the asyncio loop, one ~6s Falcon call freezes the loop
     and serializes every other in-flight request. Wrapping the handler in an
-    ``async def`` that offloads via ``anyio.to_thread.run_sync`` lets a single
+    `async def` that offloads via `anyio.to_thread.run_sync` lets a single
     server instance interleave concurrent Falcon calls.
 
-    FastMCP builds each tool's arg schema with ``inspect.signature`` (which follows
-    ``functools.wraps``' ``__wrapped__``), so the wrapper exposes the original
-    handler's ``Field(...)`` parameters unchanged; but it detects async by
-    inspecting the object directly (not ``__wrapped__``), so the wrapper is awaited
+    FastMCP builds each tool's arg schema with `inspect.signature` (which follows
+    `functools.wraps`' `__wrapped__`), so the wrapper exposes the original
+    handler's `Field(...)` parameters unchanged; but it detects async by
+    inspecting the object directly (not `__wrapped__`), so the wrapper is awaited
     off-loop. Already-async handlers (e.g. ngsiem) are returned untouched.
+
+    Two properties of the default anyio thread pool are load-bearing here:
+
+    - **Concurrency caps at 40.** `anyio.to_thread.run_sync` shares one
+      `CapacityLimiter` of 40 tokens per event loop, so calls 41+ queue until a
+      worker frees up (60 concurrent callers of a 1s handler take ~2s, not ~1s).
+      This is deliberate backpressure, not a bug: it bounds both thread count and
+      the request rate we aim at the Falcon API. Raising it means passing an
+      explicit `limiter=`.
+    - **A cancelled request still occupies its worker.** We keep the default
+      `abandon_on_cancel=False`, so when a client disconnects or the MCP 60s
+      timeout fires, the thread is held until the blocking FalconPy call returns
+      rather than being abandoned. Abandoning would free the slot sooner but leaks
+      threads without bound under repeated timeouts, which is the worse failure.
 
     Args:
         method: The tool handler to wrap.
@@ -57,9 +71,7 @@ def offload_to_thread(method: Callable[..., Any]) -> Callable[..., Any]:
 
     @wraps(method)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
-        return await anyio.to_thread.run_sync(
-            partial(method, *args, **kwargs)
-        )
+        return await anyio.to_thread.run_sync(partial(method, *args, **kwargs))
 
     return wrapper
 
@@ -183,9 +195,9 @@ class BaseModule(ABC):
         Search tools query entity IDs first (honoring the requested sort) and then
         hydrate full details by ID. Some "get entities by IDs" endpoints return
         resources in arbitrary order, discarding the sort. This restores the order
-        of ``ordered_ids``. It is a no-op for endpoints that already preserve order.
+        of `ordered_ids`. It is a no-op for endpoints that already preserve order.
 
-        Entities whose ID is not in ``ordered_ids`` are appended in their original
+        Entities whose ID is not in `ordered_ids` are appended in their original
         order (never dropped); IDs with no matching entity are skipped.
 
         Args:

--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -5,8 +5,11 @@ This module provides the base class for all Falcon MCP server modules.
 """
 
 from abc import ABC, abstractmethod
+from functools import partial, wraps
+from inspect import iscoroutinefunction
 from typing import Any, Callable
 
+import anyio
 from mcp import Resource
 from mcp.server import FastMCP
 from mcp.types import ToolAnnotations
@@ -25,6 +28,40 @@ READ_ONLY_ANNOTATIONS = ToolAnnotations(
     idempotentHint=True,
     openWorldHint=True,
 )
+
+
+def offload_to_thread(method: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a sync tool handler so it runs on a worker thread, not the event loop.
+
+    Falcon tool handlers are synchronous and call blocking, ``requests``-based
+    FalconPy. Run inline on the asyncio loop, one ~6s Falcon call freezes the loop
+    and serializes every other in-flight request. Wrapping the handler in an
+    ``async def`` that offloads via ``anyio.to_thread.run_sync`` lets a single
+    server instance interleave concurrent Falcon calls.
+
+    FastMCP builds each tool's arg schema with ``inspect.signature`` (which follows
+    ``functools.wraps``' ``__wrapped__``), so the wrapper exposes the original
+    handler's ``Field(...)`` parameters unchanged; but it detects async by
+    inspecting the object directly (not ``__wrapped__``), so the wrapper is awaited
+    off-loop. Already-async handlers (e.g. ngsiem) are returned untouched.
+
+    Args:
+        method: The tool handler to wrap.
+
+    Returns:
+        The original method if it is already a coroutine function, otherwise an
+        async wrapper that offloads the call to a thread.
+    """
+    if iscoroutinefunction(method):
+        return method
+
+    @wraps(method)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return await anyio.to_thread.run_sync(
+            partial(method, *args, **kwargs)
+        )
+
+    return wrapper
 
 
 class BaseModule(ABC):
@@ -72,7 +109,7 @@ class BaseModule(ABC):
         """
         prefixed_name = f"falcon_{name}"
         server.add_tool(
-            method,
+            offload_to_thread(method),
             name=prefixed_name,
             annotations=annotations or READ_ONLY_ANNOTATIONS,
             structured_output=False,

--- a/falcon_mcp/modules/ngsiem.py
+++ b/falcon_mcp/modules/ngsiem.py
@@ -188,7 +188,7 @@ class NGSIEMModule(BaseModule):
 
         logger.debug("Starting NGSIEM search with query: %s", query_string)
 
-        start_response = self.client.command(
+        start_response = await self.client.command_async(
             operation="StartSearchV1",
             repository=repository,
             body=body_params,
@@ -221,7 +221,7 @@ class NGSIEMModule(BaseModule):
             await asyncio.sleep(POLL_INTERVAL_SECONDS)
             elapsed += POLL_INTERVAL_SECONDS
 
-            poll_response = self.client.command(
+            poll_response = await self.client.command_async(
                 operation="GetSearchStatusV1",
                 repository=repository,
                 search_id=job_id,
@@ -255,7 +255,7 @@ class NGSIEMModule(BaseModule):
 
         # Step 3: Timeout — attempt cleanup
         logger.warning("NGSIEM search job timed out: %s", job_id)
-        self.client.command(
+        await self.client.command_async(
             operation="StopSearchV1",
             repository=repository,
             id=job_id,

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -23,7 +23,7 @@ from falcon_mcp.common.auth import (
     strip_trailing_slash_middleware,
 )
 from falcon_mcp.common.logging import configure_logging, get_logger
-from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
+from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS, offload_to_thread
 
 logger = get_logger(__name__)
 
@@ -154,7 +154,7 @@ class FalconMCPServer:
         # falcon_list_enabled_modules is always registered — dynamic mode's no-results
         # hint references it by name, and it's useful in both modes.
         self.server.add_tool(
-            self.list_enabled_modules,
+            offload_to_thread(self.list_enabled_modules),
             name="falcon_list_enabled_modules",
             annotations=READ_ONLY_ANNOTATIONS,
             structured_output=False,
@@ -172,14 +172,14 @@ class FalconMCPServer:
         else:
             # Normal mode: register all three core tools and then each module's tools.
             self.server.add_tool(
-                self.falcon_check_connectivity,
+                offload_to_thread(self.falcon_check_connectivity),
                 name="falcon_check_connectivity",
                 annotations=READ_ONLY_ANNOTATIONS,
                 structured_output=False,
             )
 
             self.server.add_tool(
-                self.list_modules,
+                offload_to_thread(self.list_modules),
                 name="falcon_list_modules",
                 annotations=READ_ONLY_ANNOTATIONS,
                 structured_output=False,
@@ -209,6 +209,12 @@ class FalconMCPServer:
     def falcon_check_connectivity(self) -> dict[str, bool]:
         """Check connectivity to the Falcon API."""
         try:
+            # Deliberately bypasses FalconClient._token_lock: this is a stateless
+            # probe (stateful=False) that never mutates the shared token, so it
+            # cannot corrupt a concurrent refresh. It may fire its own throwaway
+            # /oauth2/token POST alongside a real refresh, which is acceptable for
+            # a diagnostic tool — the lock guards the shared-state refresh path,
+            # not every possible token request.
             result = self.falcon_client.client._login_handler(stateful=False)
             return {"connected": result.get("status_code") == 201}
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
+    "anyio>=4.5",
     "crowdstrike-falconpy>=1.3.0",
     "mcp>=1.12.1,<2.0.0",
     "python-dotenv>=1.1.1",

--- a/tests/modules/test_ngsiem.py
+++ b/tests/modules/test_ngsiem.py
@@ -20,11 +20,44 @@ class TestNGSIEMModule(TestModules):
 
         # search_ngsiem is async and calls the async offload wrapper command_async.
         # Route it through the sync `command` mock so the existing side_effect /
-        # call_args_list assertions (which inspect `command`) keep working.
+        # call_args_list assertions (which inspect `command`) keep working. Because
+        # every routed call passes through both mocks, `command.call_count` above
+        # `command_async.await_count` means the module reached the blocking sync
+        # client directly — see test_search_ngsiem_offloads_every_api_call.
         async def _command_async(*args, **kwargs):
             return self.mock_client.command(*args, **kwargs)
 
         self.mock_client.command_async = AsyncMock(side_effect=_command_async)
+
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_search_ngsiem_offloads_every_api_call(self, mock_sleep):
+        """Every NGSIEM API call must go through command_async, never sync command.
+
+        search_ngsiem is an async handler, so `offload_to_thread` returns it
+        untouched — nothing else moves its Falcon calls off the event loop. A
+        direct `self.client.command(...)` here would block the loop and undo the
+        concurrency fix, so this fails if any call site reverts to the sync path.
+        """
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"id": "job-123", "hashedQueryOnView": "abc"}},
+            {"status_code": 200, "body": {"done": True, "events": [{"aid": "agent-1"}]}},
+        ]
+
+        asyncio.run(
+            self.module.search_ngsiem(
+                query_string="#event_simpleName=ProcessRollup2",
+                start="2025-01-01T00:00:00Z",
+                repository="search-all",
+            )
+        )
+
+        self.assertEqual(
+            self.mock_client.command_async.await_count,
+            self.mock_client.command.call_count,
+            "every Falcon call in search_ngsiem must be awaited via command_async; "
+            "a count mismatch means a call site uses the blocking sync client",
+        )
+        self.assertEqual(self.mock_client.command_async.await_count, 2)
 
     def test_register_tools(self):
         """Test registering tools with the server."""

--- a/tests/modules/test_ngsiem.py
+++ b/tests/modules/test_ngsiem.py
@@ -18,6 +18,14 @@ class TestNGSIEMModule(TestModules):
         """Set up test fixtures."""
         self.setup_module(NGSIEMModule)
 
+        # search_ngsiem is async and calls the async offload wrapper command_async.
+        # Route it through the sync `command` mock so the existing side_effect /
+        # call_args_list assertions (which inspect `command`) keep working.
+        async def _command_async(*args, **kwargs):
+            return self.mock_client.command(*args, **kwargs)
+
+        self.mock_client.command_async = AsyncMock(side_effect=_command_async)
+
     def test_register_tools(self):
         """Test registering tools with the server."""
         expected_tools = [

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,258 @@
+"""
+Concurrency regression tests for the tool-offload wrapper.
+
+The bug these guard against: sync tool handlers ran inline on the asyncio event
+loop, so a single blocking Falcon call froze the loop and serialized every other
+in-flight request. `offload_to_thread` (applied in `BaseModule._add_tool` and to
+the core tools in `server.py`) runs each sync handler on a worker thread so a
+single server instance interleaves concurrent calls.
+
+These tests would fail (wall-clock ≈ N × sleep) if the wrapper were removed.
+"""
+
+import asyncio
+import threading
+import time
+import unittest
+from collections.abc import Coroutine
+from inspect import iscoroutinefunction
+from typing import Any, TypeVar
+from unittest.mock import MagicMock, patch
+
+from mcp.server.fastmcp import FastMCP
+
+from falcon_mcp.client import FalconClient
+from falcon_mcp.dynamic import DynamicMode
+from falcon_mcp.modules.base import BaseModule, offload_to_thread
+
+_T = TypeVar("_T")
+
+# Per-call sleep and fan-out. If handlers run serially, total ≈ CONCURRENCY *
+# SLEEP_SECONDS; concurrent, total ≈ SLEEP_SECONDS. The threshold sits well
+# between the two so timing jitter can't flip the result.
+SLEEP_SECONDS = 0.3
+CONCURRENCY = 8
+SERIAL_TOTAL = SLEEP_SECONDS * CONCURRENCY
+CONCURRENT_THRESHOLD = SLEEP_SECONDS * 3  # 0.9s << serial 2.4s
+
+
+def run_async(coro: Coroutine[Any, Any, _T]) -> _T:
+    return asyncio.run(coro)
+
+
+class _SleepingModule(BaseModule):
+    """A module with one sync tool that blocks on client.command (like real handlers)."""
+
+    def register_tools(self, server: FastMCP) -> None:
+        self._add_tool(server=server, method=self.slow_tool, name="slow_tool")
+
+    def slow_tool(self) -> dict[str, Any]:
+        """Sleep, then return a canned result (stands in for a slow Falcon call)."""
+        return self.client.command("SlowOperation")
+
+
+def _make_sleeping_client() -> MagicMock:
+    """A mock FalconClient whose command() blocks for SLEEP_SECONDS."""
+    client = MagicMock(spec=FalconClient)
+
+    def _blocking_command(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        time.sleep(SLEEP_SECONDS)
+        return {"status_code": 200, "body": {"resources": [{"id": "ok"}]}}
+
+    client.command.side_effect = _blocking_command
+    return client
+
+
+class TestOffloadToThread(unittest.TestCase):
+    """Unit tests for the wrapper itself."""
+
+    def test_sync_handler_is_wrapped_as_async(self):
+        def handler() -> str:
+            return "sync"
+
+        wrapped = offload_to_thread(handler)
+        self.assertTrue(iscoroutinefunction(wrapped))
+        self.assertEqual(run_async(wrapped()), "sync")
+
+    def test_async_handler_returned_untouched(self):
+        async def handler() -> str:
+            return "async"
+
+        # Already-async handlers (e.g. ngsiem) must not be double-wrapped.
+        self.assertIs(offload_to_thread(handler), handler)
+
+    def test_wrapper_preserves_wrapped_reference(self):
+        def handler() -> None:
+            """Docstring."""
+
+        wrapped = offload_to_thread(handler)
+        self.assertIs(wrapped.__wrapped__, handler)
+        self.assertEqual(wrapped.__doc__, handler.__doc__)
+
+
+class TestStandardModeConcurrency(unittest.TestCase):
+    """Standard mode: module tools registered via _add_tool run concurrently."""
+
+    def _build_tool(self):
+        server = FastMCP("test")
+        module = _SleepingModule(_make_sleeping_client())
+        module.register_tools(server)
+        return server._tool_manager._tools["falcon_slow_tool"]
+
+    def test_registered_tool_is_async(self):
+        tool = self._build_tool()
+        self.assertTrue(tool.is_async, "wrapped handler must be detected as async")
+
+    def test_concurrent_tool_runs_interleave(self):
+        tool = self._build_tool()
+
+        async def fire_all() -> float:
+            start = time.monotonic()
+            await asyncio.gather(*(tool.run({}) for _ in range(CONCURRENCY)))
+            return time.monotonic() - start
+
+        elapsed = run_async(fire_all())
+        self.assertLess(
+            elapsed,
+            CONCURRENT_THRESHOLD,
+            f"{CONCURRENCY} calls took {elapsed:.2f}s; expected ~{SLEEP_SECONDS}s "
+            f"(serial would be ~{SERIAL_TOTAL:.2f}s) — handlers are not interleaving",
+        )
+
+
+class TestDynamicModeConcurrency(unittest.TestCase):
+    """Dynamic mode: falcon_execute_tool dispatches to the same wrapped handlers."""
+
+    def _build_dynamic(self):
+        server = FastMCP("test")
+        modules = {"sleeping": _SleepingModule(_make_sleeping_client())}
+        dynamic = DynamicMode(modules, server)
+        return dynamic
+
+    def test_execute_tool_runs_interleave(self):
+        dynamic = self._build_dynamic()
+
+        async def fire_all() -> float:
+            start = time.monotonic()
+            await asyncio.gather(
+                *(
+                    dynamic._execute_tool(tool_name="falcon_slow_tool", parameters={})
+                    for _ in range(CONCURRENCY)
+                )
+            )
+            return time.monotonic() - start
+
+        elapsed = run_async(fire_all())
+        self.assertLess(
+            elapsed,
+            CONCURRENT_THRESHOLD,
+            f"dynamic mode: {CONCURRENCY} calls took {elapsed:.2f}s; expected "
+            f"~{SLEEP_SECONDS}s (serial would be ~{SERIAL_TOTAL:.2f}s)",
+        )
+
+
+class TestTokenRefreshLock(unittest.TestCase):
+    """Only one thread refreshes a stale token; the rest reuse it."""
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_concurrent_stale_token_refreshes_once(self, mock_apiharness, mock_environ_get):
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "id",
+            "FALCON_CLIENT_SECRET": "secret",
+        }.get(key, default)
+
+        underlying = MagicMock()
+        underlying.refreshable = True
+        # Token starts stale; the first login() clears it. A small sleep inside
+        # login widens the race window so an unlocked implementation would let
+        # multiple threads in.
+        underlying.token_stale = True
+
+        def _login() -> bool:
+            time.sleep(0.05)
+            underlying.token_stale = False
+            return True
+
+        underlying.login.side_effect = _login
+        underlying.command.return_value = {"status_code": 200, "body": {}}
+        mock_apiharness.return_value = underlying
+
+        client = FalconClient()
+
+        barrier = threading.Barrier(CONCURRENCY)
+
+        def _call() -> None:
+            barrier.wait()  # release all threads at once
+            client.command("SomeOperation")
+
+        threads = [threading.Thread(target=_call) for _ in range(CONCURRENCY)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(
+            underlying.login.call_count,
+            1,
+            "stale-token refresh should fire exactly once under concurrency",
+        )
+        self.assertEqual(underlying.command.call_count, CONCURRENCY)
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_valid_token_skips_refresh(self, mock_apiharness, mock_environ_get):
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "id",
+            "FALCON_CLIENT_SECRET": "secret",
+        }.get(key, default)
+
+        underlying = MagicMock()
+        underlying.refreshable = True
+        underlying.token_stale = False  # already valid
+        underlying.command.return_value = {"status_code": 200, "body": {}}
+        mock_apiharness.return_value = underlying
+
+        client = FalconClient()
+        client.command("SomeOperation")
+
+        underlying.login.assert_not_called()
+
+
+class TestCommandAsync(unittest.TestCase):
+    """command_async offloads the blocking call to a worker thread."""
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_command_async_returns_result_off_loop(self, mock_apiharness, mock_environ_get):
+        mock_environ_get.side_effect = lambda key, default=None: {
+            "FALCON_CLIENT_ID": "id",
+            "FALCON_CLIENT_SECRET": "secret",
+        }.get(key, default)
+
+        underlying = MagicMock()
+        underlying.refreshable = True
+        underlying.token_stale = False
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+
+        def _command(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            seen["thread"] = threading.get_ident()
+            return {"status_code": 200, "body": {"resources": []}}
+
+        underlying.command.side_effect = _command
+        mock_apiharness.return_value = underlying
+
+        client = FalconClient()
+
+        async def call() -> dict[str, Any]:
+            return await client.command_async("Op")
+
+        result = run_async(call())
+        self.assertEqual(result["status_code"], 200)
+        # The blocking call ran on a worker thread, not the calling thread.
+        self.assertNotEqual(seen["thread"], loop_thread)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -19,6 +19,7 @@ from inspect import iscoroutinefunction
 from typing import Any, TypeVar
 from unittest.mock import MagicMock, patch
 
+import anyio
 from mcp.server.fastmcp import FastMCP
 
 from falcon_mcp.client import FalconClient
@@ -34,6 +35,11 @@ SLEEP_SECONDS = 0.3
 CONCURRENCY = 8
 SERIAL_TOTAL = SLEEP_SECONDS * CONCURRENCY
 CONCURRENT_THRESHOLD = SLEEP_SECONDS * 3  # 0.9s << serial 2.4s
+
+# anyio's default CapacityLimiter for to_thread.run_sync, i.e. the ceiling on how
+# many offloaded handlers run at once. Asserted (not just referenced) in
+# TestThreadPoolBackpressure so an upstream change surfaces as a clear failure.
+DEFAULT_THREAD_LIMIT = 40
 
 
 def run_async(coro: Coroutine[Any, Any, _T]) -> _T:
@@ -154,13 +160,32 @@ class TestDynamicModeConcurrency(unittest.TestCase):
 class TestTokenRefreshLock(unittest.TestCase):
     """Only one thread refreshes a stale token; the rest reuse it."""
 
-    @patch("falcon_mcp.client.os.environ.get")
-    @patch("falcon_mcp.client.APIHarnessV2")
-    def test_concurrent_stale_token_refreshes_once(self, mock_apiharness, mock_environ_get):
+    @staticmethod
+    def _stub_env(mock_environ_get) -> None:
         mock_environ_get.side_effect = lambda key, default=None: {
             "FALCON_CLIENT_ID": "id",
             "FALCON_CLIENT_SECRET": "secret",
         }.get(key, default)
+
+    @staticmethod
+    def _fire_concurrently(client: FalconClient) -> None:
+        """Release CONCURRENCY threads into client.command() simultaneously."""
+        barrier = threading.Barrier(CONCURRENCY)
+
+        def _call() -> None:
+            barrier.wait()  # release all threads at once
+            client.command("SomeOperation")
+
+        threads = [threading.Thread(target=_call) for _ in range(CONCURRENCY)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
+    def test_concurrent_stale_token_refreshes_once(self, mock_apiharness, mock_environ_get):
+        self._stub_env(mock_environ_get)
 
         underlying = MagicMock()
         underlying.refreshable = True
@@ -179,18 +204,7 @@ class TestTokenRefreshLock(unittest.TestCase):
         mock_apiharness.return_value = underlying
 
         client = FalconClient()
-
-        barrier = threading.Barrier(CONCURRENCY)
-
-        def _call() -> None:
-            barrier.wait()  # release all threads at once
-            client.command("SomeOperation")
-
-        threads = [threading.Thread(target=_call) for _ in range(CONCURRENCY)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        self._fire_concurrently(client)
 
         self.assertEqual(
             underlying.login.call_count,
@@ -201,11 +215,60 @@ class TestTokenRefreshLock(unittest.TestCase):
 
     @patch("falcon_mcp.client.os.environ.get")
     @patch("falcon_mcp.client.APIHarnessV2")
+    def test_failed_refresh_retries_serially_not_in_parallel(
+        self, mock_apiharness, mock_environ_get
+    ):
+        """A failing login degrades to serial retries, never a parallel stampede.
+
+        The double-check collapses callers only because a successful login clears
+        `token_stale`. When login fails the token stays stale, so each waiting
+        thread retries in turn. That is the documented trade-off (see
+        `_ensure_token_fresh`): N serial attempts instead of N simultaneous ones,
+        so a broken credential cannot fan out into a burst against the token
+        endpoint. This pins that behavior — and that the lock is still released on
+        the failure path rather than deadlocking the remaining callers.
+        """
+        self._stub_env(mock_environ_get)
+
+        underlying = MagicMock()
+        underlying.refreshable = True
+        underlying.token_stale = True  # login never clears it: bad credentials
+
+        overlap = []
+        in_login = 0
+        overlap_guard = threading.Lock()
+
+        def _login() -> bool:
+            nonlocal in_login
+            with overlap_guard:
+                in_login += 1
+                overlap.append(in_login)
+            time.sleep(0.02)
+            with overlap_guard:
+                in_login -= 1
+            return False
+
+        underlying.login.side_effect = _login
+        underlying.command.return_value = {"status_code": 401, "body": {}}
+        mock_apiharness.return_value = underlying
+
+        client = FalconClient()
+        self._fire_concurrently(client)
+
+        # Never two logins in flight at once — the lock serializes the retries.
+        self.assertEqual(
+            max(overlap),
+            1,
+            f"token logins overlapped ({max(overlap)} concurrent); the refresh lock "
+            "must serialize retries even when login fails",
+        )
+        # Every caller still reaches the API and gets the 401 back.
+        self.assertEqual(underlying.command.call_count, CONCURRENCY)
+
+    @patch("falcon_mcp.client.os.environ.get")
+    @patch("falcon_mcp.client.APIHarnessV2")
     def test_valid_token_skips_refresh(self, mock_apiharness, mock_environ_get):
-        mock_environ_get.side_effect = lambda key, default=None: {
-            "FALCON_CLIENT_ID": "id",
-            "FALCON_CLIENT_SECRET": "secret",
-        }.get(key, default)
+        self._stub_env(mock_environ_get)
 
         underlying = MagicMock()
         underlying.refreshable = True
@@ -217,6 +280,96 @@ class TestTokenRefreshLock(unittest.TestCase):
         client.command("SomeOperation")
 
         underlying.login.assert_not_called()
+
+
+class TestThreadPoolBackpressure(unittest.TestCase):
+    """The offload path is bounded by anyio's default thread limiter, not unbounded."""
+
+    def test_offload_shares_default_limiter(self):
+        """Offloaded handlers borrow from the 40-token default limiter.
+
+        Concurrency is capped rather than unbounded: calls past the limit queue for
+        a worker instead of opening a thread (and a Falcon connection) per request.
+        This pins both the cap's existence and that our wrapper uses the shared
+        default limiter rather than an unbounded pool.
+        """
+        peak = 0
+        current = 0
+        guard = threading.Lock()
+        released = threading.Event()
+
+        def handler() -> int:
+            nonlocal peak, current
+            with guard:
+                current += 1
+                peak = max(peak, current)
+            released.wait(timeout=5)
+            with guard:
+                current -= 1
+            return 1
+
+        wrapped = offload_to_thread(handler)
+        oversubscribe = 2 * DEFAULT_THREAD_LIMIT + 5
+
+        async def fire_all() -> None:
+            async with anyio.create_task_group() as tg:
+                limiter = anyio.to_thread.current_default_thread_limiter()
+                self.assertEqual(
+                    limiter.total_tokens,
+                    DEFAULT_THREAD_LIMIT,
+                    "anyio's default thread limiter changed; revisit the cap "
+                    "documented on offload_to_thread",
+                )
+                for _ in range(oversubscribe):
+                    tg.start_soon(wrapped)
+                # Let the first wave saturate the pool, then drain everything.
+                await anyio.sleep(0.2)
+                released.set()
+
+        anyio.run(fire_all)
+
+        self.assertEqual(
+            peak,
+            DEFAULT_THREAD_LIMIT,
+            f"{oversubscribe} concurrent calls ran {peak} handlers at once; expected "
+            f"the pool to cap at {DEFAULT_THREAD_LIMIT} and queue the rest",
+        )
+
+    def test_cancelled_call_still_completes_its_thread(self):
+        """Cancellation does not abandon the worker mid-call.
+
+        We keep anyio's default `abandon_on_cancel=False`, so a client disconnect
+        or the MCP 60s timeout waits for the in-flight blocking call instead of
+        orphaning the thread. Abandoning would free the slot sooner but leak
+        threads without bound under repeated timeouts.
+        """
+        finished = threading.Event()
+
+        def handler() -> int:
+            time.sleep(SLEEP_SECONDS)
+            finished.set()
+            return 1
+
+        wrapped = offload_to_thread(handler)
+
+        async def cancel_early() -> float:
+            start = time.monotonic()
+            with anyio.move_on_after(SLEEP_SECONDS / 10):
+                await wrapped()
+            return time.monotonic() - start
+
+        elapsed = anyio.run(cancel_early)
+
+        self.assertTrue(
+            finished.is_set(),
+            "handler should run to completion even though the caller cancelled",
+        )
+        self.assertGreaterEqual(
+            elapsed,
+            SLEEP_SECONDS,
+            "cancel scope should wait for the blocking call rather than abandon it; "
+            f"returned after {elapsed:.2f}s",
+        )
 
 
 class TestCommandAsync(unittest.TestCase):


### PR DESCRIPTION
Downstream consumers running the server over HTTP saw requests pile up when they fired them concurrently. Under `Promise.all` or a few open browser tabs, a batch of calls that should finish in about 6 seconds was taking 60 to 120 and tripping the MCP 60s timeout. Their workaround was spawning a fresh server process per call to get parallelism, paying the stdio handshake every time.

The cause is that our tool handlers are synchronous and call blocking FalconPy, and FastMCP runs sync handlers inline on the asyncio event loop. The MCP SDK already dispatches each request as its own task, but while one ~6s Falcon call is in flight the loop is frozen, so every other request waits behind it. One instance could only run one call at a time.

This offloads each sync handler to a worker thread at the point where tools get registered, so a single instance now interleaves concurrent Falcon calls. It's one wrapper at the registration boundary rather than a change to the ~140 handler call sites. FastMCP reads the schema through the wrapped signature, so parameters and descriptions stay identical, and it detects the wrapper as async so it awaits it off the loop. Already-async handlers like ngsiem are left alone and instead await a new `command_async` helper, and a lock serializes the stale-token refresh so concurrent callers don't all hit the token endpoint at once.

I measured it both ways. Against the live API, 10 parallel host searches dropped from 14.8s to 1.6s. In an isolated benchmark the speedup tracks the caller count, reaching about 16x at 16 concurrent calls. The existing tests pass unchanged, and a new regression test fails if handlers ever go back to running serially. Both standard and dynamic mode were checked against the live API, including a run driven end to end through a real agent.


Review turned up two properties of the default anyio thread pool that the design leans on without saying so, both now documented on the wrapper. Concurrency caps at 40 per event loop, so the speedup above tracks caller count only up to that point; past it, calls queue for a worker. And because we keep the default `abandon_on_cancel=False`, a cancelled or timed-out request holds its thread until the blocking call returns instead of orphaning it. Both are the defaults I want, but the reasoning was only in my head.

I also walked back a claim in the token-refresh docstring. It said the refresh fires exactly once across concurrent callers, which is true only while login succeeds and clears the stale flag. Let login fail and the token stays stale, so each waiting thread retries in turn — serialized rather than collapsed. That still keeps a bad credential from fanning out into a burst at the token endpoint, so the behavior is fine; the docstring was just overselling it.

Tests now cover the thread cap, the cancellation contract, and that failed-login path. One more worth calling out: the ngsiem suite routes `command_async` through the sync `command` mock so its existing assertions keep working, and I checked what that costs. Reverting ngsiem to the blocking client left all 13 tests green. Comparing call counts across the two mocks catches it now, down to a single reverted call site.
