### PR TITLE
fix(modules/detections): rename falcon_aggregate_alerts to falcon_aggregate_detections

### DIFF
--- a/docs/modules/detections.md
+++ b/docs/modules/detections.md
@@ -13,7 +13,7 @@ Accessing and analyzing CrowdStrike Falcon detections
 
 ## Tools
 
-### `falcon_aggregate_alerts`
+### `falcon_aggregate_detections`
 
 **Required scopes:** `Alerts:read`
 

--- a/falcon_mcp/filter_hints.py
+++ b/falcon_mcp/filter_hints.py
@@ -17,7 +17,7 @@ FILTER_HINTS: dict[str, str] = {
         "Sort by timestamp.desc for latest. "
         "Ex: status:'new'+severity_name:'Critical'"
     ),
-    "falcon_aggregate_alerts": (
+    "falcon_aggregate_detections": (
         "Common fields: severity_name (Critical|High|Medium|Low|Informational), "
         "status (new|in_progress|closed|reopened), product (epp|idp|xdr|overwatch), "
         "device.hostname, tactic, technique_id, assigned_to_name, filename. "

--- a/falcon_mcp/modules/detections.py
+++ b/falcon_mcp/modules/detections.py
@@ -45,7 +45,7 @@ class DetectionsModule(BaseModule):
         self._add_tool(
             server=server,
             method=self.aggregate_detections,
-            name="aggregate_alerts",
+            name="aggregate_detections",
         )
 
         self._add_tool(

--- a/falcon_mcp/resources/detections.py
+++ b/falcon_mcp/resources/detections.py
@@ -989,9 +989,9 @@ assigned_to_name:!'*'+severity_name:!'Informational'
 # All unassigned alerts except informational (numeric approach)
 assigned_to_name:!'*'+severity:>=20
 
-=== falcon_aggregate_alerts AGGREGATION FIELDS ===
+=== falcon_aggregate_detections AGGREGATION FIELDS ===
 
-The `filter` syntax above applies unchanged to falcon_aggregate_alerts, where it narrows
+The `filter` syntax above applies unchanged to falcon_aggregate_detections, where it narrows
 which alerts are counted. The `field` parameter, which chooses what to group by, accepts a
 different and narrower set of fields than `filter` does. These fields are verified
 aggregatable:

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -203,7 +203,7 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     "falcon_get_detection_details": [
         "Get me the details for this detection",
     ],
-    "falcon_aggregate_alerts": [
+    "falcon_aggregate_detections": [
         "How many detections do we have by severity?",
         "What are the top 10 hosts by alert count this week?",
         "Show me alert volume per day for the last 30 days",

--- a/tests/modules/test_detections.py
+++ b/tests/modules/test_detections.py
@@ -22,7 +22,7 @@ class TestDetectionsModule(TestModules):
         expected_tools = [
             "falcon_search_detections",
             "falcon_get_detection_details",
-            "falcon_aggregate_alerts",
+            "falcon_aggregate_detections",
             "falcon_update_detections",
         ]
         self.assert_tools_registered(expected_tools)
@@ -586,11 +586,11 @@ class TestDetectionsModule(TestModules):
         self.assertIn("interval", result["error"])
         self.mock_client.command.assert_not_called()
 
-    def test_aggregate_alerts_is_read_only(self):
-        """falcon_aggregate_alerts must advertise itself as read-only."""
+    def test_aggregate_detections_is_read_only(self):
+        """falcon_aggregate_detections must advertise itself as read-only."""
         self.module.register_tools(self.mock_server)
         self.assert_tool_annotations(
-            "falcon_aggregate_alerts",
+            "falcon_aggregate_detections",
             ToolAnnotations(
                 readOnlyHint=True,
                 destructiveHint=False,


### PR DESCRIPTION
The aggregate tool in the detections module was registered as `falcon_aggregate_alerts`, the only one in that module not using the detections noun, sitting next to `falcon_search_detections`, `falcon_get_detection_details` and `falcon_update_detections`. This renames it to `falcon_aggregate_detections`.

The Python method was already named `aggregate_detections`, so only the registered name needed changing. The `FILTER_HINTS` key, the aggregation-fields section of the FQL guide and the generated module docs follow along.

This hasn't shipped in a release yet, so no alias is kept for the old name.

Fixes #485