### PR TITLE
feat(modules/base): add shared aggregate-query foundation

### DIFF
--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -15,9 +15,9 @@ from mcp.server import FastMCP
 from mcp.types import ToolAnnotations
 
 from falcon_mcp.client import FalconClient
-from falcon_mcp.common.errors import handle_api_response
+from falcon_mcp.common.errors import _format_error_response, handle_api_response
 from falcon_mcp.common.logging import get_logger
-from falcon_mcp.common.utils import prepare_api_parameters
+from falcon_mcp.common.utils import filter_none_values, prepare_api_parameters
 
 logger = get_logger(__name__)
 
@@ -486,6 +486,248 @@ class BaseModule(ABC):
 
     def _is_error(self, response: Any) -> bool:
         return isinstance(response, dict) and "error" in response
+
+    @staticmethod
+    def _build_aggregate_spec(
+        agg_type: str,
+        field: str,
+        filter: str | None = None,
+        name: str | None = None,
+        size: int | None = None,
+        sort: str | None = None,
+        interval: str | None = None,
+        time_zone: str | None = None,
+        from_: int | None = None,
+        q: str | None = None,
+        missing: str | None = None,
+        include: str | None = None,
+        exclude: str | None = None,
+        date_ranges: list[dict[str, Any]] | None = None,
+        ranges: list[dict[str, Any]] | None = None,
+        percents: list[float] | None = None,
+        filters_spec: dict[str, Any] | None = None,
+        extended_bounds: dict[str, Any] | None = None,
+        min_doc_count: int | None = None,
+        max_doc_count: int | None = None,
+        sub_aggregates: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Build one aggregation spec for a Falcon aggregate endpoint.
+
+        Pure function — no I/O. Covers the full `msa.AggregateQueryRequest`
+        superset; the narrower dialects need no separate code path because they
+        are strict subsets and unset keys are omitted:
+
+        | Dialect | Fields | Notes |
+        |---|---|---|
+        | `msa.AggregateQueryRequest` | all 21 | live-verified |
+        | `fwmgr.msa.AggregateQueryRequest` | all 21 | field-identical to `msa`; NOT live-verified |
+        | `detectsapi.AggregateAlertQueryRequest` | 18 | no filters_spec/percents/extended_bounds |
+        | `api.MSAAggregateQueryRequest` | 8 | type/field/filter/name/size/sort/from/date_ranges |
+
+        Passing an out-of-dialect field is the caller's error, but the API will
+        **not** tell you: live, sending `percents`/`filters_spec`/`extended_bounds`
+        — or even a fabricated `totally_made_up_field` — to the 8-field
+        `api.MSAAggregateQueryRequest` endpoint returns HTTP 200 with buckets
+        identical to the clean request. Unknown keys are silently dropped, so a
+        successful response is no evidence the field was honored. Verify a field
+        actually changes the result before documenting it downstream.
+
+        Only `agg_type` and `field` are genuinely required — swagger marks 16
+        fields `required`, which is a spec artifact. Omitting either of these two
+        returns HTTP 500. `name` is optional and echoes back as `""`.
+
+        Note `filter=""` and `size=0`/`from_=0`/`min_doc_count=0` are kept: only
+        `None` counts as unset, so a caller-supplied falsy value survives.
+
+        Nested values (`date_ranges`, `ranges`, `filters_spec`, `extended_bounds`,
+        `sub_aggregates`) are forwarded by reference, not copied — treat the
+        returned spec as owned by the caller and do not mutate it in place.
+
+        Args:
+            agg_type: Aggregation type, sent as the wire key `type`. Support is
+                per-operation — see `_base_aggregate` for the live-verified vocabulary.
+            field: The document field to aggregate on. Required.
+            filter: FQL filter narrowing the documents aggregated.
+            name: Label echoed back on the result, used to identify it in a
+                multi-spec response.
+            size: Max buckets to return. Unbounded up to at least 100000 live.
+            sort: Bucket sort, e.g. `_count.desc`.
+            interval: Bucket width for `date_histogram`. Bare unit names only.
+            time_zone: Numeric UTC offset, e.g. `+00:00`.
+            from_: Bucket offset, sent as the wire key `from`.
+            q: Free-text query.
+            missing: Value substituted for documents missing `field`.
+            include: Bucket-key include pattern.
+            exclude: Bucket-key exclude pattern.
+            date_ranges: `[{"from": ..., "to": ...}, ...]` for `date_range`.
+            ranges: `[{"From": ..., "To": ...}, ...]` for `range`.
+            percents: Percentiles to compute, e.g. `[50.0, 95.0]`.
+            filters_spec: Named sub-filters for the `filters` type.
+            extended_bounds: Forces histogram bounds beyond the matched data.
+            min_doc_count: Drop buckets with fewer than this many documents.
+            max_doc_count: Drop buckets with more than this many documents.
+            sub_aggregates: Nested specs (build each with this same method).
+
+        Returns:
+            The aggregation spec dict, with every unset key omitted.
+        """
+        spec: dict[str, Any] = {
+            # `type` and `from` are renamed: `type` shadows a builtin and `from`
+            # is a Python keyword, so the kwargs are `agg_type` / `from_`.
+            "type": agg_type,
+            "field": field,
+            "from": from_,
+            "filter": filter,
+            "name": name,
+            "size": size,
+            "sort": sort,
+            "interval": interval,
+            "time_zone": time_zone,
+            "q": q,
+            "missing": missing,
+            "include": include,
+            "exclude": exclude,
+            "date_ranges": date_ranges,
+            "ranges": ranges,
+            "percents": percents,
+            "filters_spec": filters_spec,
+            "extended_bounds": extended_bounds,
+            "min_doc_count": min_doc_count,
+            "max_doc_count": max_doc_count,
+            "sub_aggregates": sub_aggregates,
+        }
+        return filter_none_values(spec)
+
+    def _base_aggregate(
+        self,
+        operation: str,
+        specs: list[dict[str, Any]] | None = None,
+        error_message: str = "Aggregate operation failed",
+        **spec_kwargs: Any,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Run one or more aggregation specs against a Falcon aggregate endpoint.
+
+        Pass either `specs` (a pre-built list, for batching) or the single-spec
+        kwargs accepted by `_build_aggregate_spec` — not both.
+
+        **The body is always a list, even for one spec.** Every dialect rejects a
+        bare object live: `cannot unmarshal object into Go value of type
+        []*msa.AggregateQueryRequest`. Swagger marks 6 operations as bare objects;
+        that is wrong, confirmed across 5 operations in 3 dialects with zero
+        counter-examples. Do not "simplify" this to `body={...}`.
+
+        Response shape: `resources: [{name, buckets, sum_other_doc_count}]`, returned
+        here as a bare list — aggregate responses carry no `meta.pagination`, so
+        there is no envelope to build. `sum_other_doc_count` is not universal (the
+        case-management SLA endpoint omits it). Buckets key on **`label`**, not
+        `key` (swagger's item schema omits `label` entirely); for `date_histogram`
+        that `label` is epoch milliseconds as an integer, alongside a
+        `key_as_string` ISO timestamp. Sub-aggregate results nest as
+        `buckets[].sub_aggregates[]`, recursively the same shape. With multiple
+        specs, **response order is not preserved** — identify each result by its
+        `name`, which echoes back as `""` when omitted.
+
+        Live-verified `type` values on alerts: `terms`, `date_histogram`, `range`,
+        `date_range`, `cardinality`, `percentiles`, `avg`, `sum`, `min`, `max`,
+        `filters`, `value_count`. Not accepted there, and the failure mode differs
+        by type: `stats`, `extended_stats`, and `missing` return HTTP 500 with only
+        a trace-id, while `histogram` returns a clean HTTP 400. Do not assume a
+        uniform 400 when handling an unsupported type. **Support is per-operation**
+        — casemgmt rejects `date_histogram` that alerts accepts — so there is
+        deliberately no hardcoded allowlist here; types pass through to the API.
+
+        Two traps worth knowing before trusting a result:
+
+        - **A bad FQL filter or bogus `field` is silent**: HTTP 200 with
+          `buckets: null` and no error. An empty result never proves the query
+          was right.
+        - **HTTP 200 can carry a body-level 400.** `handle_api_response` only
+          inspects the HTTP status, so this method checks `body.errors` on a
+          success status and formats the error itself; otherwise
+          `invalid aggregate type` would silently become `[]`. The returned
+          `details.status_code` stays the true transport status (e.g. 200), and the
+          message quotes the API's own text rather than borrowing the generic 400
+          advice about FQL syntax. That check is deliberately scoped to 2xx: a real
+          4xx/5xx also carries `errors[]`, and routing those here would skip
+          `handle_api_response`'s 403 branch and lose the `required_scopes` hint.
+          Note the more common failure is a real HTTP 500 carrying only a trace-id
+          — a bogus `type` and an omitted `type`/`field` both land there.
+
+        A 403 here means one of two different things, and the message string is
+        what distinguishes them: `access denied, scope not permitted` is a genuine
+        missing scope that adding the scope fixes, whereas `authorization failed`
+        is **not** scope-fixable (read siblings return 200 on the same scope) and
+        should not be chased with scope changes.
+
+        Format constraints (both are clean 400s when violated): `time_zone` needs a
+        numeric offset (`+00:00`, `-05:00`) — IANA names and `UTC`/`Z` are
+        rejected; `interval` accepts bare unit names only (`hour`, `day`, `week`,
+        `month`, `quarter`, `year`) — `1d`/`30m` are 400s, while `minute` is a 500.
+
+        Args:
+            operation: The API operation name (e.g. "PostAggregatesAlertsV2").
+            specs: Pre-built aggregation specs, for batching several in one call.
+            error_message: Custom error message for failed operations.
+            **spec_kwargs: Single-spec arguments forwarded to `_build_aggregate_spec`.
+
+        Returns:
+            The API's `resources` list (one entry per aggregation), or an error dict.
+
+        Raises:
+            ValueError: If both `specs` and single-spec kwargs are given, if neither
+                is, or if `specs` is an empty list.
+        """
+        if specs is not None and spec_kwargs:
+            raise ValueError(
+                "Pass either `specs` or the single-spec kwargs, not both: "
+                f"got specs plus {sorted(spec_kwargs)}"
+            )
+        if specs is None:
+            if not spec_kwargs:
+                raise ValueError("Provide `specs` or the single-spec kwargs (agg_type, field)")
+            specs = [self._build_aggregate_spec(**spec_kwargs)]
+        elif not specs:
+            # `[]` is falsy but not None, so it would otherwise reach the API as a
+            # zero-spec POST. Never useful, and usually an upstream comprehension
+            # that filtered down to nothing.
+            raise ValueError("`specs` is empty: provide at least one aggregation spec")
+
+        logger.debug("Executing %s with %d aggregate spec(s)", operation, len(specs))
+
+        # Always list-wrapped — see the docstring; a bare dict is rejected live.
+        response = self.client.command(operation, body=specs)
+
+        # A 2xx can still carry a body-level error (e.g. `invalid aggregate type`
+        # arrives as HTTP 200 + errors[] + resources: null). handle_api_response
+        # only looks at the HTTP status, so surface it here or the cause is lost.
+        # Scoped to success statuses on purpose: a real 4xx/5xx also carries
+        # `errors[]`, and routing those here would skip handle_api_response's 403
+        # branch, losing `required_scopes`.
+        status_code = response.get("status_code")
+        body = response.get("body") or {}
+        if status_code is not None and status_code < 300 and body.get("errors"):
+            # Format directly rather than forcing a synthetic 4xx through
+            # handle_api_response: that would report a fabricated `status_code` in
+            # `details` and prepend its 400 blurb about FQL syntax, which has
+            # nothing to do with a body-level `invalid aggregate type`.
+            api_messages = [
+                message
+                for error in body["errors"]
+                if (message := error.get("message"))
+            ]
+            detail = f" API said: {'; '.join(api_messages)}" if api_messages else ""
+            return _format_error_response(
+                f"{error_message}:{detail}" if detail else error_message,
+                details=response,
+                operation=operation,
+            )
+
+        return handle_api_response(
+            response,
+            operation=operation,
+            error_message=error_message,
+            default_result=[],
+        )
 
     def _format_fql_error_response(
         self,

--- a/tests/modules/test_base.py
+++ b/tests/modules/test_base.py
@@ -923,6 +923,607 @@ class TestExtractPagination(TestModules):
         self.assertIsNone(self._envelope_next({"body": {}}))
 
 
+class TestBuildAggregateSpec(TestModules):
+    """Body construction for aggregate queries — pure, no API calls."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(ConcreteBaseModule)
+
+    def test_minimal_spec_is_type_and_field_only(self):
+        """Live-verified minimal body: `type` + `field`. Nothing else leaks in.
+
+        Swagger marks 16 fields `required`; live, only these two matter (omitting
+        either returns HTTP 500). Unset kwargs must not appear as None/empty keys.
+        """
+        spec = self.module._build_aggregate_spec(agg_type="terms", field="status")
+        self.assertEqual(spec, {"type": "terms", "field": "status"})
+
+    def test_agg_type_maps_to_type_key(self):
+        """`agg_type` is renamed to the wire key `type` (avoids shadowing the builtin)."""
+        spec = self.module._build_aggregate_spec(agg_type="cardinality", field="agent_id")
+        self.assertEqual(spec["type"], "cardinality")
+        self.assertNotIn("agg_type", spec)
+
+    def test_from_underscore_maps_to_from_key(self):
+        """`from_` is renamed to the wire key `from` (a Python keyword)."""
+        spec = self.module._build_aggregate_spec(agg_type="terms", field="status", from_=25)
+        self.assertEqual(spec["from"], 25)
+        self.assertNotIn("from_", spec)
+
+    def test_msa_dialect_full_superset(self):
+        """msa.AggregateQueryRequest: all 21 fields round-trip with correct values.
+
+        Asserts full dict equality, not just the key set: two same-typed fields
+        wired to each other's kwarg (e.g. `sort`/`interval` swapped in the dict
+        literal) would satisfy a key-set check but corrupt every request.
+        """
+        spec = self.module._build_aggregate_spec(
+            agg_type="terms",
+            field="status",
+            filter="status:'new'",
+            name="by_status",
+            size=10,
+            sort="_count.desc",
+            interval="day",
+            time_zone="+00:00",
+            from_=0,
+            q="search",
+            missing="N/A",
+            include="a*",
+            exclude="b*",
+            date_ranges=[{"from": "2026-01-01", "to": "2026-02-01"}],
+            ranges=[{"From": 0, "To": 10}],
+            percents=[50.0, 95.0],
+            filters_spec={"filters": [{"label": "x", "filter": "status:'new'"}]},
+            extended_bounds={"min": 0, "max": 100},
+            min_doc_count=1,
+            max_doc_count=1000,
+            sub_aggregates=[{"type": "terms", "field": "severity"}],
+        )
+        self.assertEqual(
+            spec,
+            {
+                "type": "terms",
+                "field": "status",
+                "filter": "status:'new'",
+                "name": "by_status",
+                "size": 10,
+                "sort": "_count.desc",
+                "interval": "day",
+                "time_zone": "+00:00",
+                "from": 0,
+                "q": "search",
+                "missing": "N/A",
+                "include": "a*",
+                "exclude": "b*",
+                "date_ranges": [{"from": "2026-01-01", "to": "2026-02-01"}],
+                "ranges": [{"From": 0, "To": 10}],
+                "percents": [50.0, 95.0],
+                "filters_spec": {"filters": [{"label": "x", "filter": "status:'new'"}]},
+                "extended_bounds": {"min": 0, "max": 100},
+                "min_doc_count": 1,
+                "max_doc_count": 1000,
+                "sub_aggregates": [{"type": "terms", "field": "severity"}],
+            },
+        )
+        self.assertEqual(len(spec), 21)
+
+    def test_fwmgr_dialect_matches_msa_superset(self):
+        """fwmgr.msa.AggregateQueryRequest is field-identical to the msa superset.
+
+        SPEC-DERIVED, NOT LIVE-VERIFIED: every fwmgr aggregate operation was
+        blocked on the probe tenant with `authorization failed` (not a scope
+        problem — the read siblings return 200 on the same scope). This asserts
+        that the two swagger definitions share the same 21 fields, which is why
+        the helper needs no fwmgr-specific code path. The first downstream fwmgr
+        aggregate tool should re-probe live.
+        """
+        kwargs = dict(
+            agg_type="terms",
+            field="rule_group",
+            filter="enabled:true",
+            name="by_group",
+            size=10,
+            sort="_count.desc",
+            interval="day",
+            time_zone="-05:00",
+            from_=0,
+            q="search",
+            missing="N/A",
+            include="a*",
+            exclude="b*",
+            date_ranges=[{"from": "2026-01-01", "to": "2026-02-01"}],
+            ranges=[{"From": 0, "To": 10}],
+            percents=[99.0],
+            filters_spec={"filters": [{"label": "x", "filter": "enabled:true"}]},
+            extended_bounds={"min": 0, "max": 100},
+            min_doc_count=1,
+            max_doc_count=1000,
+            sub_aggregates=[{"type": "terms", "field": "platform"}],
+        )
+        spec = self.module._build_aggregate_spec(**kwargs)
+        self.assertEqual(len(spec), 21)
+
+    def test_api_msa_dialect_subset(self):
+        """api.MSAAggregateQueryRequest is an 8-field subset; only those keys appear.
+
+        Live-verified via `aggregates.slas.post.v1`.
+        """
+        spec = self.module._build_aggregate_spec(
+            agg_type="terms",
+            field="status",
+            filter="status:'open'",
+            name="by_status",
+            size=5,
+            sort="_count.desc",
+            from_=0,
+            date_ranges=[{"from": "2026-01-01", "to": "2026-02-01"}],
+        )
+        self.assertEqual(
+            set(spec),
+            {"type", "field", "filter", "name", "size", "sort", "from", "date_ranges"},
+        )
+
+    def test_detectsapi_dialect_subset(self):
+        """detectsapi.AggregateAlertQueryRequest drops filters_spec/percents/extended_bounds.
+
+        Live-verified via `PostAggregatesAlertsV2`. Staying in-dialect is the
+        caller's job: the API silently ignores unknown keys (live, even a
+        fabricated field returns HTTP 200 with unchanged buckets), so an
+        out-of-dialect field is never reported back as an error.
+        """
+        spec = self.module._build_aggregate_spec(
+            agg_type="date_histogram",
+            field="created_timestamp",
+            filter="status:'new'",
+            name="over_time",
+            size=10,
+            sort="_count.desc",
+            interval="day",
+            time_zone="+00:00",
+            from_=0,
+            q="search",
+            missing="N/A",
+            include="a*",
+            exclude="b*",
+            date_ranges=[{"from": "2026-01-01", "to": "2026-02-01"}],
+            ranges=[{"From": 0, "To": 10}],
+            min_doc_count=1,
+            max_doc_count=1000,
+            sub_aggregates=[{"type": "terms", "field": "severity"}],
+        )
+        self.assertEqual(
+            set(spec),
+            {
+                "type", "field", "filter", "name", "size", "sort", "interval",
+                "time_zone", "from", "q", "missing", "include", "exclude",
+                "date_ranges", "ranges", "min_doc_count", "max_doc_count",
+                "sub_aggregates",
+            },
+        )
+        # The three out-of-dialect fields stay absent when the caller omits them.
+        for key in ("filters_spec", "percents", "extended_bounds"):
+            self.assertNotIn(key, spec)
+
+    def test_nested_structures_pass_through_unmodified(self):
+        """date_ranges/ranges/filters_spec/extended_bounds are forwarded byte-for-byte."""
+        date_ranges = [{"from": "2026-01-01T00:00:00Z", "to": "2026-02-01T00:00:00Z"}]
+        ranges = [{"From": 0, "To": 10}, {"From": 10, "To": 100}]
+        filters_spec = {"filters": [{"label": "critical", "filter": "severity:>=70"}]}
+        extended_bounds = {"min": 1735689600, "max": 1738368000}
+
+        spec = self.module._build_aggregate_spec(
+            agg_type="range",
+            field="severity",
+            date_ranges=date_ranges,
+            ranges=ranges,
+            filters_spec=filters_spec,
+            extended_bounds=extended_bounds,
+        )
+
+        self.assertEqual(spec["date_ranges"], date_ranges)
+        self.assertEqual(spec["ranges"], ranges)
+        self.assertEqual(spec["filters_spec"], filters_spec)
+        self.assertEqual(spec["extended_bounds"], extended_bounds)
+
+    def test_sub_aggregates_nest_recursively(self):
+        """A sub_aggregates list built by the same helper nests unmodified.
+
+        Live, sub-aggregate results come back as `buckets[].sub_aggregates[]` with
+        the same bucket shape, recursively.
+        """
+        inner = self.module._build_aggregate_spec(
+            agg_type="terms",
+            field="severity",
+            size=5,
+            sub_aggregates=[
+                self.module._build_aggregate_spec(agg_type="cardinality", field="agent_id")
+            ],
+        )
+        outer = self.module._build_aggregate_spec(
+            agg_type="terms", field="status", sub_aggregates=[inner]
+        )
+
+        self.assertEqual(outer["sub_aggregates"], [inner])
+        self.assertEqual(
+            outer["sub_aggregates"][0]["sub_aggregates"],
+            [{"type": "cardinality", "field": "agent_id"}],
+        )
+
+    def test_falsy_but_meaningful_values_survive(self):
+        """size=0, min_doc_count=0, from_=0 are real values, not "unset" — keep them."""
+        spec = self.module._build_aggregate_spec(
+            agg_type="terms",
+            field="status",
+            size=0,
+            from_=0,
+            min_doc_count=0,
+            max_doc_count=0,
+        )
+        self.assertEqual(spec["size"], 0)
+        self.assertEqual(spec["from"], 0)
+        self.assertEqual(spec["min_doc_count"], 0)
+        self.assertEqual(spec["max_doc_count"], 0)
+
+    def test_empty_string_filter_survives(self):
+        """An empty-string filter is a caller-supplied value, not an omission."""
+        spec = self.module._build_aggregate_spec(agg_type="terms", field="status", filter="")
+        self.assertIn("filter", spec)
+        self.assertEqual(spec["filter"], "")
+
+
+class TestBaseAggregate(TestModules):
+    """The aggregate API call path — mocked client."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(ConcreteBaseModule)
+
+    def test_single_spec_is_still_list_wrapped(self):
+        """A single aggregation must be sent as a one-element list, never a bare dict.
+
+        Live, every dialect rejects a bare object: `cannot unmarshal object into
+        Go value of type []*msa.AggregateQueryRequest`. Swagger marks 6 ops as
+        bare objects; that is wrong. Do not "simplify" this to body={...}.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"name": "by_status", "buckets": []}]},
+        }
+
+        self.module._base_aggregate(
+            "PostAggregatesAlertsV2", agg_type="terms", field="status"
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "PostAggregatesAlertsV2", body=[{"type": "terms", "field": "status"}]
+        )
+
+    def test_multi_spec_passes_through_in_one_list(self):
+        """N specs go out in a single list body; N results come back."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"name": "by_severity", "buckets": []},
+                    {"name": "by_status", "buckets": []},
+                ]
+            },
+        }
+
+        specs = [
+            {"type": "terms", "field": "status", "name": "by_status"},
+            {"type": "terms", "field": "severity", "name": "by_severity"},
+        ]
+        result = self.module._base_aggregate("PostAggregatesAlertsV2", specs=specs)
+
+        self.mock_client.command.assert_called_once_with(
+            "PostAggregatesAlertsV2", body=specs
+        )
+        # Response order is NOT preserved live (sent good,bad → got bad,good); each
+        # result carries its own `name`, so callers identify results by name.
+        self.assertEqual({r["name"] for r in result}, {"by_status", "by_severity"})
+
+    def test_success_returns_resources_list_directly(self):
+        """Aggregates have no meta.pagination, so return bare resources — no envelope."""
+        buckets = [{"label": "new", "count": 12}, {"label": "closed", "count": 3}]
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"name": "by_status", "buckets": buckets, "sum_other_doc_count": 0}
+                ]
+            },
+        }
+
+        result = self.module._base_aggregate(
+            "PostAggregatesAlertsV2", agg_type="terms", field="status"
+        )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(
+            result,
+            [{"name": "by_status", "buckets": buckets, "sum_other_doc_count": 0}],
+        )
+        # Buckets key on `label`, not `key` — swagger's item schema omits `label`.
+        self.assertEqual(result[0]["buckets"][0]["label"], "new")
+        self.assertNotIn("results", result[0])
+        self.assertNotIn("pagination", result[0])
+
+    def test_http_200_with_body_errors_returns_error_not_empty_list(self):
+        """Regression guard: a 200 carrying errors[] must not silently become [].
+
+        Live, casemgmt + `date_histogram` returns HTTP 200 with
+        {"errors":[{"code":400,"message":"invalid aggregate type"}],"resources":null}.
+        `handle_api_response` only inspects the HTTP status, so without an explicit
+        body-level check the real cause is discarded.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "errors": [{"code": 400, "message": "invalid aggregate type"}],
+                "resources": None,
+            },
+        }
+
+        result = self.module._base_aggregate(
+            "AggregateCases",
+            agg_type="date_histogram",
+            field="created_timestamp",
+            error_message="Failed to aggregate cases",
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+        self.assertIn("Failed to aggregate cases", result["error"])
+        self.assertIn("invalid aggregate type", result["error"])
+
+    def test_http_200_with_body_errors_missing_code_still_errors(self):
+        """A body-level error with no usable `code` still surfaces as an error dict."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"errors": [{"message": "something is wrong"}], "resources": None},
+        }
+
+        result = self.module._base_aggregate(
+            "PostAggregatesAlertsV2", agg_type="terms", field="status"
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+        self.assertIn("something is wrong", result["error"])
+
+    def test_http_error_returns_error_dict(self):
+        """A real HTTP 4xx routes through handle_api_response as an error dict."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "invalid interval"}]},
+        }
+
+        result = self.module._base_aggregate(
+            "PostAggregatesAlertsV2",
+            agg_type="date_histogram",
+            field="created_timestamp",
+            interval="1d",
+            error_message="Failed to aggregate alerts",
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+        self.assertIn("Failed to aggregate alerts", result["error"])
+
+    def test_http_500_bogus_type_returns_error_dict(self):
+        """A bogus `type` yields HTTP 500 live (not a clean 400); still an error dict."""
+        self.mock_client.command.return_value = {
+            "status_code": 500,
+            "body": {"errors": [{"message": "trace-id: abc123"}]},
+        }
+
+        result = self.module._base_aggregate(
+            "PostAggregatesAlertsV2", agg_type="not_a_real_type", field="status"
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    def test_empty_resources_returns_empty_list(self):
+        """No aggregations returned is an empty list, not an error."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        result = self.module._base_aggregate(
+            "PostAggregatesAlertsV2", agg_type="terms", field="status"
+        )
+
+        self.assertEqual(result, [])
+
+    def test_null_resources_on_clean_200_returns_empty_list(self):
+        """`resources: null` with no errors[] is an empty result, not an error.
+
+        Live trap: an invalid FQL filter or bogus `field` returns HTTP 200 with
+        null buckets and no error — an empty result never proves the query was right.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": None},
+        }
+
+        result = self.module._base_aggregate(
+            "PostAggregatesAlertsV2", agg_type="terms", field="bogus_field"
+        )
+
+        self.assertEqual(result, [])
+
+    def test_empty_specs_list_is_a_caller_error(self):
+        """`specs=[]` must not burn an API round trip on a zero-spec request.
+
+        An empty list is falsy but not None, so it would otherwise slip past the
+        `specs is None` guard and POST `body=[]`. Realistic upstream cause: a list
+        comprehension that filtered down to nothing.
+        """
+        with self.assertRaises(ValueError):
+            self.module._base_aggregate("PostAggregatesAlertsV2", specs=[])
+        self.mock_client.command.assert_not_called()
+
+    def test_body_errors_with_no_status_code_does_not_crash(self):
+        """A missing `status_code` skips the 2xx gate and still yields an error dict.
+
+        `handle_api_response` already treats a None status as a failure; this
+        confirms the new gate degrades into that path rather than raising.
+        """
+        self.mock_client.command.return_value = {
+            "body": {"errors": [{"message": "no status at all"}], "resources": None}
+        }
+
+        result = self.module._base_aggregate(
+            "PostAggregatesAlertsV2", agg_type="terms", field="status"
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    def test_body_error_preserves_true_transport_status_in_details(self):
+        """The error dict must report the REAL status (200), not a fabricated 400.
+
+        `details` is the only artifact a client or log line sees. Stamping a
+        synthetic 400 there would tell whoever is debugging that the transport
+        returned 400 when it actually returned 200 — and would drag in
+        `handle_api_response`'s 400 blurb about FQL syntax, which has nothing to
+        do with an `invalid aggregate type`.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "errors": [
+                    {"code": 400, "message": 'invalid aggregate type: "date_histogram"'}
+                ],
+                "resources": None,
+            },
+        }
+
+        result = self.module._base_aggregate(
+            "aggregates.slas.post.v1",
+            agg_type="date_histogram",
+            field="created_timestamp",
+            error_message="Failed to aggregate SLAs",
+        )
+
+        self.assertIn("error", result)
+        # The real cause is named.
+        self.assertIn('invalid aggregate type: "date_histogram"', result["error"])
+        # No invented filter-syntax advice.
+        self.assertNotIn("FQL uses", result["error"])
+        # The true transport status survives for whoever is debugging.
+        self.assertEqual(result["details"]["status_code"], 200)
+
+    def test_http_403_keeps_status_and_scope_guidance(self):
+        """A real 403 must NOT be re-stamped — that would strip the scope hint.
+
+        The body-level-error check only exists for 2xx responses. A 403 also
+        carries `errors[]`, so a blanket re-stamp to 400 would both mangle the
+        message into FQL-syntax advice and bypass `handle_api_response`'s 403
+        branch, which attaches `required_scopes` and a resolution. Downstream
+        aggregate tasks rely on that hint to tell a genuine missing scope
+        (`access denied, scope not permitted`) from the non-scope-fixable
+        `authorization failed`.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {
+                "errors": [{"code": 403, "message": "access denied, scope not permitted"}]
+            },
+        }
+
+        result = self.module._base_aggregate(
+            "QueryDevicesByFilter", agg_type="terms", field="status"
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("access denied, scope not permitted", result["error"])
+        # 403-specific handling survives.
+        self.assertEqual(result["required_scopes"], ["Hosts:read"])
+        self.assertIn("resolution", result)
+        # And the message is not mislabeled as a filter-syntax problem.
+        self.assertNotIn("FQL uses", result["error"])
+        self.assertEqual(result["details"]["status_code"], 403)
+
+    def test_resource_without_sum_other_doc_count_passes_through(self):
+        """`sum_other_doc_count` is not universal — the SLA endpoint omits it.
+
+        Live-verified on `aggregates.slas.post.v1`, whose resources carry only
+        `name` and `buckets`. Nothing is normalized or back-filled here.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"name": "", "buckets": [{"label": "Corp SLA", "count": 1}]}
+                ]
+            },
+        }
+
+        result = self.module._base_aggregate(
+            "aggregates.slas.post.v1", agg_type="terms", field="name"
+        )
+
+        self.assertEqual(set(result[0]), {"name", "buckets"})
+
+    def test_date_histogram_bucket_label_is_epoch_millis(self):
+        """date_histogram buckets carry an int `label` plus `key_as_string`.
+
+        Live-verified on `PostAggregatesAlertsV2`: `label` is epoch milliseconds,
+        not a display string, so callers must not assume `label` is a str.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "name": "",
+                        "buckets": [
+                            {
+                                "label": 1680566400000,
+                                "key_as_string": "2023-04-04T00:00:00.000Z",
+                                "count": 1,
+                            }
+                        ],
+                    }
+                ]
+            },
+        }
+
+        result = self.module._base_aggregate(
+            "PostAggregatesAlertsV2",
+            agg_type="date_histogram",
+            field="created_timestamp",
+            interval="day",
+        )
+
+        bucket = result[0]["buckets"][0]
+        self.assertIsInstance(bucket["label"], int)
+        self.assertEqual(bucket["key_as_string"], "2023-04-04T00:00:00.000Z")
+
+    def test_no_specs_and_no_kwargs_is_a_caller_error(self):
+        """Calling with neither `specs` nor spec kwargs fails before any API call."""
+        with self.assertRaises(ValueError):
+            self.module._base_aggregate("PostAggregatesAlertsV2")
+        self.mock_client.command.assert_not_called()
+
+    def test_specs_and_spec_kwargs_together_is_a_caller_error(self):
+        """Passing both `specs` and single-spec kwargs is ambiguous — fail loudly."""
+        with self.assertRaises(ValueError):
+            self.module._base_aggregate(
+                "PostAggregatesAlertsV2",
+                specs=[{"type": "terms", "field": "status"}],
+                agg_type="terms",
+                field="severity",
+            )
+        self.mock_client.command.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
The Falcon API has 135 aggregate operations, and 50 of them take the same request body in four slightly different dialects. Rather than let each of the 12 planned per-module aggregate tools hand-roll a body builder and rediscover the same quirks, this puts the construction in one place on `BaseModule`. No tools yet; those come with the module tasks that use this.

`_build_aggregate_spec` covers the full 21-field `msa.AggregateQueryRequest` superset and drops unset keys, which is what lets the three narrower dialects work without their own code path since they're strict subsets. `_base_aggregate` makes the call and always wraps the body in a list.
