### PR TITLE
feat(modules/detections): add alert aggregation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Full docs are available at **[developer.crowdstrike.com/falcon-mcp](https://deve
 | [Correlation Rules](https://developer.crowdstrike.com/falcon-mcp/modules/correlationrules/) | Search, create, update, and manage NG-SIEM correlation rules |
 | [Custom IOA](https://developer.crowdstrike.com/falcon-mcp/modules/custom-ioa/) | Create and manage Custom IOA behavioral detection rules and rule groups |
 | [Data Protection](https://developer.crowdstrike.com/falcon-mcp/modules/data-protection/) | Search Data Protection classifications, policies, and content patterns |
-| [Detections](https://developer.crowdstrike.com/falcon-mcp/modules/detections/) | Find and analyze detections to understand malicious activity |
+| [Detections](https://developer.crowdstrike.com/falcon-mcp/modules/detections/) | Find, aggregate, and analyze detections to understand malicious activity |
 | [Discover](https://developer.crowdstrike.com/falcon-mcp/modules/discover/) | Search application inventory and discover unmanaged assets |
 | [Exclusions](https://developer.crowdstrike.com/falcon-mcp/modules/exclusions/) | Search, create, update, and delete IOA, machine learning, sensor visibility, and certificate-based exclusions |
 | [Firewall Management](https://developer.crowdstrike.com/falcon-mcp/modules/firewall/) | Search and manage firewall rules and rule groups |

--- a/docs/modules/detections.md
+++ b/docs/modules/detections.md
@@ -13,6 +13,27 @@ Accessing and analyzing CrowdStrike Falcon detections
 
 ## Tools
 
+### `falcon_aggregate_alerts`
+
+**Required scopes:** `Alerts:read`
+
+Count and summarize detections (also called alerts) without retrieving each record.
+
+Use this for "how many" and "top N" questions — alerts per severity, status,
+tactic, or host, distinct host counts, and alert volume over time — instead of
+paging through falcon_search_detections. Consult
+falcon://detections/search/fql-guide before constructing filter expressions.
+Returns one aggregation per request holding `buckets`, which key on `label`
+with a `count`; single-value aggregations (`cardinality`, `max`, `min`, `avg`,
+`sum`) report their answer as `value` instead.
+
+**Example prompts:**
+
+- "How many detections do we have by severity?"
+- "What are the top 10 hosts by alert count this week?"
+- "Show me alert volume per day for the last 30 days"
+- "How many distinct hosts have critical alerts?"
+
 ### `falcon_get_detection_details`
 
 **Required scopes:** `Alerts:read`

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -14,6 +14,7 @@ API_SCOPE_REQUIREMENTS = {
     # Alerts operations (migrated from detections)
     "GetQueriesAlertsV2": ["Alerts:read"],
     "PostEntitiesAlertsV2": ["Alerts:read"],
+    "PostAggregatesAlertsV2": ["Alerts:read"],
     "PatchEntitiesAlertsV3": ["Alerts:write"],
     # Hosts operations
     "QueryDevicesByFilter": ["Hosts:read"],

--- a/falcon_mcp/filter_hints.py
+++ b/falcon_mcp/filter_hints.py
@@ -17,6 +17,15 @@ FILTER_HINTS: dict[str, str] = {
         "Sort by timestamp.desc for latest. "
         "Ex: status:'new'+severity_name:'Critical'"
     ),
+    "falcon_aggregate_alerts": (
+        "Common fields: severity_name (Critical|High|Medium|Low|Informational), "
+        "status (new|in_progress|closed|reopened), product (epp|idp|xdr|overwatch), "
+        "device.hostname, tactic, technique_id, assigned_to_name, filename. "
+        "The filter narrows which alerts are counted; the aggregated field is set "
+        "separately by the field param. "
+        "Date filters: timestamp:>'now-24h' (relative). "
+        "Ex: status:'new'+severity_name:'Critical'"
+    ),
     # === Hosts ===
     "falcon_search_hosts": (
         "Common fields: hostname, platform_name (Windows|Linux|Mac), "

--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -523,7 +523,8 @@ class BaseModule(ABC):
             name: Label echoed back on the result, identifying it in a
                 multi-spec response
             size: Max buckets to return
-            sort: Bucket sort in pipe form only, e.g. "_count|desc"
+            sort: Bucket sort, e.g. "_count|desc". Accepted forms vary by
+                endpoint; each tool documents what its own endpoint takes
             interval: Bucket width for `date_histogram`, as a bare unit name
                 ("hour", "day", "week", "month", "quarter", "year")
             time_zone: Numeric UTC offset, e.g. "+00:00"

--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -523,7 +523,7 @@ class BaseModule(ABC):
             name: Label echoed back on the result, identifying it in a
                 multi-spec response
             size: Max buckets to return
-            sort: Bucket sort, e.g. "_count.desc"
+            sort: Bucket sort in pipe form only, e.g. "_count|desc"
             interval: Bucket width for `date_histogram`, as a bare unit name
                 ("hour", "day", "week", "month", "quarter", "year")
             time_zone: Numeric UTC offset, e.g. "+00:00"
@@ -569,11 +569,52 @@ class BaseModule(ABC):
         }
         return filter_none_values(spec)
 
+    # Aggregation types that need a companion key in the same spec. The API answers a
+    # spec missing its companion with an opaque 500 rather than a validation error.
+    _AGGREGATE_REQUIRED_COMPANIONS: dict[str, str] = {
+        "date_histogram": "interval",
+        "date_range": "date_ranges",
+        "range": "ranges",
+    }
+
+    @classmethod
+    def _find_missing_aggregate_companion(
+        cls, specs: list[dict[str, Any]]
+    ) -> tuple[str, str] | None:
+        """Find the first aggregation spec missing a required companion key.
+
+        Recurses into `sub_aggregates`, which the API validates the same way.
+
+        Args:
+            specs: Aggregation specs to check
+
+        Returns:
+            A (type, missing key) pair, or None if every spec is complete
+        """
+        for spec in specs:
+            if not isinstance(spec, dict):
+                # Malformed input is the API's to reject, not this check's to crash on.
+                continue
+
+            agg_type = spec.get("type")
+            if isinstance(agg_type, str):
+                companion = cls._AGGREGATE_REQUIRED_COMPANIONS.get(agg_type)
+                if companion and not spec.get(companion):
+                    return agg_type, companion
+
+            nested = spec.get("sub_aggregates")
+            if isinstance(nested, list):
+                found = cls._find_missing_aggregate_companion(nested)
+                if found:
+                    return found
+        return None
+
     def _base_aggregate(
         self,
         operation: str,
         specs: list[dict[str, Any]] | None = None,
         error_message: str = "Aggregate operation failed",
+        parameters: dict[str, Any] | None = None,
         **spec_kwargs: Any,
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Run one or more aggregation specs against a Falcon aggregate endpoint.
@@ -585,6 +626,8 @@ class BaseModule(ABC):
             operation: The API operation name (e.g. "PostAggregatesAlertsV2")
             specs: Pre-built aggregation specs, for batching several in one call
             error_message: Custom error message for failed operations
+            parameters: Query-string parameters for endpoints that take them
+                alongside the body (e.g. `include_hidden`)
             **spec_kwargs: Single-spec arguments forwarded to
                 `_build_aggregate_spec`
 
@@ -611,10 +654,21 @@ class BaseModule(ABC):
             # zero-spec POST.
             raise ValueError("`specs` is empty: provide at least one aggregation spec")
 
+        missing = self._find_missing_aggregate_companion(specs)
+        if missing:
+            agg_type, companion = missing
+            return _format_error_response(
+                f"`{companion}` is required when type is `{agg_type}`",
+                operation=operation,
+            )
+
         logger.debug("Executing %s with %d aggregate spec(s)", operation, len(specs))
 
         # List-wrapped even for one spec; the API 400s on a bare object.
-        response = self.client.command(operation, body=specs)
+        command_kwargs: dict[str, Any] = {"body": specs}
+        if parameters:
+            command_kwargs["parameters"] = parameters
+        response = self.client.command(operation, **command_kwargs)
 
         # A 2xx can still carry a body-level error, which handle_api_response would
         # read as success and discard. Only 2xx: a real 4xx/5xx also carries

--- a/falcon_mcp/modules/detections.py
+++ b/falcon_mcp/modules/detections.py
@@ -5,7 +5,7 @@ This module provides tools for accessing and analyzing CrowdStrike Falcon detect
 """
 
 from textwrap import dedent
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
@@ -40,6 +40,12 @@ class DetectionsModule(BaseModule):
             server=server,
             method=self.get_detection_details,
             name="get_detection_details",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.aggregate_detections,
+            name="aggregate_alerts",
         )
 
         self._add_tool(
@@ -205,6 +211,158 @@ class DetectionsModule(BaseModule):
             ids=ids,
             id_key="composite_ids",
             include_hidden=include_hidden,
+        )
+
+    def aggregate_detections(
+        self,
+        field: str = Field(
+            description=(
+                "Alert field to aggregate on, such as `severity_name`, `status`, "
+                "`tactic`, `technique`, `product`, `device.hostname`, or `timestamp`. "
+                "See `falcon://detections/search/fql-guide` for the aggregatable fields."
+            ),
+            examples=["severity_name", "status", "tactic", "device.hostname"],
+        ),
+        type: Literal[
+            "terms",
+            "date_histogram",
+            "date_range",
+            "range",
+            "cardinality",
+            "max",
+            "min",
+            "avg",
+            "sum",
+            "percentiles",
+        ] = Field(
+            default="terms",
+            description=(
+                "Aggregation to run. Use `terms` to count alerts per distinct value, "
+                "`date_histogram` for a time series, `date_range` or `range` for "
+                "explicit buckets, and `cardinality` for a distinct-value count."
+            ),
+        ),
+        filter: str | None = Field(
+            default=None,
+            description=(
+                "FQL filter expression narrowing which alerts are counted. See "
+                "`falcon://detections/search/fql-guide` for syntax."
+            ),
+            examples=["status:'new'", "severity_name:'Critical'+product:'epp'"],
+        ),
+        size: int | None = Field(
+            default=10,
+            ge=1,
+            le=1000,
+            description="Maximum number of buckets to return for `terms` aggregations.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description=(
+                "Bucket ordering, using the pipe form only: `_count|desc` (most "
+                "alerts first), `_count|asc`, `_key|asc`, or `_key|desc`. The dot "
+                "form accepted by search sorts is rejected here."
+            ),
+            examples=["_count|desc", "_key|asc"],
+        ),
+        interval: Literal["hour", "day", "week", "month", "quarter", "year"] | None = Field(
+            default=None,
+            description=(
+                "Bucket width for `date_histogram` aggregations. Required whenever "
+                "`type` is `date_histogram`."
+            ),
+        ),
+        date_ranges: list[dict[str, str]] | None = Field(
+            default=None,
+            description=(
+                "Explicit time buckets for `date_range` aggregations, for example "
+                "`[{'from': 'now-7d', 'to': 'now'}]`. Required whenever `type` is "
+                "`date_range`."
+            ),
+            examples=[[{"from": "now-7d", "to": "now"}]],
+        ),
+        ranges: list[dict[str, Any]] | None = Field(
+            default=None,
+            description=(
+                "Numeric buckets for `range` aggregations, for example "
+                "`[{'From': 0, 'To': 50}]`. Required whenever `type` is `range`."
+            ),
+            examples=[[{"From": 0, "To": 50}, {"From": 50, "To": 100}]],
+        ),
+        percents: list[float] | None = Field(
+            default=None,
+            description="Percentiles to compute for `percentiles` aggregations.",
+            examples=[[50.0, 95.0]],
+        ),
+        missing: str | None = Field(
+            default=None,
+            description=(
+                "Label used for alerts that have no value for `field`, so they are "
+                "counted instead of dropped."
+            ),
+            examples=["Unassigned"],
+        ),
+        include: str | None = Field(
+            default=None,
+            description=(
+                "Keep only buckets whose key matches this regular expression, e.g. "
+                "`High|Critical`."
+            ),
+            examples=["High|Critical"],
+        ),
+        name: str = Field(
+            default="alert_aggregation",
+            description="Label echoed back on the returned aggregation.",
+        ),
+        time_zone: str | None = Field(
+            default=None,
+            description="UTC offset applied to date buckets, e.g. `+00:00`.",
+            examples=["+00:00"],
+        ),
+        sub_aggregates: list[dict[str, Any]] | None = Field(
+            default=None,
+            description=(
+                "Nested aggregations applied within each bucket, each shaped like a "
+                "top-level spec, e.g. `[{'type': 'terms', 'field': 'status'}]`."
+            ),
+            examples=[[{"type": "terms", "field": "status", "size": 3}]],
+        ),
+        include_hidden: bool = Field(
+            default=True,
+            description=(
+                "Whether to count hidden alerts (default: True). Set False to match "
+                "the alert totals shown in the Falcon console."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Count and summarize detections (also called alerts) without retrieving each record.
+
+        Use this for "how many" and "top N" questions — alerts per severity, status,
+        tactic, or host, distinct host counts, and alert volume over time — instead of
+        paging through falcon_search_detections. Consult
+        falcon://detections/search/fql-guide before constructing filter expressions.
+        Returns one aggregation per request holding `buckets`, which key on `label`
+        with a `count`; single-value aggregations (`cardinality`, `max`, `min`, `avg`,
+        `sum`) report their answer as `value` instead.
+        """
+        return self._base_aggregate(
+            operation="PostAggregatesAlertsV2",
+            agg_type=type,
+            field=field,
+            filter=filter,
+            name=name,
+            size=size,
+            sort=sort,
+            interval=interval,
+            date_ranges=date_ranges,
+            ranges=ranges,
+            percents=percents,
+            missing=missing,
+            include=include,
+            time_zone=time_zone,
+            sub_aggregates=sub_aggregates,
+            parameters={"include_hidden": include_hidden},
+            error_message="Failed to aggregate detections",
         )
 
     def update_detections(

--- a/falcon_mcp/resources/detections.py
+++ b/falcon_mcp/resources/detections.py
@@ -988,4 +988,52 @@ assigned_to_name:!'*'+severity_name:!'Informational'
 
 # All unassigned alerts except informational (numeric approach)
 assigned_to_name:!'*'+severity:>=20
+
+=== falcon_aggregate_alerts AGGREGATION FIELDS ===
+
+The `filter` syntax above applies unchanged to falcon_aggregate_alerts, where it narrows
+which alerts are counted. The `field` parameter, which chooses what to group by, accepts a
+different and narrower set of fields than `filter` does. These fields are verified
+aggregatable:
+
+Classification: severity_name, severity, status, tactic, technique, tactic_id,
+  technique_id, objective, product, pattern_id, scenario, type, name, display_name,
+  confidence, resolution, global_prevalence
+Device: device.hostname, device.platform_name, device.os_version,
+  device.product_type_desc, platform, hostname, agent_id, cid
+Assignment: assigned_to_name, assigned_to_uid, tags, data_domains, source_products,
+  source_vendors, email_sent, show_in_ui
+Process/file: filename, filepath, cmdline, sha256, md5, user_name, alleged_filetype,
+  ioc_type, ioc_value, local_process_id, parent_details.filename,
+  grandparent_details.filename, child_process_ids, triggering_process_graph_id
+Time: timestamp, created_timestamp, updated_timestamp, crawled_timestamp,
+  seconds_to_triaged, seconds_to_resolved
+Correlation: aggregate_id, poly_id, falcon_host_link, comment, description
+
+An unsupported aggregation field returns an empty result rather than an error, so a field
+absent from this list cannot be distinguished from a genuine zero count.
+
+Bucket ordering uses the pipe form only — `_count|desc`, `_count|asc`, `_key|asc`,
+`_key|desc`. The dot form used by search sorts (`timestamp.desc`) is rejected with a 400.
+
+Three aggregation types need a companion argument: `date_histogram` requires `interval`,
+`date_range` requires `date_ranges`, and `range` requires `ranges`. This applies to nested
+specs passed via `sub_aggregates` as well.
+
+Aggregation examples:
+
+# Alerts per severity, most common first
+field=severity_name, type=terms, sort=_count|desc
+
+# Busiest hosts among new critical alerts
+field=device.hostname, type=terms, size=10, filter=status:'new'+severity_name:'Critical'
+
+# Daily alert volume for the last week
+field=timestamp, type=date_histogram, interval=day, filter=timestamp:>'now-7d'
+
+# Distinct hosts that have alerts
+field=device.hostname, type=cardinality
+
+# Unassigned alerts counted under an explicit label
+field=assigned_to_name, type=terms, missing=Unassigned
 """

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -203,6 +203,12 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     "falcon_get_detection_details": [
         "Get me the details for this detection",
     ],
+    "falcon_aggregate_alerts": [
+        "How many detections do we have by severity?",
+        "What are the top 10 hosts by alert count this week?",
+        "Show me alert volume per day for the last 30 days",
+        "How many distinct hosts have critical alerts?",
+    ],
     "falcon_update_detections": [
         "Mark detection abc123 as in_progress",
         "Assign detection abc123 to analyst@example.com",

--- a/tests/integration/test_detections.py
+++ b/tests/integration/test_detections.py
@@ -107,6 +107,151 @@ class TestDetectionsIntegration(BaseIntegrationTest):
         # If operation name is wrong, this will be an error response
         self.assert_no_error(result, context="operation name validation")
 
+        # PostAggregatesAlertsV2 is only exercised by aggregate_detections.
+        aggregated = self.call_method(
+            self.module.aggregate_detections, field="severity_name"
+        )
+        self.assert_no_error(aggregated, context="PostAggregatesAlertsV2 name validation")
+
+    def test_aggregate_detections_terms_returns_labelled_buckets(self):
+        """A terms aggregation returns buckets keyed on `label` with a count."""
+        result = self.call_method(
+            self.module.aggregate_detections,
+            field="severity_name",
+            type="terms",
+            sort="_count|desc",
+        )
+
+        self.assert_no_error(result, context="aggregate_detections terms")
+        self.assert_valid_list_response(
+            result, min_length=1, context="aggregate_detections terms"
+        )
+
+        buckets = result[0].get("buckets")
+        if not buckets:
+            self.skip_with_warning(
+                "No alerts to aggregate", "aggregate_detections terms buckets"
+            )
+            return
+
+        # Buckets key on `label`, not `key` — asserted so a shape change is caught.
+        assert "label" in buckets[0], f"expected `label` in bucket, got {buckets[0]}"
+        assert "count" in buckets[0], f"expected `count` in bucket, got {buckets[0]}"
+
+    def test_aggregate_detections_sort_pipe_format_is_accepted(self):
+        """Aggregate sorts use the pipe form; the dot form is rejected upstream.
+
+        Locks in the live behavior that `_count|desc` works here, unlike the
+        `severity.desc` form accepted by search sorts.
+        """
+        result = self.call_method(
+            self.module.aggregate_detections,
+            field="severity_name",
+            type="terms",
+            sort="_count|desc",
+        )
+        self.assert_no_error(result, context="aggregate_detections sort=_count|desc")
+
+        buckets = result[0].get("buckets") or []
+        if len(buckets) > 1:
+            counts = [b.get("count", 0) for b in buckets]
+            assert counts == sorted(counts, reverse=True), (
+                f"_count|desc did not order buckets by descending count: {counts}"
+            )
+
+    def test_aggregate_detections_cardinality_reports_value(self):
+        """Single-value aggregations report their answer as `value`, not `count`."""
+        result = self.call_method(
+            self.module.aggregate_detections,
+            field="device.hostname",
+            type="cardinality",
+        )
+
+        self.assert_no_error(result, context="aggregate_detections cardinality")
+        buckets = result[0].get("buckets") or []
+        if not buckets:
+            self.skip_with_warning(
+                "No alerts to aggregate", "aggregate_detections cardinality"
+            )
+            return
+
+        assert "value" in buckets[0], f"expected `value` in bucket, got {buckets[0]}"
+
+    def test_aggregate_detections_date_histogram_buckets_by_interval(self):
+        """A date_histogram over timestamp accepts a bare interval unit."""
+        result = self.call_method(
+            self.module.aggregate_detections,
+            field="timestamp",
+            type="date_histogram",
+            interval="day",
+            filter="timestamp:>'now-7d'",
+        )
+
+        self.assert_no_error(result, context="aggregate_detections date_histogram")
+        self.assert_valid_list_response(
+            result, min_length=1, context="aggregate_detections date_histogram"
+        )
+
+    def test_aggregate_detections_include_hidden_changes_totals(self):
+        """include_hidden=False counts no more alerts than the default."""
+        shown = self.call_method(
+            self.module.aggregate_detections,
+            field="severity_name",
+            include_hidden=False,
+        )
+        everything = self.call_method(
+            self.module.aggregate_detections,
+            field="severity_name",
+            include_hidden=True,
+        )
+
+        self.assert_no_error(shown, context="aggregate_detections include_hidden=False")
+        self.assert_no_error(everything, context="aggregate_detections include_hidden=True")
+
+        def total(result):
+            return sum(b.get("count", 0) for b in (result[0].get("buckets") or []))
+
+        # Hidden alerts are a superset, so excluding them cannot raise the count.
+        assert total(shown) <= total(everything), (
+            f"include_hidden=False counted more ({total(shown)}) "
+            f"than include_hidden=True ({total(everything)})"
+        )
+
+    def test_aggregate_detections_missing_companion_is_caught_locally(self):
+        """A type missing its companion argument is rejected before the API call.
+
+        The live API answers these with an opaque 500, so the tool must catch them.
+        """
+        result = self.call_method(
+            self.module.aggregate_detections,
+            field="timestamp",
+            type="date_histogram",
+        )
+
+        assert isinstance(result, dict) and "error" in result, (
+            f"expected a local validation error, got {result!r}"
+        )
+        assert "interval" in result["error"], (
+            f"error should name the missing argument, got {result['error']!r}"
+        )
+
+    def test_aggregate_detections_unsupported_field_returns_empty(self):
+        """An unsupported aggregation field returns empty buckets, not an error.
+
+        Documents the silent-ignore behavior that makes a bad field
+        indistinguishable from a genuine zero count.
+        """
+        result = self.call_method(
+            self.module.aggregate_detections,
+            field="not_a_real_alert_field_xyz",
+        )
+
+        self.assert_no_error(result, context="aggregate_detections unsupported field")
+        assert not (result[0].get("buckets") or []), (
+            "expected no buckets for an unsupported aggregation field, "
+            f"got {result[0].get('buckets')}"
+        )
+
     def test_update_detections_status(self):
         """Test updating a detection status using PatchEntitiesAlertsV3.
 

--- a/tests/modules/test_base.py
+++ b/tests/modules/test_base.py
@@ -1271,6 +1271,7 @@ class TestBaseAggregate(TestModules):
             "AggregateCases",
             agg_type="date_histogram",
             field="created_timestamp",
+            interval="day",
             error_message="Failed to aggregate cases",
         )
 
@@ -1368,6 +1369,93 @@ class TestBaseAggregate(TestModules):
             self.module._base_aggregate("PostAggregatesAlertsV2", specs=[])
         self.mock_client.command.assert_not_called()
 
+    def test_missing_type_companion_short_circuits(self):
+        """A spec missing its type's companion key never reaches the API.
+
+        The API answers these with an opaque 500, so they are caught locally.
+        """
+        cases = [
+            ({"type": "date_histogram", "field": "timestamp"}, "interval"),
+            ({"type": "date_range", "field": "timestamp"}, "date_ranges"),
+            ({"type": "range", "field": "severity"}, "ranges"),
+        ]
+        for spec, companion in cases:
+            with self.subTest(agg_type=spec["type"]):
+                self.mock_client.command.reset_mock()
+                result = self.module._base_aggregate(
+                    "PostAggregatesAlertsV2", specs=[spec]
+                )
+                self.assertIn("error", result)
+                self.assertIn(companion, result["error"])
+                self.mock_client.command.assert_not_called()
+
+    def test_missing_companion_found_in_nested_specs(self):
+        """The companion check recurses into `sub_aggregates` at any depth."""
+        deep = {
+            "type": "terms",
+            "field": "status",
+            "sub_aggregates": [
+                {
+                    "type": "terms",
+                    "field": "product",
+                    "sub_aggregates": [{"type": "range", "field": "severity"}],
+                }
+            ],
+        }
+
+        result = self.module._base_aggregate("PostAggregatesAlertsV2", specs=[deep])
+
+        self.assertIn("error", result)
+        self.assertIn("ranges", result["error"])
+        self.mock_client.command.assert_not_called()
+
+    def test_complete_companions_reach_the_api(self):
+        """Supplying each companion key lets the request through untouched."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"name": "ok", "buckets": []}]},
+        }
+        spec = {
+            "type": "date_histogram",
+            "field": "timestamp",
+            "interval": "day",
+            "sub_aggregates": [
+                {"type": "range", "field": "severity", "ranges": [{"From": 0, "To": 50}]}
+            ],
+        }
+
+        result = self.module._base_aggregate("PostAggregatesAlertsV2", specs=[spec])
+
+        self.assertEqual(result[0]["name"], "ok")
+        self.mock_client.command.assert_called_once()
+
+    def test_malformed_nested_specs_do_not_crash_the_check(self):
+        """Malformed `sub_aggregates` values reach the API instead of raising.
+
+        The check inspects caller-supplied dicts whose values are untyped, so a
+        non-dict entry must not turn into an AttributeError.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"name": "ok", "buckets": []}]},
+        }
+        malformed = [
+            "not-a-list",
+            [123],
+            [{"type": "terms", "field": "x", "sub_aggregates": "nope"}],
+            [{"type": ["terms"], "field": "x"}],
+            [{"type": {"a": 1}, "field": "x"}],
+        ]
+        for nested in malformed:
+            with self.subTest(nested=nested):
+                self.mock_client.command.reset_mock()
+                result = self.module._base_aggregate(
+                    "PostAggregatesAlertsV2",
+                    specs=[{"type": "terms", "field": "status", "sub_aggregates": nested}],
+                )
+                self.assertEqual(result[0]["name"], "ok")
+                self.mock_client.command.assert_called_once()
+
     def test_body_errors_with_no_status_code_does_not_crash(self):
         """A missing `status_code` skips the 2xx gate and still yields an error dict.
 
@@ -1408,6 +1496,7 @@ class TestBaseAggregate(TestModules):
             "aggregates.slas.post.v1",
             agg_type="date_histogram",
             field="created_timestamp",
+            interval="day",
             error_message="Failed to aggregate SLAs",
         )
 

--- a/tests/modules/test_detections.py
+++ b/tests/modules/test_detections.py
@@ -22,6 +22,7 @@ class TestDetectionsModule(TestModules):
         expected_tools = [
             "falcon_search_detections",
             "falcon_get_detection_details",
+            "falcon_aggregate_alerts",
             "falcon_update_detections",
         ]
         self.assert_tools_registered(expected_tools)
@@ -319,6 +320,284 @@ class TestDetectionsModule(TestModules):
         self.assertIn("fql_guide", result)
         self.assertEqual(result["fql_guide"], SEARCH_DETECTIONS_FQL_DOCUMENTATION)
         self.assertIn("error", result["hint"].lower())
+
+    def test_aggregate_detections_builds_minimal_body(self):
+        """Aggregating sends a list-wrapped spec and omits unset keys."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "name": "alert_aggregation",
+                        "buckets": [{"label": "Critical", "count": 7}],
+                    }
+                ]
+            },
+        }
+
+        result = self.module.aggregate_detections(
+            field="severity_name",
+            type="terms",
+            filter=None,
+            size=10,
+            sort=None,
+            interval=None,
+            date_ranges=None,
+            ranges=None,
+            percents=None,
+            missing=None,
+            include=None,
+            name="alert_aggregation",
+            time_zone=None,
+            sub_aggregates=None,
+            include_hidden=True,
+        )
+
+        operation, kwargs = (
+            self.mock_client.command.call_args[0][0],
+            self.mock_client.command.call_args[1],
+        )
+        self.assertEqual(operation, "PostAggregatesAlertsV2")
+
+        # The API rejects a bare object, so the body must be list-wrapped.
+        self.assertEqual(
+            kwargs["body"],
+            [
+                {
+                    "type": "terms",
+                    "field": "severity_name",
+                    "name": "alert_aggregation",
+                    "size": 10,
+                }
+            ],
+        )
+        self.assertEqual(result[0]["buckets"], [{"label": "Critical", "count": 7}])
+
+    def test_aggregate_detections_forwards_include_hidden_as_query_param(self):
+        """include_hidden travels as a query parameter, not inside the body spec."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"name": "alert_aggregation", "buckets": []}]},
+        }
+
+        self.module.aggregate_detections(
+            field="status",
+            type="terms",
+            filter=None,
+            size=None,
+            sort=None,
+            interval=None,
+            date_ranges=None,
+            ranges=None,
+            percents=None,
+            missing=None,
+            include=None,
+            name="alert_aggregation",
+            time_zone=None,
+            sub_aggregates=None,
+            include_hidden=False,
+        )
+
+        kwargs = self.mock_client.command.call_args[1]
+        self.assertEqual(kwargs["parameters"], {"include_hidden": False})
+        self.assertNotIn("include_hidden", kwargs["body"][0])
+
+    def test_aggregate_detections_passes_through_optional_spec_fields(self):
+        """Optional aggregation controls reach the body under their wire names."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"name": "daily", "buckets": []}]},
+        }
+
+        self.module.aggregate_detections(
+            field="timestamp",
+            type="date_histogram",
+            filter="status:'new'",
+            size=None,
+            sort="_count|desc",
+            interval="day",
+            date_ranges=None,
+            ranges=None,
+            percents=None,
+            missing="Unassigned",
+            include="High|Critical",
+            name="daily",
+            time_zone="+00:00",
+            sub_aggregates=[{"type": "terms", "field": "status"}],
+            include_hidden=True,
+        )
+
+        spec = self.mock_client.command.call_args[1]["body"][0]
+        self.assertEqual(spec["type"], "date_histogram")
+        self.assertEqual(spec["interval"], "day")
+        self.assertEqual(spec["filter"], "status:'new'")
+        self.assertEqual(spec["sort"], "_count|desc")
+        self.assertEqual(spec["missing"], "Unassigned")
+        self.assertEqual(spec["include"], "High|Critical")
+        self.assertEqual(spec["time_zone"], "+00:00")
+        self.assertEqual(spec["sub_aggregates"], [{"type": "terms", "field": "status"}])
+
+    def test_aggregate_detections_error(self):
+        """A failed aggregation surfaces an error rather than empty buckets."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "failed to validate aggregates query(s)"}]},
+        }
+
+        result = self.module.aggregate_detections(
+            field="severity_name",
+            type="terms",
+            filter=None,
+            size=10,
+            sort=None,
+            interval=None,
+            date_ranges=None,
+            ranges=None,
+            percents=None,
+            missing=None,
+            include=None,
+            name="alert_aggregation",
+            time_zone=None,
+            sub_aggregates=None,
+            include_hidden=True,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+
+    def test_aggregate_detections_handles_null_buckets(self):
+        """A zero-match aggregation returns buckets: null, which must pass through."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"name": "alert_aggregation", "buckets": None, "sum_other_doc_count": 0}
+                ]
+            },
+        }
+
+        result = self.module.aggregate_detections(
+            field="severity_name",
+            type="terms",
+            filter="status:'nonexistent'",
+            size=10,
+            sort=None,
+            interval=None,
+            date_ranges=None,
+            ranges=None,
+            percents=None,
+            missing=None,
+            include=None,
+            name="alert_aggregation",
+            time_zone=None,
+            sub_aggregates=None,
+            include_hidden=True,
+        )
+
+        self.assertIsNone(result[0]["buckets"])
+
+    def test_aggregate_detections_requires_type_specific_companion(self):
+        """Types needing a companion argument fail fast instead of 500ing upstream."""
+        cases = [
+            ("date_histogram", "interval"),
+            ("date_range", "date_ranges"),
+            ("range", "ranges"),
+        ]
+        for agg_type, companion in cases:
+            with self.subTest(agg_type=agg_type):
+                self.mock_client.command.reset_mock()
+
+                result = self.module.aggregate_detections(
+                    field="timestamp",
+                    type=agg_type,
+                    filter=None,
+                    size=None,
+                    sort=None,
+                    interval=None,
+                    date_ranges=None,
+                    ranges=None,
+                    percents=None,
+                    missing=None,
+                    include=None,
+                    name="alert_aggregation",
+                    time_zone=None,
+                    sub_aggregates=None,
+                    include_hidden=True,
+                )
+
+                self.assertIn("error", result)
+                self.assertIn(companion, result["error"])
+                # The point of the guard: no request is sent at all.
+                self.mock_client.command.assert_not_called()
+
+    def test_aggregate_detections_accepts_type_with_its_companion(self):
+        """Supplying the companion argument lets the request through."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"name": "daily", "buckets": []}]},
+        }
+
+        result = self.module.aggregate_detections(
+            field="timestamp",
+            type="date_histogram",
+            filter=None,
+            size=None,
+            sort=None,
+            interval="day",
+            date_ranges=None,
+            ranges=None,
+            percents=None,
+            missing=None,
+            include=None,
+            name="daily",
+            time_zone=None,
+            sub_aggregates=None,
+            include_hidden=True,
+        )
+
+        self.assertEqual(result[0]["name"], "daily")
+        self.mock_client.command.assert_called_once()
+
+    def test_aggregate_detections_checks_nested_spec_companions(self):
+        """A nested spec missing its companion argument is caught too.
+
+        The API validates sub_aggregates the same way, so a nested
+        date_histogram without an interval must not reach it.
+        """
+        result = self.module.aggregate_detections(
+            field="status",
+            type="terms",
+            filter=None,
+            size=None,
+            sort=None,
+            interval=None,
+            date_ranges=None,
+            ranges=None,
+            percents=None,
+            missing=None,
+            include=None,
+            name="alert_aggregation",
+            time_zone=None,
+            sub_aggregates=[{"type": "date_histogram", "field": "timestamp"}],
+            include_hidden=True,
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("interval", result["error"])
+        self.mock_client.command.assert_not_called()
+
+    def test_aggregate_alerts_is_read_only(self):
+        """falcon_aggregate_alerts must advertise itself as read-only."""
+        self.module.register_tools(self.mock_server)
+        self.assert_tool_annotations(
+            "falcon_aggregate_alerts",
+            ToolAnnotations(
+                readOnlyHint=True,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
 
     def test_update_detections_has_write_annotations(self):
         """Verify falcon_update_detections has correct non-read-only annotations."""


### PR DESCRIPTION
Adds `falcon_aggregate_alerts` to the detections module, so "how many by X" and "top N" questions can be answered with a single counting call instead of paging through search results. It uses `PostAggregatesAlertsV2`, since the v1 aggregate endpoint and `GetAggregateDetects` are both deprecated.

The parameter surface is narrower than the swagger schema. Ten aggregation types actually work, and they're exposed as a `Literal` because an unrecognized type comes back as an opaque 500 instead of a validation error. Four documented body fields are silently ignored by the API, so I left them out rather than offer controls that quietly do nothing.

Three types need a companion argument: `date_histogram` needs `interval`, `date_range` needs `date_ranges`, and `range` needs `ranges`. Omit one and you get the same unhelpful 500, at any nesting depth. That check went into `_base_aggregate` and recurses through `sub_aggregates` so the other modules following this pattern get it for free. `_base_aggregate` also picked up a `parameters` argument, since `include_hidden` belongs in the query string here rather than the body.

The FQL guide covers the aggregatable fields, which are a narrower set than the filterable ones, and calls out that an unsupported field comes back empty rather than as an error.

One drive-by fix: the shared helper's `sort` docstring showed a form this endpoint rejects. Sort handling turns out to vary by endpoint, so the helper says that now and each tool documents what its own endpoint takes.
