### PR TITLE
feat(server): add tool-level filtering with --read-only, --tools, and --exclude-tools

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -56,11 +56,26 @@ FALCON_BASE_URL=https://api.us-2.crowdstrike.com
 # Only applies to sse and streamable-http transports
 #FALCON_MCP_API_KEY=
 
-# Enable dynamic mode: exposes 3 tools (list-modules + search + execute) instead of all module tools
+# Enable dynamic mode: exposes 3 tools (list-enabled-tools + search + execute) instead of all module tools
 # Reduces context window usage; great for large module sets or context-constrained clients
 # Options: true, false
 # Default: false
 #FALCON_MCP_DYNAMIC=false
+
+# Register only read-only tools, disabling every tool that mutates tenant state
+# Takes precedence over FALCON_MCP_TOOLS
+# Options: true, false
+# Default: false
+#FALCON_MCP_READ_ONLY=false
+
+# Allow-list of tool names to register (comma-separated, falcon_-prefixed)
+# Additive: these are added to the tools from FALCON_MCP_MODULES, and may name
+# tools from modules that are not enabled. Set alone, only these tools load.
+#FALCON_MCP_TOOLS=falcon_search_detections,falcon_search_hosts
+
+# Deny-list of tool names to withhold (comma-separated, falcon_-prefixed)
+# Overrides FALCON_MCP_TOOLS
+#FALCON_MCP_EXCLUDE_TOOLS=falcon_delete_host_groups
 
 # HTTP/HTTPS proxy URL for outbound Falcon API connections
 # Use this in enterprise or restricted network environments

--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,21 @@ FALCON_BASE_URL=https://api.us-2.crowdstrike.com
 # Default: false
 #FALCON_MCP_DYNAMIC=false
 
+# Register only read-only tools, disabling every tool that mutates tenant state
+# Takes precedence over FALCON_MCP_TOOLS
+# Options: true, false
+# Default: false
+#FALCON_MCP_READ_ONLY=false
+
+# Allow-list of tool names to register (comma-separated, falcon_-prefixed)
+# Additive: these are added to the tools from FALCON_MCP_MODULES, and may name
+# tools from modules that are not enabled. Set alone, only these tools load.
+#FALCON_MCP_TOOLS=falcon_search_detections,falcon_search_hosts
+
+# Deny-list of tool names to withhold (comma-separated, falcon_-prefixed)
+# Overrides FALCON_MCP_TOOLS
+#FALCON_MCP_EXCLUDE_TOOLS=falcon_delete_host_groups
+
 # =============================================================================
 # Optional: Proxy Configuration
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,7 @@ FALCON_BASE_URL=https://api.us-2.crowdstrike.com
 # Only applies to sse and streamable-http transports
 #FALCON_MCP_API_KEY=
 
-# Enable dynamic mode: exposes 3 tools (list-modules + search + execute) instead of all module tools
+# Enable dynamic mode: exposes 3 tools (list-enabled-tools + search + execute) instead of all module tools
 # Reduces context window usage; great for large module sets or context-constrained clients
 # Options: true, false
 # Default: false

--- a/README.md
+++ b/README.md
@@ -243,12 +243,14 @@ falcon-mcp --read-only --exclude-tools falcon_execute_rtr_read_only_command
 ```
 
 Filtering applies to dynamic mode too — a withheld tool is absent from `falcon_search_tools`
-results and rejected by `falcon_execute_tool`. The rejection says the tool exists but the server's
-configuration withholds it, and names the rule, so an agent reports a disabled tool as disabled
-rather than telling the user the capability does not exist. `falcon_list_enabled_tools` carries a
-`filters_active` field whenever a rule is in effect. The startup log reports which rules are active
-and how many tools `--read-only` and `--exclude-tools` withheld, so you can confirm what you
-deployed. Run with `--debug` to see the withheld tools by name.
+results and rejected by `falcon_execute_tool`. Because dynamic mode dispatches by name rather than
+registering tools individually, that rejection spells out that the tool exists but the server's
+configuration withholds it, and names the one rule responsible, so an agent reports a disabled tool
+as disabled instead of telling the user the capability does not exist.
+`falcon_list_enabled_tools` carries a `filters_active` field in either mode whenever a rule is in
+effect. The startup log reports which rules are active and how many tools `--read-only` and
+`--exclude-tools` withheld, so you can confirm what you deployed. Run with `--debug` to see the
+withheld tools by name.
 
 These options filter tools, not resources. A withheld tool's FQL guide resource stays available —
 guides are static field documentation carrying no tenant data.

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ See the [Docker Deployment guide](https://developer.crowdstrike.com/falcon-mcp/d
 ## Dynamic Mode
 
 Running many modules at once inflates the context window every AI client must hold. Dynamic mode
-replaces the full tool surface with three tools — `falcon_list_enabled_modules` to see which
-modules are loaded, `falcon_search_tools` to discover the right tool on demand, and
+replaces the full tool surface with three tools — `falcon_list_enabled_tools` to see every tool the
+server serves, `falcon_search_tools` to look up a tool's parameters on demand, and
 `falcon_execute_tool` to run it — so agents only load the schemas they actually need.
 
 ```bash
@@ -223,7 +223,8 @@ startup rather than being ignored, so a typo in a deny-list cannot silently leav
 - `--tools X` on its own registers **only** X — no modules are loaded by default.
 - `--modules detections --tools X` registers every `detections` tool **plus** X, even when X
   belongs to a module that is not enabled. That module contributes only X, not its whole surface,
-  and `falcon_list_enabled_modules` does not list it.
+  and `falcon_list_enabled_modules` does not list it. `falcon_list_enabled_tools` does list X — it
+  reports served tools, so it is the reliable answer to "is this capability available here?"
 
 To *subtract*, use `--exclude-tools` or `--read-only`. All four knobs compose, and they resolve in
 a fixed order:

--- a/README.md
+++ b/README.md
@@ -243,9 +243,12 @@ falcon-mcp --read-only --exclude-tools falcon_execute_rtr_read_only_command
 ```
 
 Filtering applies to dynamic mode too — a withheld tool is absent from `falcon_search_tools`
-results and rejected by `falcon_execute_tool`. The startup log reports which rules are active and
-how many tools `--read-only` and `--exclude-tools` withheld, so you can confirm what you deployed.
-Run with `--debug` to see the withheld tools by name.
+results and rejected by `falcon_execute_tool`. The rejection says the tool exists but the server's
+configuration withholds it, and names the rule, so an agent reports a disabled tool as disabled
+rather than telling the user the capability does not exist. `falcon_list_enabled_tools` carries a
+`filters_active` field whenever a rule is in effect. The startup log reports which rules are active
+and how many tools `--read-only` and `--exclude-tools` withheld, so you can confirm what you
+deployed. Run with `--debug` to see the withheld tools by name.
 
 These options filter tools, not resources. A withheld tool's FQL guide resource stays available —
 guides are static field documentation carrying no tenant data.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,68 @@ falcon-mcp --dynamic
 See the [Dynamic Mode guide](https://developer.crowdstrike.com/falcon-mcp/usage/dynamic-mode/) for
 the full discover → execute workflow and trade-offs.
 
+## Restricting What a Server Can Do
+
+`--modules` is all-or-nothing per module: enabling one to get its search tools also exposes every
+mutating tool it carries. Three tool-level options narrow that surface.
+
+```bash
+# Investigation-only server: no tool that mutates tenant state is registered
+falcon-mcp --read-only
+
+# Expose exactly two tools, nothing else
+falcon-mcp --tools falcon_search_detections,falcon_search_hosts
+
+# Keep the module, drop one tool
+falcon-mcp --modules hostgroups --exclude-tools falcon_delete_host_groups
+
+# All of detections, plus one tool from a module you did not enable
+falcon-mcp --modules detections --tools falcon_search_applications
+```
+
+| Flag | Environment Variable | Effect |
+| --- | --- | --- |
+| `--read-only` | `FALCON_MCP_READ_ONLY` | Registers only read-only tools |
+| `--tools` | `FALCON_MCP_TOOLS` | Allow-list of tool names, added to the enabled modules |
+| `--exclude-tools` | `FALCON_MCP_EXCLUDE_TOOLS` | Deny-list of tool names |
+
+Tool names are the `falcon_`-prefixed names your client displays. An unrecognized name aborts
+startup rather than being ignored, so a typo in a deny-list cannot silently leave a tool exposed.
+
+### Composing the options
+
+`--tools` is **additive**, not a narrowing filter. It grants individual tools on top of whatever
+`--modules` already enabled, reaching across the module boundary:
+
+- `--tools X` on its own registers **only** X — no modules are loaded by default.
+- `--modules detections --tools X` registers every `detections` tool **plus** X, even when X
+  belongs to a module that is not enabled. That module contributes only X, not its whole surface,
+  and `falcon_list_enabled_modules` does not list it.
+
+To *subtract*, use `--exclude-tools` or `--read-only`. All four knobs compose, and they resolve in
+a fixed order:
+
+1. `--exclude-tools` removes a tool unconditionally, even if `--tools` names it.
+2. `--read-only` removes every mutating tool unconditionally, even if `--tools` names it.
+3. `--tools` adds the tools it names, bypassing the module gate.
+4. `--modules` decides which tools are candidates by default.
+
+Because the first two rules always win, `--read-only` and `--exclude-tools` are safe to set as a
+deployment-wide floor: an additive `--tools` list cannot widen past them. Combining them is how you
+express "search everything, change nothing, and don't even offer that one tool":
+
+```bash
+falcon-mcp --read-only --exclude-tools falcon_execute_rtr_read_only_command
+```
+
+Filtering applies to dynamic mode too — a withheld tool is absent from `falcon_search_tools`
+results and rejected by `falcon_execute_tool`. The startup log reports which rules are active and
+how many tools `--read-only` and `--exclude-tools` withheld, so you can confirm what you deployed.
+Run with `--debug` to see the withheld tools by name.
+
+These options filter tools, not resources. A withheld tool's FQL guide resource stays available —
+guides are static field documentation carrying no tenant data.
+
 ## Deployment Options
 
 - [Amazon Bedrock AgentCore](https://developer.crowdstrike.com/falcon-mcp/deployment/amazon-bedrock/)

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -28,6 +28,9 @@ Configure your CrowdStrike API credentials and server settings using environment
 | `FALCON_MCP_STATELESS_HTTP` | `false` | Stateless mode for scalable deployments (required for AWS AgentCore) |
 | `FALCON_MCP_API_KEY` | — | API key for HTTP transport authentication |
 | `FALCON_MCP_DYNAMIC` | `false` | [Dynamic mode](/falcon-mcp/usage/dynamic-mode/): expose three tools instead of all module tools |
+| `FALCON_MCP_READ_ONLY` | `false` | Register only read-only tools ([tool restrictions](/falcon-mcp/usage/cli/#restricting-the-tool-surface)) |
+| `FALCON_MCP_TOOLS` | — | Comma-separated allow-list of tool names, added to the enabled modules |
+| `FALCON_MCP_EXCLUDE_TOOLS` | — | Comma-separated deny-list of tool names |
 | `FALCON_PROXY_URL` | — | HTTP/HTTPS proxy URL for outbound API connections |
 
 ## Using a .env File
@@ -64,6 +67,9 @@ FALCON_BASE_URL=https://api.crowdstrike.com
 #FALCON_MCP_STATELESS_HTTP=false
 #FALCON_MCP_API_KEY=your-api-key
 #FALCON_MCP_DYNAMIC=false
+#FALCON_MCP_READ_ONLY=false
+#FALCON_MCP_TOOLS=falcon_search_detections,falcon_search_hosts
+#FALCON_MCP_EXCLUDE_TOOLS=falcon_delete_host_groups
 #FALCON_PROXY_URL=http://proxy.corp.example.com:8080
 ```
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -82,6 +82,57 @@ falcon-mcp --help
 | `--member-cid` | `FALCON_MEMBER_CID` | — | Flight Control child CID |
 | `--proxy` | `FALCON_PROXY_URL` | — | HTTP/HTTPS proxy for outbound API connections |
 | `--dynamic` | `FALCON_MCP_DYNAMIC` | `false` | [Dynamic mode](/falcon-mcp/usage/dynamic-mode/): expose three tools instead of all module tools to reduce context usage |
+| `--read-only` | `FALCON_MCP_READ_ONLY` | `false` | Register only read-only tools, disabling every tool that mutates tenant state |
+| `--tools` | `FALCON_MCP_TOOLS` | — | Comma-separated allow-list of tool names, added to the enabled modules |
+| `--exclude-tools` | `FALCON_MCP_EXCLUDE_TOOLS` | — | Comma-separated deny-list of tool names to withhold |
+
+## Restricting the Tool Surface
+
+`--modules` gates whole modules, so enabling one to reach its search tools also exposes its
+mutating tools. The three tool-level options narrow that surface further:
+
+```bash
+# Investigation-only server
+falcon-mcp --read-only
+
+# Expose exactly two tools, nothing else
+falcon-mcp --tools falcon_search_detections,falcon_search_hosts
+
+# Keep the module, drop one tool
+falcon-mcp --modules hostgroups --exclude-tools falcon_delete_host_groups
+
+# All of detections, plus one tool from a module you did not enable
+falcon-mcp --modules detections --tools falcon_search_applications
+```
+
+Tool names are the `falcon_`-prefixed names clients display. An unrecognized name aborts startup
+instead of being ignored, so a typo in a deny-list cannot silently leave a tool exposed.
+
+`--tools` is **additive**, not a narrowing filter. It grants individual tools on top of whatever
+`--modules` already enabled, reaching across the module boundary:
+
+- `--tools X` on its own registers **only** X — no modules are loaded by default.
+- `--modules detections --tools X` registers every `detections` tool **plus** X, even when X belongs
+  to a module that is not enabled. That module contributes only X, not its whole surface, and
+  `falcon_list_enabled_modules` does not list it.
+
+To *subtract*, use `--exclude-tools` or `--read-only`. All four options compose and resolve in a
+fixed order:
+
+1. `--exclude-tools` removes a tool unconditionally, even if `--tools` names it.
+2. `--read-only` removes every mutating tool unconditionally, even if `--tools` names it.
+3. `--tools` adds the tools it names, bypassing the module gate.
+4. `--modules` decides which tools are candidates by default.
+
+Since the first two rules always win, they work as a deployment-wide floor that an additive
+`--tools` list cannot widen past. The restrictions also hold in dynamic mode: a withheld tool is
+absent from `falcon_search_tools` results and rejected by `falcon_execute_tool`. The startup log
+reports which rules are active and how many tools `--read-only` and `--exclude-tools` withheld; add
+`--debug` to see those tools by name. A tool that was simply never requested is not counted as
+withheld — only `--tools` grants and the two subtracting rules are decisions worth reporting.
+
+These options filter tools, not resources. A withheld tool's FQL guide resource stays available,
+since guides are static field documentation carrying no tenant data.
 
 ## Using as a Library
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -127,9 +127,10 @@ fixed order:
 
 Since the first two rules always win, they work as a deployment-wide floor that an additive
 `--tools` list cannot widen past. The restrictions also hold in dynamic mode: a withheld tool is
-absent from `falcon_search_tools` results and rejected by `falcon_execute_tool`. That rejection
-names the rule and says the tool exists but is withheld by configuration, so an agent does not
-report a disabled tool as a capability the product lacks; `falcon_list_enabled_tools` also carries a
+absent from `falcon_search_tools` results and rejected by `falcon_execute_tool`. Since dynamic mode
+dispatches by name, that rejection says the tool exists but is withheld by configuration and names
+the one rule responsible, so an agent does not report a disabled tool as a capability the product
+lacks. In either mode `falcon_list_enabled_tools` carries a
 `filters_active` field while any rule is in effect. The startup log
 reports which rules are active and how many tools `--read-only` and `--exclude-tools` withheld; add
 `--debug` to see those tools by name. A tool that was simply never requested is not counted as

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -81,7 +81,7 @@ falcon-mcp --help
 | `--stateless-http` | `FALCON_MCP_STATELESS_HTTP` | `false` | Stateless mode for scalable deployments |
 | `--member-cid` | `FALCON_MEMBER_CID` | — | Flight Control child CID |
 | `--proxy` | `FALCON_PROXY_URL` | — | HTTP/HTTPS proxy for outbound API connections |
-| `--dynamic` | `FALCON_MCP_DYNAMIC` | `false` | [Dynamic mode](/falcon-mcp/usage/dynamic-mode/): expose three tools instead of all module tools to reduce context usage |
+| `--dynamic` | `FALCON_MCP_DYNAMIC` | `false` | [Dynamic mode](/falcon-mcp/usage/dynamic-mode/): expose three meta-tools (list-enabled-tools, search, execute) instead of all module tools to reduce context usage |
 | `--read-only` | `FALCON_MCP_READ_ONLY` | `false` | Register only read-only tools, disabling every tool that mutates tenant state |
 | `--tools` | `FALCON_MCP_TOOLS` | — | Comma-separated allow-list of tool names, added to the enabled modules |
 | `--exclude-tools` | `FALCON_MCP_EXCLUDE_TOOLS` | — | Comma-separated deny-list of tool names to withhold |
@@ -114,7 +114,8 @@ instead of being ignored, so a typo in a deny-list cannot silently leave a tool 
 - `--tools X` on its own registers **only** X — no modules are loaded by default.
 - `--modules detections --tools X` registers every `detections` tool **plus** X, even when X belongs
   to a module that is not enabled. That module contributes only X, not its whole surface, and
-  `falcon_list_enabled_modules` does not list it.
+  `falcon_list_enabled_modules` does not list it. `falcon_list_enabled_tools` does list X — it
+  reports served tools, so it is the reliable answer to "is this capability available here?"
 
 To *subtract*, use `--exclude-tools` or `--read-only`. All four options compose and resolve in a
 fixed order:

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -127,7 +127,10 @@ fixed order:
 
 Since the first two rules always win, they work as a deployment-wide floor that an additive
 `--tools` list cannot widen past. The restrictions also hold in dynamic mode: a withheld tool is
-absent from `falcon_search_tools` results and rejected by `falcon_execute_tool`. The startup log
+absent from `falcon_search_tools` results and rejected by `falcon_execute_tool`. That rejection
+names the rule and says the tool exists but is withheld by configuration, so an agent does not
+report a disabled tool as a capability the product lacks; `falcon_list_enabled_tools` also carries a
+`filters_active` field while any rule is in effect. The startup log
 reports which rules are active and how many tools `--read-only` and `--exclude-tools` withheld; add
 `--debug` to see those tools by name. A tool that was simply never requested is not counted as
 withheld — only `--tools` grants and the two subtracting rules are decisions worth reporting.

--- a/docs/usage/dynamic-mode.md
+++ b/docs/usage/dynamic-mode.md
@@ -11,8 +11,7 @@ Dynamic mode solves this by replacing the full tool surface with two meta-tools:
 `falcon_search_tools` to look up a tool's parameter schema and `falcon_execute_tool` to run it. The
 agent fetches the schema for exactly the tools it needs, paying a short discovery round-trip instead
 of a large up-front context cost. A third always-on tool, `falcon_list_enabled_tools`, returns the
-complete inventory of served tool names cheaply — every name costs a few kilobytes, against roughly
-ten times that for a 20-result schema search.
+complete inventory of served tool names.
 
 > [!NOTE]
 > Dynamic mode is in public preview. The feature flag and behavior are stable, but feedback is
@@ -50,7 +49,7 @@ core tool, instead of the full module surface:
 | Tool | Purpose |
 |------|---------|
 | `falcon_list_enabled_tools` | List every capability tool this server serves (meta-tools excluded) |
-| `falcon_search_tools` | Look up full parameter schemas for tools matching a keyword or module |
+| `falcon_search_tools` | Look up the parameters of tools matching a keyword or module |
 | `falcon_execute_tool` | Execute a discovered tool by name with the given parameters |
 
 The typical agent workflow is:
@@ -58,13 +57,9 @@ The typical agent workflow is:
 1. Call `falcon_list_enabled_tools` when you need to know what the server serves at all — a name
    absent from that list is not available, whether because its module is off or a tool filter
    withholds it.
-2. Call `falcon_search_tools` with a keyword or module name to get the parameter schemas for the
-   tools you intend to use.
+2. Call `falcon_search_tools` with a keyword or module name to get the parameters of the tools you
+   intend to use, along with their `read_only` and `destructive` flags.
 3. Call `falcon_execute_tool` with the tool name and parameters to run it.
-
-`falcon_list_enabled_modules` is not registered in dynamic mode: module information stays reachable
-through `falcon_search_tools`, which carries a `module` field on every result and accepts a `module`
-filter. It remains available in normal mode.
 
 Because `falcon_execute_tool` is a general dispatcher, it carries no read-only safety annotation by
 default — the agent must rely on the `read_only` and `destructive` fields returned by
@@ -126,8 +121,28 @@ Every response carries `total` (the number of tools matching the query, before a
 `truncated`, so a capped result set is never mistaken for the complete set. When results are
 truncated, raise `limit` (up to 500) or narrow the query.
 
-If no tools match, the response says so and points at `falcon_list_enabled_tools`. A capability with
-no matching tool is not served by that server — report that rather than searching again.
+If no tools match, the response says so and points at `falcon_list_enabled_tools`. A capability that
+is absent from that full inventory is not served by that server — report that rather than searching
+again.
+
+## Tool Filtering in Dynamic Mode
+
+`--read-only`, `--tools`, and `--exclude-tools` apply here as they do in normal mode: a withheld
+tool is absent from `falcon_search_tools` and cannot be run through `falcon_execute_tool`. Omitting
+it from the catalog is the enforcement, so the executor is not a bypass.
+
+Because a withheld tool is missing rather than flagged, its absence would otherwise be
+indistinguishable from a tool that never existed — leading an agent to tell the user the capability
+does not exist when the operator simply disabled it. Two things prevent that:
+
+- `falcon_execute_tool` on a withheld name reports that the tool exists but the server's
+  configuration withholds it, and names the rule. A name that was never served still returns the
+  plain unknown-tool error, so the two cases stay distinguishable.
+- `falcon_list_enabled_tools` carries a `filters_active` field describing the rules in effect. The
+  field is absent when no filter is configured.
+
+A tool from a module that was never enabled is not a filtered tool — it reports as unknown, since
+no rule withheld it.
 
 ## When to Use Dynamic Mode
 

--- a/docs/usage/dynamic-mode.md
+++ b/docs/usage/dynamic-mode.md
@@ -133,11 +133,16 @@ it from the catalog is the enforcement, so the executor is not a bypass.
 
 Because a withheld tool is missing rather than flagged, its absence would otherwise be
 indistinguishable from a tool that never existed — leading an agent to tell the user the capability
-does not exist when the operator simply disabled it. Two things prevent that:
+does not exist when the operator simply disabled it. This matters here in particular: dynamic mode
+dispatches by name, so an agent can name a withheld tool, whereas in normal mode the tool is not in
+`tools/list` at all. Two things prevent the misreport:
 
 - `falcon_execute_tool` on a withheld name reports that the tool exists but the server's
-  configuration withholds it, and names the rule. A name that was never served still returns the
-  plain unknown-tool error, so the two cases stay distinguishable.
+  configuration withholds it, naming the single rule responsible — `read-only` or `deny-list`, not
+  every rule the server has enabled — so an operator debugging their config is pointed at the right
+  flag. A name that was never served still returns the plain unknown-tool error, so the two cases
+  stay distinguishable. The message warns against reproducing the withheld effect through another
+  tool, not against using other tools at all.
 - `falcon_list_enabled_tools` carries a `filters_active` field describing the rules in effect. The
   field is absent when no filter is configured.
 

--- a/docs/usage/dynamic-mode.md
+++ b/docs/usage/dynamic-mode.md
@@ -1,5 +1,5 @@
 <!-- meta:title Dynamic Mode -->
-<!-- meta:description Reduce context usage by exposing two meta-tools instead of all module tools. -->
+<!-- meta:description Reduce context usage by exposing three meta-tools instead of all module tools. -->
 <!-- meta:section usage -->
 <!-- meta:link-base /falcon-mcp/ -->
 
@@ -8,10 +8,11 @@ set grows, this balloons the context window that AI clients must hold in every c
 for tools that will never be called in that session.
 
 Dynamic mode solves this by replacing the full tool surface with two meta-tools:
-`falcon_search_tools` to discover tools on demand and `falcon_execute_tool` to run them. The agent
-fetches the schema for exactly the tools it needs, paying a short discovery round-trip instead of a
-large up-front context cost. A third always-on tool, `falcon_list_enabled_modules`, remains
-available to help orient the agent before it starts searching.
+`falcon_search_tools` to look up a tool's parameter schema and `falcon_execute_tool` to run it. The
+agent fetches the schema for exactly the tools it needs, paying a short discovery round-trip instead
+of a large up-front context cost. A third always-on tool, `falcon_list_enabled_tools`, returns the
+complete inventory of served tool names cheaply — every name costs a few kilobytes, against roughly
+ten times that for a 20-result schema search.
 
 > [!NOTE]
 > Dynamic mode is in public preview. The feature flag and behavior are stable, but feedback is
@@ -43,20 +44,27 @@ are loaded into the catalog and `--transport` to choose the server transport.
 
 ## How It Works
 
-With dynamic mode enabled, the server exposes two meta-tools plus the `falcon_list_enabled_modules`
+With dynamic mode enabled, the server exposes two meta-tools plus the `falcon_list_enabled_tools`
 core tool, instead of the full module surface:
 
 | Tool | Purpose |
 |------|---------|
-| `falcon_search_tools` | Discover tools by keyword, module name, or parameter name |
+| `falcon_list_enabled_tools` | List every capability tool this server serves (meta-tools excluded) |
+| `falcon_search_tools` | Look up full parameter schemas for tools matching a keyword or module |
 | `falcon_execute_tool` | Execute a discovered tool by name with the given parameters |
-| `falcon_list_enabled_modules` | List which modules are loaded in the current server |
 
 The typical agent workflow is:
 
-1. Call `falcon_search_tools` with a keyword or module name to find relevant tools and their
-   parameter schemas.
-2. Call `falcon_execute_tool` with the tool name and parameters to run it.
+1. Call `falcon_list_enabled_tools` when you need to know what the server serves at all — a name
+   absent from that list is not available, whether because its module is off or a tool filter
+   withholds it.
+2. Call `falcon_search_tools` with a keyword or module name to get the parameter schemas for the
+   tools you intend to use.
+3. Call `falcon_execute_tool` with the tool name and parameters to run it.
+
+`falcon_list_enabled_modules` is not registered in dynamic mode: module information stays reachable
+through `falcon_search_tools`, which carries a `module` field on every result and accepts a `module`
+filter. It remains available in normal mode.
 
 Because `falcon_execute_tool` is a general dispatcher, it carries no read-only safety annotation by
 default — the agent must rely on the `read_only` and `destructive` fields returned by
@@ -77,7 +85,8 @@ default — the agent must rely on the `read_only` and `destructive` fields retu
 ```
 
 The response includes the tool name, a description, and its full parameter schema with FQL field
-hints already inlined for filter parameters.
+hints already inlined for filter parameters, wrapped in a `results` list alongside `total` and
+`truncated`.
 
 **Step 2 — Execute it:**
 
@@ -113,7 +122,12 @@ avoid large responses.
 { "query": "quarantine release" }
 ```
 
-If no tools match, the response lists available module names so the agent can narrow its query.
+Every response carries `total` (the number of tools matching the query, before any limit) and
+`truncated`, so a capped result set is never mistaken for the complete set. When results are
+truncated, raise `limit` (up to 500) or narrow the query.
+
+If no tools match, the response says so and points at `falcon_list_enabled_tools`. A capability with
+no matching tool is not served by that server — report that rather than searching again.
 
 ## When to Use Dynamic Mode
 

--- a/falcon_mcp/dynamic.py
+++ b/falcon_mcp/dynamic.py
@@ -97,6 +97,10 @@ class DynamicToolCatalog:
     def get(self, tool_name: str) -> ToolEntry | None:
         return self._entries.get(tool_name)
 
+    def describe_policy(self) -> str:
+        """Name the filtering rules in effect, for error messages that cite the cause."""
+        return self._policy.describe()
+
     def search(
         self,
         query: str = "",
@@ -188,11 +192,7 @@ class DynamicToolCatalog:
 
 
 class DynamicMode:
-    """Registers the 2 discovery meta-tools (falcon_search_tools + falcon_execute_tool).
-
-    falcon_list_enabled_tools is registered separately by the server, giving dynamic
-    mode 3 tools total in the client-visible surface.
-    """
+    """Registers the 2 discovery meta-tools (falcon_search_tools + falcon_execute_tool)."""
 
     def __init__(
         self,
@@ -225,35 +225,54 @@ class DynamicMode:
         ),
         module: str | None = Field(
             default=None,
-            description="Filter results to a specific module (e.g., 'hosts', 'detections').",
+            description=(
+                "Restrict results to one module (e.g., 'hosts', 'detections'). Pass it "
+                "with no query to browse everything that module serves."
+            ),
         ),
         limit: int = Field(
             default=20,
             ge=1,
             le=500,
-            description="Maximum number of results to return (default: 20).",
+            description="Maximum number of results to return (default: 20, max: 500).",
         ),
     ) -> dict[str, Any]:
-        """Look up full parameter schemas for tools matching a keyword.
+        """Get a Falcon tool's parameters so you can call it with falcon_execute_tool.
 
-        Call falcon_list_enabled_tools first when you need the complete inventory of
-        what this server serves; use this to get a tool's parameters before calling
-        falcon_execute_tool. Returns matching tools with full schemas, plus total and
-        truncated so you can tell when results were capped.
+        This is the entry point in dynamic mode: search by keyword, or pass a module
+        name (or no query at all) to browse. Each result carries the tool's name,
+        module, description, a summary of every parameter (type, required, description,
+        examples, and filter-syntax hints where the tool takes a filter), and
+        read_only/destructive flags — check those before executing anything that
+        mutates. Read total and truncated to tell a capped list from a complete one.
         """
         results = self.catalog.search(query=query, module=module, limit=limit)
         total = self.catalog.count_matches(query=query, module=module)
         truncated = total > len(results)
 
         if not results:
+            # Under an active policy, "not served" is a config choice the user can
+            # change, not a missing capability — the two need different advice.
+            if self.catalog.resolution.withheld_by_rule:
+                hint = (
+                    f"No tool matching '{query}' is served by this server, which is "
+                    f"running with a tool filter ({self.catalog.describe_policy()}). "
+                    "Call falcon_list_enabled_tools for what it does serve. The "
+                    "capability may exist but be withheld by configuration — tell the "
+                    "user that rather than trying more searches."
+                )
+            else:
+                hint = (
+                    f"No tool matching '{query}' is served by this server. Call "
+                    "falcon_list_enabled_tools for the full inventory. If the capability "
+                    "you need is genuinely absent, it was not enabled on this server — "
+                    "tell the user rather than trying more searches."
+                )
             return {
                 "results": [],
                 "total": 0,
                 "truncated": False,
-                "hint": f"No tool matching '{query}' is served by this server. Call "
-                "falcon_list_enabled_tools for the full inventory. If the capability "
-                "you need is genuinely absent, it was not enabled on this server — "
-                "tell the user rather than trying more searches.",
+                "hint": hint,
             }
 
         envelope: dict[str, Any] = {
@@ -289,6 +308,17 @@ class DynamicMode:
         """
         entry = self.catalog.get(tool_name)
         if not entry:
+            # A tool the policy withheld is absent from the catalog exactly like one
+            # that never existed. Say which it is, or the model reports an operator
+            # config choice to the user as a missing product capability.
+            if tool_name in self.catalog.resolution.withheld_by_rule:
+                return {
+                    "error": f"'{tool_name}' exists on this server but its configuration "
+                    f"withholds it ({self.catalog.describe_policy()}). The capability is "
+                    "not missing — tell the user it is disabled by server configuration, "
+                    "and do not look for another tool to do it.",
+                    "tool": tool_name,
+                }
             return {
                 "error": f"Unknown tool: '{tool_name}'. Use falcon_search_tools to discover valid names."
             }

--- a/falcon_mcp/dynamic.py
+++ b/falcon_mcp/dynamic.py
@@ -97,8 +97,12 @@ class DynamicToolCatalog:
     def get(self, tool_name: str) -> ToolEntry | None:
         return self._entries.get(tool_name)
 
+    def withholding_rule(self, tool_name: str) -> str | None:
+        """Name the rule that withholds this tool, or None if no rule did."""
+        return self.resolution.reasons.get(tool_name)
+
     def describe_policy(self) -> str:
-        """Name the filtering rules in effect, for error messages that cite the cause."""
+        """Summarize every filtering rule the server has enabled."""
         return self._policy.describe()
 
     def search(
@@ -251,8 +255,6 @@ class DynamicMode:
         truncated = total > len(results)
 
         if not results:
-            # Under an active policy, "not served" is a config choice the user can
-            # change, not a missing capability — the two need different advice.
             if self.catalog.resolution.withheld_by_rule:
                 hint = (
                     f"No tool matching '{query}' is served by this server, which is "
@@ -311,12 +313,14 @@ class DynamicMode:
             # A tool the policy withheld is absent from the catalog exactly like one
             # that never existed. Say which it is, or the model reports an operator
             # config choice to the user as a missing product capability.
-            if tool_name in self.catalog.resolution.withheld_by_rule:
+            rule = self.catalog.withholding_rule(tool_name)
+            if rule is not None:
                 return {
                     "error": f"'{tool_name}' exists on this server but its configuration "
-                    f"withholds it ({self.catalog.describe_policy()}). The capability is "
-                    "not missing — tell the user it is disabled by server configuration, "
-                    "and do not look for another tool to do it.",
+                    f"withholds it ({rule}). The capability is not missing — tell the user "
+                    "it is disabled by this server's configuration. Do not try to achieve "
+                    "the same effect through a different tool, though other tools remain "
+                    "available for other work.",
                     "tool": tool_name,
                 }
             return {

--- a/falcon_mcp/dynamic.py
+++ b/falcon_mcp/dynamic.py
@@ -1,7 +1,7 @@
 """
 Dynamic mode for Falcon MCP Server.
 
-Wraps the full tool surface behind 3 tools (falcon_list_enabled_modules +
+Wraps the full tool surface behind 3 tools (falcon_list_enabled_tools +
 falcon_search_tools + falcon_execute_tool) to reduce context window consumption
 while keeping all functionality accessible on-demand.
 """
@@ -103,6 +103,17 @@ class DynamicToolCatalog:
         module: str | None = None,
         limit: int = 20,
     ) -> list[dict[str, Any]]:
+        return [self._format_entry(e) for e in self._matches(query, module)[:limit]]
+
+    def count_matches(self, query: str = "", module: str | None = None) -> int:
+        """Count every matching entry, ignoring the result limit.
+
+        Shares _matches with search() so the reported total cannot drift from the
+        results returned.
+        """
+        return len(self._matches(query, module))
+
+    def _matches(self, query: str, module: str | None) -> list[ToolEntry]:
         candidates: list[ToolEntry] = list(self._entries.values())
 
         if module:
@@ -114,7 +125,7 @@ class DynamicToolCatalog:
                 e for e in candidates if all(t in e.search_corpus for t in tokens)
             ]
 
-        return [self._format_entry(e) for e in candidates[:limit]]
+        return candidates
 
     def _format_entry(self, entry: ToolEntry) -> dict[str, Any]:
         params_summary = {}
@@ -179,8 +190,8 @@ class DynamicToolCatalog:
 class DynamicMode:
     """Registers the 2 discovery meta-tools (falcon_search_tools + falcon_execute_tool).
 
-    falcon_list_enabled_modules is registered separately by the server, giving
-    dynamic mode 3 tools total in the client-visible surface.
+    falcon_list_enabled_tools is registered separately by the server, giving dynamic
+    mode 3 tools total in the client-visible surface.
     """
 
     def __init__(
@@ -219,25 +230,43 @@ class DynamicMode:
         limit: int = Field(
             default=20,
             ge=1,
-            le=100,
+            le=500,
             description="Maximum number of results to return (default: 20).",
         ),
-    ) -> list[dict[str, Any]] | dict[str, Any]:
-        """Discover available Falcon tools by keyword search.
+    ) -> dict[str, Any]:
+        """Look up full parameter schemas for tools matching a keyword.
 
-        Use this to find tools by name, description, module, or parameter keywords.
-        Returns tool schemas with parameter details so you can call falcon_execute_tool.
-        Consult this before executing any tool to understand its parameters.
+        Call falcon_list_enabled_tools first when you need the complete inventory of
+        what this server serves; use this to get a tool's parameters before calling
+        falcon_execute_tool. Returns matching tools with full schemas, plus total and
+        truncated so you can tell when results were capped.
         """
         results = self.catalog.search(query=query, module=module, limit=limit)
+        total = self.catalog.count_matches(query=query, module=module)
+        truncated = total > len(results)
+
         if not results:
-            available_modules = sorted({e.module for e in self.catalog.entries.values()})
             return {
                 "results": [],
-                "hint": f"No tools found matching your query. Available modules: {', '.join(available_modules)}. "
-                "Try a broader search or check falcon_list_enabled_modules.",
+                "total": 0,
+                "truncated": False,
+                "hint": f"No tool matching '{query}' is served by this server. Call "
+                "falcon_list_enabled_tools for the full inventory. If the capability "
+                "you need is genuinely absent, it was not enabled on this server — "
+                "tell the user rather than trying more searches.",
             }
-        return results
+
+        envelope: dict[str, Any] = {
+            "results": results,
+            "total": total,
+            "truncated": truncated,
+        }
+        if truncated:
+            envelope["hint"] = (
+                f"Showing {len(results)} of {total}. Call falcon_list_enabled_tools "
+                "for all names, or narrow with query."
+            )
+        return envelope
 
     async def _execute_tool(
         self,

--- a/falcon_mcp/dynamic.py
+++ b/falcon_mcp/dynamic.py
@@ -17,6 +17,7 @@ from falcon_mcp.common.fql import FQL_FILTER_HINT_SUFFIX
 from falcon_mcp.common.logging import get_logger
 from falcon_mcp.filter_hints import FILTER_HINTS, QUERY_STRING_HINTS
 from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS, BaseModule
+from falcon_mcp.tool_filter import Resolution, ToolPolicy, ToolRecord
 
 logger = get_logger(__name__)
 
@@ -39,8 +40,14 @@ class ToolEntry:
 class DynamicToolCatalog:
     """Builds a searchable catalog of tools from modules via a scratch FastMCP instance."""
 
-    def __init__(self, modules: dict[str, BaseModule]) -> None:
+    def __init__(
+        self, modules: dict[str, BaseModule], policy: ToolPolicy | None = None
+    ) -> None:
         self._entries: dict[str, ToolEntry] = {}
+        self._policy = policy or ToolPolicy()
+        self.resolution = Resolution(
+            keep=frozenset(), removed=frozenset(), withheld_by_rule=frozenset()
+        )
         self._build(modules)
 
     def _build(self, modules: dict[str, BaseModule]) -> None:
@@ -56,7 +63,25 @@ class DynamicToolCatalog:
             for tool_name in module.tools:
                 module_tool_names[tool_name] = module_name
 
+        self.resolution = self._policy.resolve(
+            {
+                tool_name: ToolRecord(
+                    module=module_tool_names.get(tool_name, "unknown"),
+                    annotations=tool_obj.annotations,
+                )
+                for tool_name, tool_obj in all_tools.items()
+            }
+        )
+
         for tool_name, tool_obj in all_tools.items():
+            # Omitting a withheld tool here is the whole enforcement: it is then
+            # absent from falcon_search_tools and 404s in falcon_execute_tool, so the
+            # executor is not a bypass.
+            if tool_name in self.resolution.removed:
+                # Named here because this path never calls server.remove_tool, so
+                # --debug would otherwise report a count with no names behind it.
+                logger.debug("Withheld tool: %s", tool_name)
+                continue
             module_name = module_tool_names.get(tool_name, "unknown")
             self._entries[tool_name] = ToolEntry(tool=tool_obj, module=module_name)
 
@@ -158,9 +183,14 @@ class DynamicMode:
     dynamic mode 3 tools total in the client-visible surface.
     """
 
-    def __init__(self, modules: dict[str, BaseModule], server: FastMCP) -> None:
+    def __init__(
+        self,
+        modules: dict[str, BaseModule],
+        server: FastMCP,
+        policy: ToolPolicy | None = None,
+    ) -> None:
         self.server = server
-        self.catalog = DynamicToolCatalog(modules)
+        self.catalog = DynamicToolCatalog(modules, policy)
 
     def register(self) -> None:
         self.server.add_tool(

--- a/falcon_mcp/dynamic.py
+++ b/falcon_mcp/dynamic.py
@@ -221,6 +221,14 @@ class DynamicMode:
             structured_output=False,
         )
 
+    def _entries_remain(self) -> bool:
+        """True if the catalog still serves at least one capability tool.
+
+        Filtering can withhold every tool (``--tools <mutator> --read-only``), which
+        changes what is honest to tell a model about looking elsewhere.
+        """
+        return bool(self.catalog.entries)
+
     async def _search_tools(
         self,
         query: str = Field(
@@ -255,9 +263,18 @@ class DynamicMode:
         truncated = total > len(results)
 
         if not results:
-            if self.catalog.resolution.withheld_by_rule:
+            # Quoting an empty query back reads as a failed lookup for "".
+            subject = f"No tool matching '{query}' is" if query else "No tool is"
+            if not self._entries_remain():
                 hint = (
-                    f"No tool matching '{query}' is served by this server, which is "
+                    "This server serves no capability tools: its configuration "
+                    f"({self.catalog.describe_policy()}) withholds all of them. Tell the "
+                    "user the server is configured with no tools available rather than "
+                    "searching again."
+                )
+            elif self.catalog.resolution.withheld_by_rule:
+                hint = (
+                    f"{subject} served by this server, which is "
                     f"running with a tool filter ({self.catalog.describe_policy()}). "
                     "Call falcon_list_enabled_tools for what it does serve. The "
                     "capability may exist but be withheld by configuration — tell the "
@@ -265,7 +282,7 @@ class DynamicMode:
                 )
             else:
                 hint = (
-                    f"No tool matching '{query}' is served by this server. Call "
+                    f"{subject} served by this server. Call "
                     "falcon_list_enabled_tools for the full inventory. If the capability "
                     "you need is genuinely absent, it was not enabled on this server — "
                     "tell the user rather than trying more searches."
@@ -315,12 +332,18 @@ class DynamicMode:
             # config choice to the user as a missing product capability.
             rule = self.catalog.withholding_rule(tool_name)
             if rule is not None:
+                # Promising other tools on an empty surface sends the model hunting.
+                remainder = (
+                    "Do not try to achieve the same effect through a different tool, "
+                    "though other tools remain available for other work."
+                    if self._entries_remain()
+                    else "This server currently serves no capability tools at all, so "
+                    "do not look for an alternative."
+                )
                 return {
                     "error": f"'{tool_name}' exists on this server but its configuration "
                     f"withholds it ({rule}). The capability is not missing — tell the user "
-                    "it is disabled by this server's configuration. Do not try to achieve "
-                    "the same effect through a different tool, though other tools remain "
-                    "available for other work.",
+                    f"it is disabled by this server's configuration. {remainder}",
                     "tool": tool_name,
                 }
             return {

--- a/falcon_mcp/registry.py
+++ b/falcon_mcp/registry.py
@@ -64,3 +64,31 @@ def get_module_names() -> list[str]:
         List of module names
     """
     return list(get_available_modules().keys())
+
+
+def get_tool_module_map() -> dict[str, str]:
+    """Resolve which module to load for a given tool name, before any module loads.
+
+    Serves the two startup decisions that must happen before a client exists:
+    rejecting allow/deny-list names that match no tool, and pulling in the modules
+    that own the names an operator allow-listed. Not a filtering input — which of a
+    loaded module's tools survive is decided after registration, from the tools the
+    server actually holds.
+
+    Registration only wires bound methods onto a throwaway server, so this makes no
+    Falcon API calls and needs no authenticated client.
+
+    Returns:
+        Dict mapping prefixed tool names to module names
+    """
+    # Imported here to keep registry out of the modules -> BaseModule -> client cycle.
+    from mcp.server.fastmcp import FastMCP
+
+    scratch = FastMCP("tool-name-probe")
+    mapping: dict[str, str] = {}
+    for module_name, module_class in get_available_modules().items():
+        module = module_class(None)  # type: ignore[arg-type]
+        module.register_tools(scratch)
+        for tool_name in module.tools:
+            mapping[tool_name] = module_name
+    return mapping

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -410,17 +410,13 @@ def parse_modules_list(modules_string: str) -> list[str]:
         modules_string: Comma-separated string of module names
 
     Returns:
-        List of validated module names (returns all available modules if empty string)
+        List of validated module names, empty if the string is empty
 
     Raises:
         argparse.ArgumentTypeError: If any module names are invalid
     """
     # Get available modules
     available_modules = registry.get_module_names()
-
-    # If empty string, return all available modules (default behavior)
-    if not modules_string:
-        return available_modules
 
     # Split by comma and clean up whitespace
     modules = [m.strip() for m in modules_string.split(",") if m.strip()]

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -24,6 +24,7 @@ from falcon_mcp.common.auth import (
 )
 from falcon_mcp.common.logging import configure_logging, get_logger
 from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS, offload_to_thread
+from falcon_mcp.tool_filter import Resolution, ToolPolicy, ToolRecord
 
 logger = get_logger(__name__)
 
@@ -53,6 +54,9 @@ class FalconMCPServer:
         member_cid: str | None = None,
         proxy: str | None = None,
         dynamic: bool = False,
+        read_only: bool = False,
+        allowed_tools: set[str] | None = None,
+        excluded_tools: set[str] | None = None,
     ):
         """Initialize the Falcon MCP server.
 
@@ -69,6 +73,13 @@ class FalconMCPServer:
             port: Port to listen on for HTTP transports (default: 8000)
             member_cid: Child CID for Flight Control (MSSP) support (defaults to FALCON_MEMBER_CID env var)
             proxy: HTTP/HTTPS proxy URL for outbound Falcon API connections (defaults to FALCON_PROXY_URL env var)
+            dynamic: Enable dynamic mode (discovery meta-tools instead of the full surface)
+            read_only: Register only read-only tools, overriding allowed_tools
+            allowed_tools: Additive allow-list of prefixed tool names.
+            excluded_tools: Deny-list of prefixed tool names; wins over allowed_tools
+
+        Raises:
+            ValueError: If allowed_tools or excluded_tools name unknown tools
         """
         # Store configuration
         self.base_url = base_url
@@ -80,7 +91,38 @@ class FalconMCPServer:
         self.port = port
         self.dynamic = dynamic
 
-        self.enabled_modules = enabled_modules or set(registry.get_module_names())
+        allowed_tools = allowed_tools or set()
+        excluded_tools = excluded_tools or set()
+
+        tool_module_map = (
+            registry.get_tool_module_map() if (allowed_tools or excluded_tools) else {}
+        )
+        self._validate_filter_tool_names(allowed_tools, excluded_tools, tool_module_map)
+
+        # Resolve which modules to load. The allow-list is additive: it pulls in the
+        # modules owning the tools it names, gated so they contribute only those
+        # tools.
+        if enabled_modules:
+            self.enabled_modules = set(enabled_modules)
+        elif allowed_tools:
+            # --tools alone supplies the whole surface, so start from no modules.
+            self.enabled_modules = set()
+        else:
+            self.enabled_modules = set(registry.get_module_names())
+
+        allow_list_modules = {
+            tool_module_map[name] for name in allowed_tools if name in tool_module_map
+        }
+        # Modules pulled in solely for the allow-list get loaded but not reported as
+        # enabled: they contribute only their named tools.
+        self.loaded_modules = self.enabled_modules | allow_list_modules
+
+        self.tool_policy = ToolPolicy(
+            read_only=read_only,
+            allowed=allowed_tools,
+            excluded=excluded_tools,
+            enabled_modules=self.enabled_modules,
+        )
 
         # Configure logging
         configure_logging(debug=self.debug)
@@ -120,7 +162,7 @@ class FalconMCPServer:
         # Initialize and register modules
         self.modules = {}
         available_modules = registry.get_available_modules()
-        for module_name in self.enabled_modules:
+        for module_name in self.loaded_modules:
             if module_name in available_modules:
                 module_class = available_modules[module_name]
                 self.modules[module_name] = module_class(self.falcon_client)
@@ -134,7 +176,7 @@ class FalconMCPServer:
         resource_word = "resource" if resource_count == 1 else "resources"
 
         # Count modules and tools with proper grammar
-        module_count = len(self.modules)
+        module_count = len(self.enabled_modules & set(self.modules))
         module_word = "module" if module_count == 1 else "modules"
 
         logger.info(
@@ -149,14 +191,61 @@ class FalconMCPServer:
             " (dynamic mode)" if self.dynamic else "",
         )
 
+        if self.tool_policy.active:
+            # Counts only what the operator asked to remove. Run with --debug to
+            # see the names.
+            withheld = len(self._resolution.withheld_by_rule)
+            logger.info(
+                "Tool policy active (%s) — %d %s withheld",
+                self.tool_policy.describe(),
+                withheld,
+                "tool" if withheld == 1 else "tools",
+            )
+
+    def _validate_filter_tool_names(
+        self,
+        allowed: set[str],
+        excluded: set[str],
+        tool_module_map: dict[str, str],
+    ) -> None:
+        """Reject allow/deny-list entries that name no known tool.
+
+        Runs before authentication so a typo costs no Falcon round-trip. Matters most
+        for the deny-list, where an ignored name would leave a tool exposed.
+
+        Args:
+            allowed: Allow-list names supplied by the operator.
+            excluded: Deny-list names supplied by the operator.
+            tool_module_map: Every known tool name mapped to its module.
+
+        Raises:
+            ValueError: If any named tool is unrecognized.
+        """
+        named = allowed | excluded
+        if not named:
+            return
+
+        unknown = sorted(named - set(tool_module_map))
+        if unknown:
+            raise ValueError(
+                f"Unrecognized tool names: {', '.join(unknown)}. "
+                "Names must be the falcon_-prefixed names clients see "
+                "(e.g. falcon_search_hosts)."
+            )
+
     def _register_tools(self) -> int:
-        """Register tools from all modules.
+        """Register tools from all modules, then subtract the ones policy withholds.
+
+        Registration runs first so the policy resolves against the tools the server
+        actually holds — module ownership and annotations are then facts, not
+        something to predict ahead of time.
 
         Returns:
-            int: Number of tools registered
+            int: Number of tools left registered
         """
         # falcon_list_enabled_modules is always registered — dynamic mode's no-results
-        # hint references it by name, and it's useful in both modes.
+        # hint references it by name, and it's useful in both modes. Meta-tools are
+        # exempt from the policy: withholding them leaves dynamic mode undiscoverable.
         self.server.add_tool(
             offload_to_thread(self.list_enabled_modules),
             name="falcon_list_enabled_modules",
@@ -167,12 +256,13 @@ class FalconMCPServer:
         if self.dynamic:
             # Dynamic mode: expose only the discovery/execution meta-tools plus
             # falcon_list_enabled_modules above (3 tools total) so the context window
-            # stays minimal.
+            # stays minimal. The catalog applies the policy while building, so a
+            # withheld tool is absent from search and 404s in the executor.
             from falcon_mcp.dynamic import DynamicMode
 
-            dynamic_mode = DynamicMode(self.modules, self.server)
+            dynamic_mode = DynamicMode(self.modules, self.server, self.tool_policy)
             dynamic_mode.register()
-            tool_count = 3  # falcon_list_enabled_modules + falcon_search_tools + falcon_execute_tool
+            self._resolution = dynamic_mode.catalog.resolution
         else:
             # Normal mode: register all three core tools and then each module's tools.
             self.server.add_tool(
@@ -192,9 +282,40 @@ class FalconMCPServer:
             for module in self.modules.values():
                 module.register_tools(self.server)
 
-            tool_count = 3 + sum(len(getattr(m, "tools", [])) for m in self.modules.values())
+            self._resolution = self._apply_policy()
 
-        return tool_count
+        # Count what the tool manager holds; arithmetic would overcount when the
+        # policy withholds a tool.
+        return len(self.server._tool_manager._tools)
+
+    def _apply_policy(self) -> Resolution:
+        """Remove the tools the policy withholds from the already-registered surface.
+
+        Returns:
+            The policy's keep/removed partition of this server's module tools.
+        """
+        registered = self.server._tool_manager._tools
+        catalog = {
+            name: ToolRecord(module=module_name, annotations=tool.annotations)
+            for module_name, module in self.modules.items()
+            for name in module.tools
+            if (tool := registered.get(name)) is not None
+        }
+        resolution = self.tool_policy.resolve(catalog)
+
+        for name in resolution.removed:
+            # remove_tool raises on an unknown name, and ToolManager.add_tool skips
+            # duplicates silently, so a repeated registration pass reaches here with
+            # the tool already gone.
+            if name in registered:
+                self.server.remove_tool(name)
+                logger.debug("Withheld tool: %s", name)
+
+        # Keep module.tools mirroring what the server serves.
+        for module in self.modules.values():
+            module.tools = [name for name in module.tools if name not in resolution.removed]
+
+        return resolution
 
     def _register_resources(self) -> int:
         """Register resources from all modules.
@@ -202,13 +323,14 @@ class FalconMCPServer:
         Returns:
             int: Number of resources registered
         """
-        # Register resources from modules
+        # Deliberately not gated by the tool policy: tool descriptions name their
+        # guide by URI, so dropping one strands a live tool. See
+        # TestGuideReferencesResolve.
         for module in self.modules.values():
-            # Check if the module has a register_resources method
             if hasattr(module, "register_resources") and callable(module.register_resources):
                 module.register_resources(self.server)
 
-        return sum(len(getattr(m, "resources", [])) for m in self.modules.values())
+        return len(self.server._resource_manager._resources)
 
     def falcon_check_connectivity(self) -> dict[str, bool]:
         """Check connectivity to the Falcon API."""
@@ -231,7 +353,7 @@ class FalconMCPServer:
         These modules are determined by the --modules flag when starting the server.
         If no modules are specified, all available modules are enabled.
         """
-        return {"modules": list(self.modules.keys())}
+        return {"modules": sorted(self.enabled_modules & set(self.modules))}
 
     def list_modules(self) -> dict[str, list[str]]:
         """Lists all available modules in the falcon-mcp server."""
@@ -312,6 +434,21 @@ def parse_modules_list(modules_string: str) -> list[str]:
         )
 
     return modules
+
+
+def parse_tools_list(tools_string: str) -> list[str]:
+    """Parse a comma-separated tool-name list.
+
+    Names are not validated here: the set of valid tool names is only known after
+    module registration, so FalconMCPServer rejects unknown names at startup.
+
+    Args:
+        tools_string: Comma-separated string of prefixed tool names
+
+    Returns:
+        List of tool names, empty if the string is empty
+    """
+    return [t.strip() for t in tools_string.split(",") if t.strip()]
 
 
 def parse_args() -> argparse.Namespace:
@@ -424,6 +561,36 @@ def parse_args() -> argparse.Namespace:
         "all module tools (env: FALCON_MCP_DYNAMIC)",
     )
 
+    # Blast-radius controls. These compose with --modules and with each other;
+    # --read-only and --exclude-tools both override --tools.
+    parser.add_argument(
+        "--read-only",
+        action="store_true",
+        default=os.environ.get("FALCON_MCP_READ_ONLY", "").lower() == "true",
+        help="Register only read-only tools, disabling every tool that mutates tenant state. "
+        "Takes precedence over --tools (env: FALCON_MCP_READ_ONLY)",
+    )
+
+    parser.add_argument(
+        "--tools",
+        type=parse_tools_list,
+        default=parse_tools_list(os.environ.get("FALCON_MCP_TOOLS", "")),
+        metavar="TOOL1,TOOL2,...",
+        help="Comma-separated allow-list of tool names to register (e.g. "
+        "falcon_search_hosts,falcon_search_detections). Additive: added to the tools from "
+        "--modules, and may name tools from modules that are not enabled. Set alone, only "
+        "these tools load. Unknown names abort startup (env: FALCON_MCP_TOOLS)",
+    )
+
+    parser.add_argument(
+        "--exclude-tools",
+        type=parse_tools_list,
+        default=parse_tools_list(os.environ.get("FALCON_MCP_EXCLUDE_TOOLS", "")),
+        metavar="TOOL1,TOOL2,...",
+        help="Comma-separated deny-list of tool names to withhold. Overrides --tools. "
+        "Unknown names abort startup (env: FALCON_MCP_EXCLUDE_TOOLS)",
+    )
+
     return parser.parse_args()
 
 
@@ -449,6 +616,9 @@ def main() -> None:
             member_cid=args.member_cid,
             proxy=args.proxy,
             dynamic=args.dynamic,
+            read_only=args.read_only,
+            allowed_tools=set(args.tools),
+            excluded_tools=set(args.exclude_tools),
         )
         logger.info("Starting server with %s transport", args.transport)
         server.run(args.transport)

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -8,7 +8,7 @@ and serves as the entry point for the application.
 import argparse
 import os
 import sys
-from typing import Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import uvicorn
 from dotenv import load_dotenv
@@ -25,6 +25,9 @@ from falcon_mcp.common.auth import (
 from falcon_mcp.common.logging import configure_logging, get_logger
 from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS, offload_to_thread
 from falcon_mcp.tool_filter import Resolution, ToolPolicy, ToolRecord
+
+if TYPE_CHECKING:
+    from falcon_mcp.dynamic import DynamicMode
 
 logger = get_logger(__name__)
 
@@ -161,6 +164,9 @@ class FalconMCPServer:
 
         # Initialize and register modules
         self.modules = {}
+        # Set before _register_tools so list_enabled_tools can tell the two catalog
+        # sources apart.
+        self._dynamic_mode: DynamicMode | None = None
         available_modules = registry.get_available_modules()
         for module_name in self.loaded_modules:
             if module_name in available_modules:
@@ -243,28 +249,29 @@ class FalconMCPServer:
         Returns:
             int: Number of tools left registered
         """
-        # falcon_list_enabled_modules is always registered — dynamic mode's no-results
-        # hint references it by name, and it's useful in both modes. Meta-tools are
-        # exempt from the policy: withholding them leaves dynamic mode undiscoverable.
+        # falcon_list_enabled_tools is always registered: it is the cheap way to see
+        # the whole served surface, and dynamic mode's zero-hit hint points here.
+        # Meta-tools are exempt from the policy — withholding them leaves the server
+        # undiscoverable.
         self.server.add_tool(
-            offload_to_thread(self.list_enabled_modules),
-            name="falcon_list_enabled_modules",
+            offload_to_thread(self.list_enabled_tools),
+            name="falcon_list_enabled_tools",
             annotations=READ_ONLY_ANNOTATIONS,
             structured_output=False,
         )
 
         if self.dynamic:
             # Dynamic mode: expose only the discovery/execution meta-tools plus
-            # falcon_list_enabled_modules above (3 tools total) so the context window
+            # falcon_list_enabled_tools above (3 tools total) so the context window
             # stays minimal. The catalog applies the policy while building, so a
             # withheld tool is absent from search and 404s in the executor.
             from falcon_mcp.dynamic import DynamicMode
 
-            dynamic_mode = DynamicMode(self.modules, self.server, self.tool_policy)
-            dynamic_mode.register()
-            self._resolution = dynamic_mode.catalog.resolution
+            self._dynamic_mode = DynamicMode(self.modules, self.server, self.tool_policy)
+            self._dynamic_mode.register()
+            self._resolution = self._dynamic_mode.catalog.resolution
         else:
-            # Normal mode: register all three core tools and then each module's tools.
+            # Normal mode: register the other two core tools and then each module's tools.
             self.server.add_tool(
                 offload_to_thread(self.falcon_check_connectivity),
                 name="falcon_check_connectivity",
@@ -273,8 +280,8 @@ class FalconMCPServer:
             )
 
             self.server.add_tool(
-                offload_to_thread(self.list_modules),
-                name="falcon_list_modules",
+                offload_to_thread(self.list_enabled_modules),
+                name="falcon_list_enabled_modules",
                 annotations=READ_ONLY_ANNOTATIONS,
                 structured_output=False,
             )
@@ -355,9 +362,23 @@ class FalconMCPServer:
         """
         return {"modules": sorted(self.enabled_modules & set(self.modules))}
 
-    def list_modules(self) -> dict[str, list[str]]:
-        """Lists all available modules in the falcon-mcp server."""
-        return {"modules": registry.get_module_names()}
+    def list_enabled_tools(self) -> dict[str, Any]:
+        """Lists every Falcon capability tool this server serves.
+
+        Call this to see the complete inventory before hunting for a capability: a
+        name absent from this list is not available on this server, whether because
+        its module is not enabled or because a tool filter withholds it. Returns the
+        sorted tool names plus their total count. Excludes this server's own
+        meta-tools, which are always present and visible in tools/list.
+        """
+        if self._dynamic_mode is not None:
+            # Building the catalog clears module.tools, so it is the only record of
+            # what falcon_execute_tool accepts.
+            names = set(self._dynamic_mode.catalog.entries)
+        else:
+            # _apply_policy() prunes module.tools to the served surface.
+            names = {name for module in self.modules.values() for name in module.tools}
+        return {"tools": sorted(names), "total": len(names)}
 
     def _run_http_transport(self, app: ASGIApp) -> None:
         """Apply middleware and start uvicorn for an HTTP transport.
@@ -553,8 +574,8 @@ def parse_args() -> argparse.Namespace:
         "--dynamic",
         action="store_true",
         default=os.environ.get("FALCON_MCP_DYNAMIC", "").lower() == "true",
-        help="Enable dynamic mode: exposes 3 tools (list-modules + search + execute) instead of "
-        "all module tools (env: FALCON_MCP_DYNAMIC)",
+        help="Enable dynamic mode: exposes 3 tools (list-enabled-tools + search + execute) "
+        "instead of all module tools (env: FALCON_MCP_DYNAMIC)",
     )
 
     # Blast-radius controls. These compose with --modules and with each other;

--- a/falcon_mcp/server.py
+++ b/falcon_mcp/server.py
@@ -368,8 +368,9 @@ class FalconMCPServer:
         Call this to see the complete inventory before hunting for a capability: a
         name absent from this list is not available on this server, whether because
         its module is not enabled or because a tool filter withholds it. Returns the
-        sorted tool names plus their total count. Excludes this server's own
-        meta-tools, which are always present and visible in tools/list.
+        sorted tool names plus their total count, and filters_active naming the filter
+        rules in effect when any are configured. Excludes this server's own meta-tools,
+        which are always present and visible in tools/list.
         """
         if self._dynamic_mode is not None:
             # Building the catalog clears module.tools, so it is the only record of
@@ -378,7 +379,12 @@ class FalconMCPServer:
         else:
             # _apply_policy() prunes module.tools to the served surface.
             names = {name for module in self.modules.values() for name in module.tools}
-        return {"tools": sorted(names), "total": len(names)}
+        result: dict[str, Any] = {"tools": sorted(names), "total": len(names)}
+        # Only present when a filter narrowed the list, so an unfiltered server's
+        # response is unchanged and the key's presence is itself the signal.
+        if self.tool_policy.active:
+            result["filters_active"] = self.tool_policy.describe()
+        return result
 
     def _run_http_transport(self, app: ASGIApp) -> None:
         """Apply middleware and start uvicorn for an HTTP transport.

--- a/falcon_mcp/tool_filter.py
+++ b/falcon_mcp/tool_filter.py
@@ -62,7 +62,8 @@ class ToolPolicy:
 
     The allow-list is additive, not intersecting: ``--modules detections --tools X``
     registers every detections tool plus X, even when X's module is off. Rules 1 and
-    2 run first, so it can never widen past ``--read-only`` or ``--exclude-tools``.
+    2 still decide any tool the allow-list names, so it can never widen past
+    ``--read-only`` or ``--exclude-tools``.
 
     Tool names are the ``falcon_``-prefixed names clients see. Scope is tools only;
     FQL guide resources are static docs and stay registered — most tool descriptions
@@ -134,20 +135,25 @@ class ToolPolicy:
 
         Follows the documented precedence, so the reason is the rule that actually
         decided this tool rather than every rule the server has enabled.
+
+        A tool nothing requested is ``_NOT_REQUESTED`` even when a subtracting rule
+        would also have dropped it: ``--tools X`` loads X's whole module to reach X,
+        so blaming read-only for a sibling the operator never named would invent a
+        decision the allow-list already made by omission.
         """
+        requested = name in self.allowed or (
+            self.enabled_modules is None or record.module in self.enabled_modules
+        )
+        if not requested:
+            return _NOT_REQUESTED
+
         if name in self.excluded:
             return "deny-list"
 
         if self.read_only and self._is_mutating(record):
             return "read-only"
 
-        if name in self.allowed:
-            return None
-
-        if self.enabled_modules is None or record.module in self.enabled_modules:
-            return None
-
-        return _NOT_REQUESTED
+        return None
 
     def _is_mutating(self, record: ToolRecord) -> bool:
         """True if read-only mode would reject this tool.

--- a/falcon_mcp/tool_filter.py
+++ b/falcon_mcp/tool_filter.py
@@ -1,0 +1,153 @@
+"""
+Tool-level filtering for the Falcon MCP server.
+
+Lets an operator shrink a server's blast radius without giving up a whole module.
+"""
+
+from dataclasses import dataclass
+
+from mcp.types import ToolAnnotations
+
+
+@dataclass(frozen=True)
+class ToolRecord:
+    """Everything a policy needs to know about one registered tool.
+
+    Attributes:
+        module: Name of the module that registered the tool.
+        annotations: The tool's effective MCP annotations, if any.
+    """
+
+    module: str
+    annotations: ToolAnnotations | None
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """Which tools a policy keeps and which it withholds.
+
+    Attributes:
+        keep: Prefixed names the policy admits.
+        removed: Prefixed names the policy withholds, for any reason.
+        withheld_by_rule: The subset of ``removed`` dropped by the deny-list or
+            read-only, rather than by never being requested.
+    """
+
+    keep: frozenset[str]
+    removed: frozenset[str]
+    withheld_by_rule: frozenset[str]
+
+
+class ToolPolicy:
+    """Resolves a catalog of candidate tools into keep/remove sets.
+
+    Precedence, highest first:
+
+    1. Deny-list — removes a tool unconditionally, even if the allow-list names it.
+    2. Read-only — removes every non-read-only tool unconditionally, even if the
+       allow-list names it.
+    3. Allow-list — adds the tools it names, bypassing the module gate.
+    4. Module gate — an unnamed tool survives only if its module was enabled in
+       its own right.
+
+    The allow-list is additive, not intersecting: ``--modules detections --tools X``
+    registers every detections tool plus X, even when X's module is off. Rules 1 and
+    2 run first, so it can never widen past ``--read-only`` or ``--exclude-tools``.
+
+    Tool names are the ``falcon_``-prefixed names clients see. Scope is tools only;
+    FQL guide resources are static docs and stay registered — most tool descriptions
+    name their guide by URI, so withholding one would point a model at nothing.
+    """
+
+    def __init__(
+        self,
+        read_only: bool = False,
+        allowed: set[str] | None = None,
+        excluded: set[str] | None = None,
+        enabled_modules: set[str] | None = None,
+    ):
+        """Initialize the policy.
+
+        Args:
+            read_only: Keep only tools whose annotations set readOnlyHint=True.
+            allowed: Additive allow-list of prefixed tool names.
+            excluded: Deny-list of prefixed tool names.
+            enabled_modules: Modules the operator enabled in their own right, whose
+                tools survive without being named. None disables the module gate,
+                so every module contributes its full surface.
+        """
+        self.read_only = read_only
+        self.allowed = frozenset(allowed or ())
+        self.excluded = frozenset(excluded or ())
+        self.enabled_modules = (
+            None if enabled_modules is None else frozenset(enabled_modules)
+        )
+
+    @property
+    def active(self) -> bool:
+        """True if any filtering rule is configured."""
+        return self.read_only or bool(self.allowed) or bool(self.excluded)
+
+    def resolve(self, catalog: dict[str, ToolRecord]) -> Resolution:
+        """Partition a catalog of candidate tools into keep and removed sets.
+
+        Pure: computed once per registration path from the full catalog, so a
+        repeated pass cannot double-count and no per-tool state is carried.
+
+        Args:
+            catalog: Prefixed tool name to its owning module and annotations.
+
+        Returns:
+            The keep/removed partition of ``catalog``, with the rule-driven removals
+            tracked separately for reporting.
+        """
+        keep: set[str] = set()
+        removed: set[str] = set()
+        by_rule: set[str] = set()
+        for name, record in catalog.items():
+            if self._keeps(name, record):
+                keep.add(name)
+                continue
+            removed.add(name)
+            if name in self.excluded or self._is_mutating(record):
+                by_rule.add(name)
+        return Resolution(
+            keep=frozenset(keep),
+            removed=frozenset(removed),
+            withheld_by_rule=frozenset(by_rule),
+        )
+
+    def _keeps(self, name: str, record: ToolRecord) -> bool:
+        if name in self.excluded:
+            return False
+
+        if self.read_only and self._is_mutating(record):
+            return False
+
+        if name in self.allowed:
+            return True
+
+        return self.enabled_modules is None or record.module in self.enabled_modules
+
+    def _is_mutating(self, record: ToolRecord) -> bool:
+        """True if read-only mode would reject this tool.
+
+        Anything other than readOnlyHint=True counts as mutating, so an unclassified
+        tool is withheld rather than exposed. Always False when read-only is off, so
+        a mutating tool dropped for another reason is not misattributed to it.
+        """
+        if not self.read_only:
+            return False
+        annotations = record.annotations
+        return not (annotations and annotations.readOnlyHint is True)
+
+    def describe(self) -> str:
+        """Human-readable summary of which rules are in effect."""
+        parts = []
+        if self.read_only:
+            parts.append("read-only")
+        if self.allowed:
+            parts.append(f"allow-list ({len(self.allowed)} named)")
+        if self.excluded:
+            parts.append(f"deny-list ({len(self.excluded)} named)")
+        return ", ".join(parts) if parts else "none"

--- a/falcon_mcp/tool_filter.py
+++ b/falcon_mcp/tool_filter.py
@@ -4,9 +4,15 @@ Tool-level filtering for the Falcon MCP server.
 Lets an operator shrink a server's blast radius without giving up a whole module.
 """
 
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 
 from mcp.types import ToolAnnotations
+
+# Sentinel reason for a tool no rule withheld — it was simply never requested, by
+# module gate or allow-list. Not a decision worth reporting, so it stays out of
+# Resolution.reasons.
+_NOT_REQUESTED = "not-requested"
 
 
 @dataclass(frozen=True)
@@ -31,11 +37,15 @@ class Resolution:
         removed: Prefixed names the policy withholds, for any reason.
         withheld_by_rule: The subset of ``removed`` dropped by the deny-list or
             read-only, rather than by never being requested.
+        reasons: For each name in ``withheld_by_rule``, the rule that dropped it —
+            ``"deny-list"`` or ``"read-only"``. Names the cause for one tool, which
+            ``ToolPolicy.describe()`` cannot do because it summarizes the whole server.
     """
 
     keep: frozenset[str]
     removed: frozenset[str]
     withheld_by_rule: frozenset[str]
+    reasons: Mapping[str, str] = field(default_factory=dict)
 
 
 class ToolPolicy:
@@ -99,35 +109,45 @@ class ToolPolicy:
 
         Returns:
             The keep/removed partition of ``catalog``, with the rule-driven removals
-            tracked separately for reporting.
+            tracked separately and each one's cause recorded.
         """
         keep: set[str] = set()
         removed: set[str] = set()
-        by_rule: set[str] = set()
+        reasons: dict[str, str] = {}
         for name, record in catalog.items():
-            if self._keeps(name, record):
+            reason = self._rejection_reason(name, record)
+            if reason is None:
                 keep.add(name)
                 continue
             removed.add(name)
-            if name in self.excluded or self._is_mutating(record):
-                by_rule.add(name)
+            if reason != _NOT_REQUESTED:
+                reasons[name] = reason
         return Resolution(
             keep=frozenset(keep),
             removed=frozenset(removed),
-            withheld_by_rule=frozenset(by_rule),
+            withheld_by_rule=frozenset(reasons),
+            reasons=reasons,
         )
 
-    def _keeps(self, name: str, record: ToolRecord) -> bool:
+    def _rejection_reason(self, name: str, record: ToolRecord) -> str | None:
+        """Name the rule that withholds this tool, or None if the policy keeps it.
+
+        Follows the documented precedence, so the reason is the rule that actually
+        decided this tool rather than every rule the server has enabled.
+        """
         if name in self.excluded:
-            return False
+            return "deny-list"
 
         if self.read_only and self._is_mutating(record):
-            return False
+            return "read-only"
 
         if name in self.allowed:
-            return True
+            return None
 
-        return self.enabled_modules is None or record.module in self.enabled_modules
+        if self.enabled_modules is None or record.module in self.enabled_modules:
+            return None
+
+        return _NOT_REQUESTED
 
     def _is_mutating(self, record: ToolRecord) -> bool:
         """True if read-only mode would reject this tool.

--- a/tests/modules/test_dynamic.py
+++ b/tests/modules/test_dynamic.py
@@ -331,21 +331,21 @@ class TestExecuteFalconTool(unittest.TestCase):
                 query="hosts nonexistent", module=None, limit=20
             )
         )
-        self.assertIsInstance(result, dict)
-        assert isinstance(result, dict)  # narrow for Pyright
         self.assertEqual(result["results"], [])
-        self.assertIn("hint", result)
-        self.assertIn("detections", result["hint"])
-        self.assertIn("No tools found", result["hint"])
+        self.assertEqual(result["total"], 0)
+        self.assertFalse(result["truncated"])
+        self.assertIn("hosts nonexistent", result["hint"])
+        self.assertIn("falcon_list_enabled_tools", result["hint"])
 
-    def test_search_tools_with_results_returns_list(self):
+    def test_search_tools_with_results_returns_envelope(self):
         result = run_async(
             self.dynamic._search_tools(
                 query="search_detections", module=None, limit=20
             )
         )
-        self.assertIsInstance(result, list)
-        self.assertGreater(len(result), 0)
+        self.assertGreater(len(result["results"]), 0)
+        self.assertEqual(result["total"], len(result["results"]))
+        self.assertFalse(result["truncated"])
 
 
 class TestDynamicServerIntegration(unittest.TestCase):
@@ -375,12 +375,12 @@ class TestDynamicServerIntegration(unittest.TestCase):
             call.kwargs["name"] for call in mock_server_instance.add_tool.call_args_list
         ]
         self.assertEqual(len(tool_names), 3)
-        self.assertIn("falcon_list_enabled_modules", tool_names)
+        self.assertIn("falcon_list_enabled_tools", tool_names)
         self.assertIn("falcon_search_tools", tool_names)
         self.assertIn("falcon_execute_tool", tool_names)
         # These must NOT be registered in dynamic mode
         self.assertNotIn("falcon_check_connectivity", tool_names)
-        self.assertNotIn("falcon_list_modules", tool_names)
+        self.assertNotIn("falcon_list_enabled_modules", tool_names)
 
     @patch("falcon_mcp.server.FalconClient")
     @patch("falcon_mcp.server.FastMCP")
@@ -408,7 +408,7 @@ class TestDynamicServerIntegration(unittest.TestCase):
         # All three core tools must be present in normal mode
         self.assertIn("falcon_check_connectivity", tool_names)
         self.assertIn("falcon_list_enabled_modules", tool_names)
-        self.assertIn("falcon_list_modules", tool_names)
+        self.assertIn("falcon_list_enabled_tools", tool_names)
         # Module tools must be registered directly
         self.assertIn("falcon_search_detections", tool_names)
 

--- a/tests/modules/test_dynamic.py
+++ b/tests/modules/test_dynamic.py
@@ -15,6 +15,7 @@ from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.modules.detections import DetectionsModule
 from falcon_mcp.modules.hosts import HostsModule
 from falcon_mcp.modules.ngsiem import NGSIEMModule
+from falcon_mcp.tool_filter import ToolPolicy
 
 _T = TypeVar("_T")
 
@@ -224,6 +225,65 @@ class TestDynamicToolCatalog(unittest.TestCase):
                 f"FILTER_HINTS has orphan key '{hint_key}' — no matching tool found. "
                 "Remove or rename the entry in filter_hints.py.",
             )
+
+
+class TestEmptySurfaceCopy(unittest.TestCase):
+    """Agent-facing copy must not misstate an empty tool surface.
+
+    `--tools <mutator> --read-only` withholds everything, leaving a catalog with no
+    entries. Telling a model that other tools remain available sends it hunting
+    through a server that serves nothing.
+    """
+
+    def setUp(self):
+        self.mock_client = MagicMock()
+        modules: dict[str, BaseModule] = {
+            "detections": DetectionsModule(self.mock_client),
+        }
+        # Deny every tool the module has, so the catalog ends up empty.
+        probe: dict[str, BaseModule] = {
+            "detections": DetectionsModule(self.mock_client)
+        }
+        all_names = set(DynamicToolCatalog(probe).entries)
+        self.dynamic = DynamicMode(
+            modules, MagicMock(), ToolPolicy(excluded=all_names)
+        )
+        self.assertEqual(self.dynamic.catalog.entries, {}, "catalog must be empty")
+
+    def test_withheld_error_does_not_promise_other_tools(self):
+        result = run_async(
+            self.dynamic._execute_tool(
+                tool_name="falcon_search_detections", parameters={}
+            )
+        )
+        self.assertIn("withholds it", result["error"])
+        self.assertNotIn(
+            "other tools remain available",
+            result["error"],
+            "claimed other tools are available on a server that serves none",
+        )
+
+    def test_empty_query_hint_does_not_quote_an_empty_query(self):
+        """A module-only browse that matches nothing must not quote an empty query.
+
+        Exercised on a NON-empty surface: an empty catalog is described by its own
+        branch, so it would never reach the query wording being asserted here.
+        """
+        served: dict[str, BaseModule] = {
+            "detections": DetectionsModule(self.mock_client)
+        }
+        dynamic = DynamicMode(served, MagicMock())
+        self.assertTrue(dynamic.catalog.entries, "surface must be non-empty")
+
+        result = run_async(
+            dynamic._search_tools(query="", module="nosuchmodule", limit=20)
+        )
+        self.assertEqual(result["results"], [])
+        self.assertNotIn(
+            "matching ''",
+            result["hint"],
+            "quoted an empty query back at the model",
+        )
 
 
 class TestExecuteFalconTool(unittest.TestCase):

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -485,7 +485,7 @@ class TestMCPComplianceDynamic(unittest.IsolatedAsyncioTestCase):
         tool_names = {t.name for t in tools}
         self.assertEqual(
             tool_names,
-            {"falcon_list_enabled_modules", "falcon_search_tools", "falcon_execute_tool"},
+            {"falcon_list_enabled_tools", "falcon_search_tools", "falcon_execute_tool"},
         )
 
     async def test_dynamic_meta_tool_annotations(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -202,53 +202,6 @@ class TestFalconMCPServer(unittest.TestCase):
             self.assertIsInstance(module_name, str)
 
     @patch("falcon_mcp.server.FalconClient")
-    def test_list_modules(self, mock_client):
-        """Test listing all available modules."""
-        # Setup mock
-        mock_client_instance = MagicMock()
-        mock_client_instance.authenticate.return_value = True
-        mock_client.return_value = mock_client_instance
-
-        # Create server with limited modules
-        server = FalconMCPServer(enabled_modules={"detections", "cloud"})
-
-        # Call list_modules
-        result = server.list_modules()
-
-        # Should return ALL modules from registry regardless of what's enabled
-        expected_modules = registry.get_module_names()
-        self.assertEqual(set(result["modules"]), set(expected_modules))
-
-        # Verify return type is correct
-        self.assertIsInstance(result["modules"], list)
-
-        # Verify each module name is a string
-        for module_name in result["modules"]:
-            self.assertIsInstance(module_name, str)
-
-    @patch("falcon_mcp.server.FalconClient")
-    def test_list_modules_consistency(self, mock_client):
-        """Test that list_modules always returns the same result."""
-        # Setup mock
-        mock_client_instance = MagicMock()
-        mock_client_instance.authenticate.return_value = True
-        mock_client.return_value = mock_client_instance
-
-        # Create two servers with different enabled modules
-        server1 = FalconMCPServer(enabled_modules={"detections"})
-        server2 = FalconMCPServer(enabled_modules={"cloud", "intel"})
-
-        # Both should return the same available modules
-        result1 = server1.list_modules()
-        result2 = server2.list_modules()
-
-        self.assertEqual(set(result1["modules"]), set(result2["modules"]))
-
-        # And both should match the registry
-        expected_modules = registry.get_module_names()
-        self.assertEqual(set(result1["modules"]), set(expected_modules))
-
-    @patch("falcon_mcp.server.FalconClient")
     @patch("falcon_mcp.server.FastMCP")
     def test_server_with_stateless_http_enabled(self, mock_fastmcp, mock_client):
         """Test server initialization with stateless_http enabled."""
@@ -434,7 +387,7 @@ class TestFalconMCPServer(unittest.TestCase):
         core_tool_names = [
             "falcon_check_connectivity",
             "falcon_list_enabled_modules",
-            "falcon_list_modules",
+            "falcon_list_enabled_tools",
         ]
         for call in mock_server_instance.add_tool.call_args_list:
             name = call.kwargs.get("name")

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -800,11 +800,12 @@ class TestDynamicModeToolFiltering(unittest.TestCase):
         self.assertNotIn(_MUTATING_TOOL, names)
 
     def test_read_only_rejects_mutating_tool_in_executor(self, mock_client):
+        """The executor must refuse it; TestWithheldToolsAreAttributable covers wording."""
         result = self._execute(
             self._dynamic_server(mock_client, read_only=True), _MUTATING_TOOL
         )
         self.assertIn("error", result)
-        self.assertIn("Unknown tool", result["error"])
+        self.assertIn("withholds it", result["error"])
 
     def test_deny_list_rejects_tool_in_executor(self, mock_client):
         server = self._dynamic_server(mock_client, excluded_tools={_READ_ONLY_TOOL})
@@ -864,6 +865,104 @@ class TestDynamicModeToolFiltering(unittest.TestCase):
         )
         result = self._execute(server, _READ_ONLY_TOOL)
         self.assertNotIn("error", result)
+
+
+@patch("falcon_mcp.server.FalconClient")
+class TestWithheldToolsAreAttributable(unittest.TestCase):
+    """A config-withheld tool must not read as a missing product capability.
+
+    Withholding removes the tool from the catalog, so its name lands in the same
+    unknown-tool branch as a name that was never served. Left alone, the model tells
+    the user the capability does not exist when the operator merely disabled it.
+    """
+
+    def setUp(self):
+        registry.discover_modules()
+
+    def _server(self, mock_client, **kwargs) -> FalconMCPServer:
+        mock_client.return_value.authenticate.return_value = True
+        return FalconMCPServer(enabled_modules={_MODULE}, **kwargs)
+
+    def _execute(self, server: FalconMCPServer, tool_name: str) -> Any:
+        tool = server.server._tool_manager._tools["falcon_execute_tool"]
+        return run_async(tool.run({"tool_name": tool_name, "parameters": {}}))
+
+    def _inventory(self, server: FalconMCPServer) -> dict[str, Any]:
+        tool = server.server._tool_manager._tools["falcon_list_enabled_tools"]
+        return run_async(tool.run({}))
+
+    def test_read_only_withheld_tool_cites_the_rule(self, mock_client):
+        server = self._server(mock_client, dynamic=True, read_only=True)
+        error = self._execute(server, _MUTATING_TOOL)["error"]
+
+        self.assertIn(_MUTATING_TOOL, error)
+        self.assertIn("read-only", error)
+        self.assertNotIn("Unknown tool", error)
+
+    def test_denied_tool_cites_the_rule(self, mock_client):
+        server = self._server(
+            mock_client, dynamic=True, excluded_tools={_MUTATING_TOOL}
+        )
+        error = self._execute(server, _MUTATING_TOOL)["error"]
+
+        self.assertIn("deny-list", error)
+        self.assertNotIn("Unknown tool", error)
+
+    def test_withheld_tool_is_still_not_executed(self, mock_client):
+        """Naming the cause must not resurrect the tool — omission is the enforcement."""
+        server = self._server(mock_client, dynamic=True, read_only=True)
+        module = server.modules[_MODULE]
+        module.client.command = MagicMock()
+
+        self._execute(server, _MUTATING_TOOL)
+
+        module.client.command.assert_not_called()
+
+    def test_never_served_name_keeps_the_unknown_tool_error(self, mock_client):
+        """The two cases must be distinguishable in both directions."""
+        server = self._server(mock_client, dynamic=True, read_only=True)
+        error = self._execute(server, "falcon_not_a_real_tool")["error"]
+
+        self.assertIn("Unknown tool", error)
+        self.assertNotIn("withholds it", error)
+
+    def test_module_gate_is_not_reported_as_a_policy_withholding(self, mock_client):
+        """--modules leaves the catalog smaller, not withheld.
+
+        A tool from an unloaded module never enters the catalog, so it must fall
+        through to the plain unknown-tool message rather than claiming a filter
+        withheld it.
+        """
+        server = self._server(mock_client, dynamic=True)
+        error = self._execute(server, _FOREIGN_TOOL)["error"]
+
+        self.assertIn("Unknown tool", error)
+        self.assertNotIn("withholds it", error)
+        self.assertNotIn("filters_active", self._inventory(server))
+
+    def test_zero_hit_hint_names_the_active_filter(self, mock_client):
+        server = self._server(mock_client, dynamic=True, read_only=True)
+        tool = server.server._tool_manager._tools["falcon_search_tools"]
+        hint = run_async(tool.run({"query": "nothing_matches_this", "limit": 20}))["hint"]
+
+        self.assertIn("tool filter", hint)
+        self.assertIn("read-only", hint)
+        self.assertIn("falcon_list_enabled_tools", hint)
+
+    def test_inventory_names_the_active_filter_in_both_modes(self, mock_client):
+        for dynamic in (True, False):
+            with self.subTest(dynamic=dynamic):
+                server = self._server(mock_client, dynamic=dynamic, read_only=True)
+                self.assertEqual(
+                    self._inventory(server)["filters_active"], "read-only"
+                )
+
+    def test_inventory_omits_the_key_when_no_filter_is_configured(self, mock_client):
+        """Presence of the key is the signal, so an unfiltered server must not carry it."""
+        for dynamic in (True, False):
+            with self.subTest(dynamic=dynamic):
+                inventory = self._inventory(self._server(mock_client, dynamic=dynamic))
+                self.assertNotIn("filters_active", inventory)
 
 
 if __name__ == "__main__":

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 from mcp.types import ToolAnnotations
 
 from falcon_mcp import registry
-from falcon_mcp.server import FalconMCPServer, parse_args, parse_tools_list
+from falcon_mcp.server import FalconMCPServer, main, parse_args, parse_tools_list
 from falcon_mcp.tool_filter import ToolPolicy, ToolRecord
 
 _T = TypeVar("_T")
@@ -228,6 +228,37 @@ class TestToolPolicy(unittest.TestCase):
         )
         self.assertEqual(p.resolve(catalog), p.resolve(catalog))
 
+    def test_never_requested_sibling_is_not_attributed_to_read_only(self):
+        """A mutator the allow-list never named was not withheld by --read-only.
+
+        --tools X --read-only loads X's whole module to reach X, so its siblings get
+        registered as candidates. Attributing them to read-only inflates the startup
+        count and makes falcon_execute_tool call a never-requested tool "withheld
+        (read-only)" when the same tool without --read-only reports Unknown tool.
+        """
+        catalog = {
+            "falcon_wanted": ToolRecord(_MODULE, _MUTATING_ANNOTATIONS),
+            "falcon_sibling_mutator": ToolRecord(_MODULE, _MUTATING_ANNOTATIONS),
+            "falcon_sibling_reader": ToolRecord(_MODULE, _READ_ONLY_ANNOTATIONS),
+        }
+        # --tools falcon_wanted --read-only: no module is enabled in its own right.
+        resolution = ToolPolicy(
+            read_only=True, allowed={"falcon_wanted"}, enabled_modules=set()
+        ).resolve(catalog)
+
+        self.assertEqual(
+            dict(resolution.reasons),
+            {"falcon_wanted": "read-only"},
+            "only the requested tool was decided by read-only",
+        )
+        self.assertEqual(resolution.withheld_by_rule, frozenset({"falcon_wanted"}))
+        # Both siblings are still gone, just not blamed on a rule.
+        self.assertEqual(
+            resolution.removed,
+            frozenset(catalog),
+            "every unrequested tool is still removed",
+        )
+
     def test_describe_reports_active_rules(self):
         self.assertEqual(ToolPolicy().describe(), "none")
         self.assertIn("read-only", ToolPolicy(read_only=True).describe())
@@ -288,6 +319,30 @@ class TestCLIDefaultsReachTheServer(unittest.TestCase):
         with patch("falcon_mcp.server.FalconClient", mock):
             server = FalconMCPServer(enabled_modules=set(args.modules))
         self.assertEqual(server.enabled_modules, set(registry.get_module_names()))
+
+    def test_main_forwards_every_filter_flag_to_the_server(self):
+        """main() must hand each parsed filter flag to the constructor.
+
+        The tests above stop at parse_args() and re-thread the namespace by hand, so
+        none of them cover the args-to-kwargs mapping in main(). Dropping
+        read_only=args.read_only there serves every mutator on a server the operator
+        asked to be read-only, with the rest of the suite still green.
+        """
+        argv = [
+            "--read-only",
+            "--tools",
+            _FOREIGN_TOOL,
+            "--exclude-tools",
+            _MUTATING_TOOL,
+        ]
+        with patch.object(sys, "argv", ["falcon-mcp", *argv]):
+            with patch("falcon_mcp.server.FalconMCPServer") as mock_server:
+                main()
+
+        kwargs = mock_server.call_args.kwargs
+        self.assertTrue(kwargs["read_only"], "--read-only never reached the server")
+        self.assertEqual(kwargs["allowed_tools"], {_FOREIGN_TOOL})
+        self.assertEqual(kwargs["excluded_tools"], {_MUTATING_TOOL})
 
     def test_explicit_modules_are_honored(self):
         args = self._args(["--modules", "detections"])

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -1,0 +1,695 @@
+"""
+Tests for tool-level filtering (read-only mode, allow-list, deny-list).
+"""
+
+import asyncio
+import re
+import unittest
+from collections.abc import Coroutine
+from typing import Any, TypeVar
+from unittest.mock import MagicMock, patch
+
+from mcp.types import ToolAnnotations
+
+from falcon_mcp import registry
+from falcon_mcp.server import FalconMCPServer, parse_tools_list
+from falcon_mcp.tool_filter import ToolPolicy, ToolRecord
+
+_T = TypeVar("_T")
+
+# hostgroups carries a mix of read-only and mutating tools, which makes it the
+# cheapest module to assert precedence against.
+_MODULE = "hostgroups"
+_READ_ONLY_TOOL = "falcon_search_host_groups"
+_MUTATING_TOOL = "falcon_delete_host_groups"
+
+# A tool from a module that is NOT enabled in these tests, used to prove the
+# allow-list is additive across the module gate.
+_FOREIGN_TOOL = "falcon_search_applications"
+
+# Always registered regardless of filtering, so tests subtract them out.
+_META_TOOLS = {
+    "falcon_list_enabled_modules",
+    "falcon_list_modules",
+    "falcon_check_connectivity",
+}
+
+_MUTATING_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+
+_READ_ONLY_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+
+# Trailing punctuation is excluded so "…fql-guide." yields the bare URI.
+_URI_PATTERN = re.compile(r"falcon://[A-Za-z0-9\-_/]+")
+
+
+def run_async(coro: Coroutine[Any, Any, _T]) -> _T:
+    return asyncio.run(coro)
+
+
+def _catalog(*specs: tuple[str, str, ToolAnnotations | None]) -> dict[str, ToolRecord]:
+    """Build a catalog from (name, module, annotations) triples."""
+    return {
+        name: ToolRecord(module=module, annotations=annotations)
+        for name, module, annotations in specs
+    }
+
+
+class TestToolPolicy(unittest.TestCase):
+    """Unit tests for the ToolPolicy precedence rules in isolation."""
+
+    def test_no_configuration_keeps_everything(self):
+        p = ToolPolicy()
+        self.assertFalse(p.active)
+        resolved = p.resolve(_catalog(("falcon_a", "m", _MUTATING_ANNOTATIONS)))
+        self.assertEqual(resolved.keep, {"falcon_a"})
+        self.assertEqual(resolved.removed, frozenset())
+
+    def test_deny_list_wins_over_allow_list(self):
+        p = ToolPolicy(allowed={"falcon_a"}, excluded={"falcon_a"})
+        resolved = p.resolve(_catalog(("falcon_a", "m", _READ_ONLY_ANNOTATIONS)))
+        self.assertEqual(resolved.removed, {"falcon_a"})
+
+    def test_read_only_wins_over_allow_list(self):
+        p = ToolPolicy(read_only=True, allowed={_MUTATING_TOOL})
+        resolved = p.resolve(_catalog((_MUTATING_TOOL, "m", _MUTATING_ANNOTATIONS)))
+        self.assertEqual(resolved.removed, {_MUTATING_TOOL})
+
+    def test_allow_list_is_additive_not_intersecting(self):
+        """A named tool survives; unnamed tools in enabled modules also survive."""
+        p = ToolPolicy(allowed={"falcon_a"}, enabled_modules={"m"})
+        resolved = p.resolve(
+            _catalog(
+                ("falcon_a", "m", _READ_ONLY_ANNOTATIONS),
+                ("falcon_b", "m", _READ_ONLY_ANNOTATIONS),
+            )
+        )
+        self.assertEqual(resolved.keep, {"falcon_a", "falcon_b"})
+
+    def test_allow_list_crosses_the_module_gate(self):
+        """A module loaded solely for the allow-list contributes only named tools."""
+        p = ToolPolicy(allowed={"falcon_a"}, enabled_modules={"enabled"})
+        resolved = p.resolve(
+            _catalog(
+                ("falcon_a", "gated", _READ_ONLY_ANNOTATIONS),
+                ("falcon_b", "gated", _READ_ONLY_ANNOTATIONS),
+                ("falcon_c", "enabled", _READ_ONLY_ANNOTATIONS),
+            )
+        )
+        self.assertEqual(resolved.keep, {"falcon_a", "falcon_c"})
+        self.assertEqual(resolved.removed, {"falcon_b"})
+
+    def test_no_enabled_modules_disables_the_module_gate(self):
+        """enabled_modules=None means every module contributes its full surface."""
+        p = ToolPolicy(read_only=True)
+        resolved = p.resolve(_catalog(("falcon_a", "anything", _READ_ONLY_ANNOTATIONS)))
+        self.assertEqual(resolved.keep, {"falcon_a"})
+
+    def test_read_only_keeps_read_only_tools(self):
+        p = ToolPolicy(read_only=True, enabled_modules={"m"})
+        resolved = p.resolve(_catalog(("falcon_a", "m", _READ_ONLY_ANNOTATIONS)))
+        self.assertEqual(resolved.keep, {"falcon_a"})
+
+    def test_read_only_withholds_tools_with_no_annotations(self):
+        """An unclassified tool is withheld, not assumed safe."""
+        p = ToolPolicy(read_only=True, enabled_modules={"m"})
+        resolved = p.resolve(_catalog(("falcon_a", "m", None)))
+        self.assertEqual(resolved.removed, {"falcon_a"})
+
+    def test_resolution_partitions_the_catalog(self):
+        """Every catalog entry lands in exactly one of keep/removed."""
+        p = ToolPolicy(read_only=True, enabled_modules={"m"})
+        catalog = _catalog(
+            ("falcon_keep", "m", _READ_ONLY_ANNOTATIONS),
+            ("falcon_drop", "m", _MUTATING_ANNOTATIONS),
+        )
+        resolved = p.resolve(catalog)
+        self.assertEqual(resolved.keep, {"falcon_keep"})
+        self.assertEqual(resolved.removed, {"falcon_drop"})
+        self.assertEqual(resolved.keep | resolved.removed, set(catalog))
+        self.assertEqual(resolved.keep & resolved.removed, set())
+
+    def test_never_requested_tool_is_removed_but_not_withheld_by_rule(self):
+        """A sibling of an allow-listed tool was never a candidate, not withheld.
+
+        Counting it as withheld reads as though a decision was made about it, when
+        the operator simply never asked for it.
+        """
+        p = ToolPolicy(allowed={"falcon_a"}, enabled_modules={"enabled"})
+        resolved = p.resolve(
+            _catalog(
+                ("falcon_a", "gated", _READ_ONLY_ANNOTATIONS),
+                ("falcon_sibling", "gated", _READ_ONLY_ANNOTATIONS),
+            )
+        )
+        self.assertEqual(resolved.removed, {"falcon_sibling"})
+        self.assertEqual(resolved.withheld_by_rule, frozenset())
+
+    def test_deny_list_and_read_only_removals_are_withheld_by_rule(self):
+        """Both explicit rules count as withheld; each is a decision made."""
+        p = ToolPolicy(
+            read_only=True, excluded={"falcon_denied"}, enabled_modules={"m"}
+        )
+        resolved = p.resolve(
+            _catalog(
+                ("falcon_denied", "m", _READ_ONLY_ANNOTATIONS),
+                ("falcon_mutator", "m", _MUTATING_ANNOTATIONS),
+                ("falcon_sibling", "off", _READ_ONLY_ANNOTATIONS),
+            )
+        )
+        self.assertEqual(resolved.withheld_by_rule, {"falcon_denied", "falcon_mutator"})
+        self.assertEqual(resolved.removed, resolved.withheld_by_rule | {"falcon_sibling"})
+
+    def test_mutating_tool_is_not_withheld_by_rule_when_read_only_is_off(self):
+        """A mutator dropped by the module gate must not be blamed on read-only."""
+        p = ToolPolicy(allowed={"falcon_a"}, enabled_modules={"enabled"})
+        resolved = p.resolve(
+            _catalog(("falcon_mutator", "gated", _MUTATING_ANNOTATIONS))
+        )
+        self.assertEqual(resolved.removed, {"falcon_mutator"})
+        self.assertEqual(resolved.withheld_by_rule, frozenset())
+
+    def test_resolve_is_pure(self):
+        """Resolving twice yields the same answer; no state accumulates."""
+        p = ToolPolicy(read_only=True, enabled_modules={"m"})
+        catalog = _catalog(
+            ("falcon_keep", "m", _READ_ONLY_ANNOTATIONS),
+            ("falcon_drop", "m", _MUTATING_ANNOTATIONS),
+        )
+        self.assertEqual(p.resolve(catalog), p.resolve(catalog))
+
+    def test_describe_reports_active_rules(self):
+        self.assertEqual(ToolPolicy().describe(), "none")
+        self.assertIn("read-only", ToolPolicy(read_only=True).describe())
+        self.assertIn("deny-list", ToolPolicy(excluded={"falcon_a"}).describe())
+
+
+class TestParseToolsList(unittest.TestCase):
+    """Tests for the CLI list parser."""
+
+    def test_empty_string_yields_empty_list(self):
+        self.assertEqual(parse_tools_list(""), [])
+
+    def test_strips_whitespace_and_blanks(self):
+        self.assertEqual(
+            parse_tools_list(" falcon_a , falcon_b ,, "), ["falcon_a", "falcon_b"]
+        )
+
+
+@patch("falcon_mcp.server.FalconClient")
+class TestServerToolFiltering(unittest.TestCase):
+    """End-to-end tests asserting the registered tool surface."""
+
+    def setUp(self):
+        registry.discover_modules()
+
+    def _server(self, mock_client, **kwargs) -> FalconMCPServer:
+        mock_client.return_value.authenticate.return_value = True
+        return FalconMCPServer(enabled_modules={_MODULE}, **kwargs)
+
+    def _module_tools(self, server: FalconMCPServer) -> set[str]:
+        return set(server.server._tool_manager._tools) - _META_TOOLS
+
+    def test_unfiltered_registers_all_module_tools(self, mock_client):
+        tools = self._module_tools(self._server(mock_client))
+        self.assertIn(_READ_ONLY_TOOL, tools)
+        self.assertIn(_MUTATING_TOOL, tools)
+
+    def test_read_only_withholds_mutating_tools(self, mock_client):
+        tools = self._module_tools(self._server(mock_client, read_only=True))
+        self.assertIn(_READ_ONLY_TOOL, tools)
+        self.assertNotIn(_MUTATING_TOOL, tools)
+
+    def test_deny_list_removes_named_tool(self, mock_client):
+        tools = self._module_tools(
+            self._server(mock_client, excluded_tools={_READ_ONLY_TOOL})
+        )
+        self.assertNotIn(_READ_ONLY_TOOL, tools)
+        self.assertIn(_MUTATING_TOOL, tools)
+
+    def test_deny_list_overrides_allow_list(self, mock_client):
+        """Precedence rule 1: deny wins even when the allow-list names the tool."""
+        tools = self._module_tools(
+            self._server(
+                mock_client,
+                allowed_tools={_READ_ONLY_TOOL},
+                excluded_tools={_READ_ONLY_TOOL},
+            )
+        )
+        self.assertNotIn(_READ_ONLY_TOOL, tools)
+
+    def test_read_only_overrides_allow_list(self, mock_client):
+        """Precedence rule 2: read-only wins even when the allow-list names the tool."""
+        tools = self._module_tools(
+            self._server(mock_client, read_only=True, allowed_tools={_MUTATING_TOOL})
+        )
+        self.assertNotIn(_MUTATING_TOOL, tools)
+
+    def test_allow_list_does_not_restrict_an_enabled_module(self, mock_client):
+        """Precedence rule 3: the allow-list adds, it does not subtract.
+
+        An explicitly enabled module keeps its full surface; the allow-list only
+        widens it. Use --exclude-tools or --read-only to subtract.
+        """
+        tools = self._module_tools(
+            self._server(mock_client, allowed_tools={_READ_ONLY_TOOL})
+        )
+        self.assertIn(_READ_ONLY_TOOL, tools)
+        self.assertIn(_MUTATING_TOOL, tools)
+
+    def test_allow_list_pulls_in_tool_from_disabled_module(self, mock_client):
+        """Precedence rule 4: the allow-list is additive across the module gate.
+
+        Reproduces `--modules detections --tools falcon_search_applications`, which
+        must yield every detections tool plus the named discover tool.
+        """
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={"detections"}, allowed_tools={_FOREIGN_TOOL}
+        )
+        tools = self._module_tools(server)
+        self.assertIn(_FOREIGN_TOOL, tools)
+        self.assertIn("falcon_search_detections", tools)
+        self.assertIn("falcon_update_detections", tools)
+
+    def test_pulled_in_module_contributes_only_named_tools(self, mock_client):
+        """A module loaded solely for the allow-list does not bring its whole surface."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={"detections"}, allowed_tools={_FOREIGN_TOOL}
+        )
+        tools = self._module_tools(server)
+        discover_tools = {
+            name for name, mod in registry.get_tool_module_map().items() if mod == "discover"
+        }
+        self.assertEqual(tools & discover_tools, {_FOREIGN_TOOL})
+
+    def test_pulled_in_module_still_registers_its_resources(self, mock_client):
+        """A module pulled in for one tool keeps its guides.
+
+        Most tool descriptions name a falcon:// URI, so withholding a guide while
+        keeping its tool would point the model at a resource that does not exist.
+        See test_every_referenced_guide_uri_resolves for the general guard.
+        """
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={"detections"}, allowed_tools={_FOREIGN_TOOL}
+        )
+        uris = {str(u) for u in server.server._resource_manager._resources}
+        self.assertIn("falcon://discover/applications/fql-guide", uris)
+        self.assertIn("falcon://detections/search/fql-guide", uris)
+
+    def test_enabled_module_still_registers_its_resources(self, mock_client):
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(enabled_modules={"discover"})
+        uris = {str(u) for u in server.server._resource_manager._resources}
+        self.assertIn("falcon://discover/applications/fql-guide", uris)
+        self.assertIn("falcon://discover/hosts/fql-guide", uris)
+
+    def test_startup_counts_match_what_was_registered(self, mock_client):
+        """The logged module/tool/resource counts must reflect reality, not arithmetic."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={"detections"}, allowed_tools={_FOREIGN_TOOL}
+        )
+        # One module enabled, even though two are loaded.
+        self.assertEqual(len(server.modules), 2)
+        self.assertEqual(server.list_enabled_modules(), {"modules": ["detections"]})
+        self.assertEqual(
+            server._register_tools(), len(server.server._tool_manager._tools)
+        )
+        self.assertEqual(
+            server._register_resources(),
+            len(server.server._resource_manager._resources),
+        )
+
+    def test_startup_log_counts_only_enabled_modules(self, mock_client):
+        """The startup summary must not count a module pulled in for one tool."""
+        mock_client.return_value.authenticate.return_value = True
+        with self.assertLogs("falcon_mcp.server", level="INFO") as captured:
+            FalconMCPServer(enabled_modules={"detections"}, allowed_tools={_FOREIGN_TOOL})
+        summary = next(m for m in captured.output if "Falcon MCP v" in m)
+        self.assertIn("1 module,", summary)
+
+    def _policy_log(self, **kwargs) -> str:
+        with self.assertLogs("falcon_mcp.server", level="INFO") as captured:
+            FalconMCPServer(**kwargs)
+        return next(m for m in captured.output if "Tool policy active" in m)
+
+    def test_allow_list_alone_reports_nothing_withheld(self, mock_client):
+        """--modules X --tools Y removed nothing the operator asked to remove.
+
+        The siblings of Y that came along with its module were never candidates, so
+        reporting them as withheld would invent a decision.
+        """
+        mock_client.return_value.authenticate.return_value = True
+        line = self._policy_log(
+            enabled_modules={"detections"}, allowed_tools={_FOREIGN_TOOL}
+        )
+        self.assertIn("0 tools withheld", line)
+
+    def test_deny_list_reports_only_its_own_removal(self, mock_client):
+        """With an allow-list and a deny-list, only the denied tool is withheld."""
+        mock_client.return_value.authenticate.return_value = True
+        line = self._policy_log(
+            enabled_modules={"detections"},
+            allowed_tools={_FOREIGN_TOOL, "falcon_search_hosts"},
+            excluded_tools={"falcon_search_detections"},
+        )
+        self.assertIn("1 tool withheld", line)
+        self.assertIn("deny-list", line)
+
+    def test_read_only_reports_the_mutators_it_withheld(self, mock_client):
+        mock_client.return_value.authenticate.return_value = True
+        line = self._policy_log(enabled_modules={_MODULE}, read_only=True)
+        self.assertRegex(line, r"read-only.*\d+ tools withheld")
+        self.assertNotIn("0 tools withheld", line)
+
+    def test_withheld_names_appear_at_debug_level(self, mock_client):
+        """The INFO line gives counts; --debug must supply the names behind them."""
+        mock_client.return_value.authenticate.return_value = True
+        with self.assertLogs("falcon_mcp.server", level="DEBUG") as captured:
+            FalconMCPServer(enabled_modules={_MODULE}, excluded_tools={_MUTATING_TOOL})
+        self.assertTrue(
+            any(f"Withheld tool: {_MUTATING_TOOL}" in m for m in captured.output),
+            captured.output,
+        )
+
+    def test_pulled_in_module_is_not_reported_as_enabled(self, mock_client):
+        """A gated module is loaded but not advertised by falcon_list_enabled_modules.
+
+        Matches the reference implementation, where an additively-named tool resolves
+        while isToolsetEnabled() on its owning toolset stays false.
+        """
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={"detections"}, allowed_tools={_FOREIGN_TOOL}
+        )
+        self.assertEqual(server.list_enabled_modules(), {"modules": ["detections"]})
+        self.assertIn("discover", server.modules)
+        self.assertIn(_FOREIGN_TOOL, server.server._tool_manager._tools)
+
+    def test_enabled_modules_reported_normally_without_a_filter(self, mock_client):
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(enabled_modules={"detections", _MODULE})
+        self.assertEqual(
+            server.list_enabled_modules(), {"modules": sorted(["detections", _MODULE])}
+        )
+
+    def test_tools_alone_reports_no_enabled_modules(self, mock_client):
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(allowed_tools={_FOREIGN_TOOL})
+        self.assertEqual(server.list_enabled_modules(), {"modules": []})
+
+    def test_tools_alone_supplies_the_entire_surface(self, mock_client):
+        """--tools with no --modules registers only the named tools."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(allowed_tools={_FOREIGN_TOOL})
+        self.assertEqual(self._module_tools(server), {_FOREIGN_TOOL})
+
+    def test_read_only_overrides_additive_allow_list(self, mock_client):
+        """A mutating tool pulled in from a disabled module is still withheld."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={"detections"}, read_only=True, allowed_tools={_MUTATING_TOOL}
+        )
+        self.assertNotIn(_MUTATING_TOOL, self._module_tools(server))
+
+    def test_deny_list_overrides_additive_allow_list(self, mock_client):
+        """Naming a tool in both lists withholds it even across the module gate."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={"detections"},
+            allowed_tools={_FOREIGN_TOOL},
+            excluded_tools={_FOREIGN_TOOL},
+        )
+        self.assertNotIn(_FOREIGN_TOOL, self._module_tools(server))
+
+    def test_all_three_controls_compose(self, mock_client):
+        """read-only and deny both override the allow-list in one configuration."""
+        tools = self._module_tools(
+            self._server(
+                mock_client,
+                read_only=True,
+                allowed_tools={
+                    _READ_ONLY_TOOL,
+                    _MUTATING_TOOL,
+                    "falcon_search_host_group_members",
+                },
+                excluded_tools={"falcon_search_host_group_members"},
+            )
+        )
+        # _MUTATING_TOOL dropped by read-only, the members search dropped by the
+        # deny-list, leaving the allow-listed read-only survivor.
+        self.assertEqual(tools, {_READ_ONLY_TOOL})
+
+    def test_name_from_disabled_module_survives_read_only_if_read_only(self, mock_client):
+        """Additive pull-in plus read-only: a read-only foreign tool is kept."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={_MODULE}, read_only=True, allowed_tools={_FOREIGN_TOOL}
+        )
+        tools = self._module_tools(server)
+        self.assertIn(_FOREIGN_TOOL, tools)
+        self.assertNotIn(_MUTATING_TOOL, tools)
+
+    def test_modules_still_gate_the_candidate_set(self, mock_client):
+        """An unnamed tool from a module that is off is not registered."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(enabled_modules={_MODULE})
+        self.assertNotIn(_FOREIGN_TOOL, self._module_tools(server))
+
+    def test_meta_tools_survive_read_only_and_allow_list(self, mock_client):
+        """Server meta-tools stay registered so the server remains usable."""
+        server = self._server(mock_client, read_only=True, allowed_tools={_READ_ONLY_TOOL})
+        self.assertTrue(_META_TOOLS.issubset(set(server.server._tool_manager._tools)))
+
+    def test_tool_count_reflects_actual_registrations(self, mock_client):
+        """The startup count must not be derived arithmetically once filtering exists."""
+        server = self._server(mock_client, excluded_tools={_MUTATING_TOOL})
+        registered = server.server._tool_manager._tools
+        self.assertEqual(server._register_tools(), len(registered))
+        self.assertNotIn(_MUTATING_TOOL, registered)
+
+    def test_repeated_registration_keeps_filter_counts_accurate(self, mock_client):
+        """Re-running registration must not inflate the logged filter summary."""
+        server = self._server(mock_client, excluded_tools={_MUTATING_TOOL})
+        before = server._resolution
+        server._register_tools()
+        self.assertEqual(before, server._resolution)
+        self.assertNotIn(_MUTATING_TOOL, server.server._tool_manager._tools)
+
+    def test_module_tools_mirrors_the_served_surface(self, mock_client):
+        """module.tools must not advertise a tool the server no longer serves."""
+        server = self._server(mock_client, excluded_tools={_MUTATING_TOOL})
+        tracked = set(server.modules[_MODULE].tools)
+        self.assertNotIn(_MUTATING_TOOL, tracked)
+        self.assertEqual(tracked, tracked & set(server.server._tool_manager._tools))
+
+    def test_fql_resources_survive_tool_level_filtering(self, mock_client):
+        """A withheld tool's guide stays readable.
+
+        Guides are static docs and confer no capability. They also outlive the tools
+        that name them — see TestGuideReferencesResolve.
+        """
+        server = self._server(mock_client, excluded_tools={_READ_ONLY_TOOL})
+        self.assertNotIn(_READ_ONLY_TOOL, self._module_tools(server))
+        resources = server.server._resource_manager._resources
+        self.assertIn("falcon://host-groups/search/fql-guide", resources)
+
+    def test_unknown_allow_list_name_aborts_startup(self, mock_client):
+        mock_client.return_value.authenticate.return_value = True
+        with self.assertRaises(ValueError) as ctx:
+            FalconMCPServer(allowed_tools={"falcon_not_a_real_tool"})
+        self.assertIn("falcon_not_a_real_tool", str(ctx.exception))
+
+    def test_unknown_deny_list_name_aborts_startup(self, mock_client):
+        """A typo in a deny-list would silently leave a tool exposed."""
+        mock_client.return_value.authenticate.return_value = True
+        with self.assertRaises(ValueError) as ctx:
+            FalconMCPServer(excluded_tools={"falcon_serch_hosts"})
+        self.assertIn("falcon_serch_hosts", str(ctx.exception))
+
+    def test_unprefixed_name_is_rejected(self, mock_client):
+        """Names are the prefixed form clients see; the bare name is a typo."""
+        mock_client.return_value.authenticate.return_value = True
+        with self.assertRaises(ValueError):
+            FalconMCPServer(excluded_tools={"search_hosts"})
+
+    def test_name_from_disabled_module_is_accepted(self, mock_client):
+        """Validation spans all available modules, not just the enabled ones."""
+        self._server(mock_client, excluded_tools={"falcon_search_hosts"})
+
+    def test_validation_precedes_authentication(self, mock_client):
+        """A bad name fails fast, without spending a Falcon round-trip."""
+        mock_client.return_value.authenticate.return_value = True
+        with self.assertRaises(ValueError):
+            FalconMCPServer(excluded_tools={"falcon_bogus"})
+        mock_client.return_value.authenticate.assert_not_called()
+
+
+@patch("falcon_mcp.server.FalconClient")
+class TestGuideReferencesResolve(unittest.TestCase):
+    """Every falcon:// URI a live tool names must resolve to a registered resource.
+
+    Tool descriptions go to the model verbatim. A description that says "consult
+    falcon://x/fql-guide" while that resource is unregistered instructs the model to
+    read something absent — the failure mode that killed module-level resource
+    gating. This catches the class, not just the one case.
+    """
+
+    def setUp(self):
+        registry.discover_modules()
+
+    def _dangling(self, server: FalconMCPServer) -> set[str]:
+        registered = {str(u) for u in server.server._resource_manager._resources}
+        referenced = {
+            uri
+            for tool in server.server._tool_manager._tools.values()
+            for uri in _URI_PATTERN.findall(tool.description or "")
+        }
+        return referenced - registered
+
+    def test_every_referenced_guide_uri_resolves(self, mock_client):
+        """The default surface: all modules, no filtering."""
+        mock_client.return_value.authenticate.return_value = True
+        self.assertEqual(self._dangling(FalconMCPServer()), set())
+
+    def test_references_resolve_for_an_additively_pulled_in_module(self, mock_client):
+        """The original break: --modules detections --tools falcon_search_applications."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={"detections"}, allowed_tools={_FOREIGN_TOOL}
+        )
+        self.assertEqual(self._dangling(server), set())
+
+    def test_references_resolve_under_read_only(self, mock_client):
+        mock_client.return_value.authenticate.return_value = True
+        self.assertEqual(self._dangling(FalconMCPServer(read_only=True)), set())
+
+    def test_the_guard_sees_a_real_reference(self, mock_client):
+        """Guard against passing vacuously: a real tool must name a real URI."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(enabled_modules={"discover"})
+        tool = server.server._tool_manager._tools[_FOREIGN_TOOL]
+        self.assertIn(
+            "falcon://discover/applications/fql-guide",
+            _URI_PATTERN.findall(tool.description or ""),
+        )
+
+
+@patch("falcon_mcp.server.FalconClient")
+class TestDynamicModeToolFiltering(unittest.TestCase):
+    """Filtered tools must vanish from the search surface AND the executor.
+
+    Filtering only the search results would leave falcon_execute_tool as a bypass.
+    """
+
+    def setUp(self):
+        registry.discover_modules()
+
+    def _dynamic_server(self, mock_client, **kwargs) -> FalconMCPServer:
+        mock_client.return_value.authenticate.return_value = True
+        return FalconMCPServer(enabled_modules={_MODULE}, dynamic=True, **kwargs)
+
+    def _search(self, server: FalconMCPServer, query: str = "") -> list[str]:
+        tool = server.server._tool_manager._tools["falcon_search_tools"]
+        result = run_async(tool.run({"query": query, "limit": 100}))
+        if isinstance(result, dict):
+            return []
+        return [entry["name"] for entry in result]
+
+    def _execute(self, server: FalconMCPServer, tool_name: str) -> Any:
+        tool = server.server._tool_manager._tools["falcon_execute_tool"]
+        return run_async(tool.run({"tool_name": tool_name, "parameters": {}}))
+
+    def test_dynamic_mode_exposes_only_meta_tools(self, mock_client):
+        server = self._dynamic_server(mock_client)
+        self.assertEqual(
+            set(server.server._tool_manager._tools),
+            {"falcon_list_enabled_modules", "falcon_search_tools", "falcon_execute_tool"},
+        )
+
+    def test_read_only_hides_mutating_tool_from_search(self, mock_client):
+        names = self._search(self._dynamic_server(mock_client, read_only=True))
+        self.assertIn(_READ_ONLY_TOOL, names)
+        self.assertNotIn(_MUTATING_TOOL, names)
+
+    def test_read_only_rejects_mutating_tool_in_executor(self, mock_client):
+        result = self._execute(
+            self._dynamic_server(mock_client, read_only=True), _MUTATING_TOOL
+        )
+        self.assertIn("error", result)
+        self.assertIn("Unknown tool", result["error"])
+
+    def test_deny_list_rejects_tool_in_executor(self, mock_client):
+        server = self._dynamic_server(mock_client, excluded_tools={_READ_ONLY_TOOL})
+        self.assertNotIn(_READ_ONLY_TOOL, self._search(server))
+        result = self._execute(server, _READ_ONLY_TOOL)
+        self.assertIn("error", result)
+
+    def test_allow_list_gated_module_hides_unnamed_tool_from_executor(self, mock_client):
+        """A pulled-in module's unnamed tools stay unreachable via the executor."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={"detections"}, dynamic=True, allowed_tools={_FOREIGN_TOOL}
+        )
+        # falcon_search_applications was named; other discover tools were not.
+        unnamed_discover = next(
+            name
+            for name, mod in registry.get_tool_module_map().items()
+            if mod == "discover" and name != _FOREIGN_TOOL
+        )
+        self.assertNotIn(unnamed_discover, self._search(server))
+        result = self._execute(server, unnamed_discover)
+        self.assertIn("error", result)
+        self.assertIn("Unknown tool", result["error"])
+
+    def test_additively_pulled_tool_is_reachable_in_dynamic_mode(self, mock_client):
+        """A tool pulled in from a disabled module must be searchable and executable."""
+        mock_client.return_value.authenticate.return_value = True
+        server = FalconMCPServer(
+            enabled_modules={"detections"}, dynamic=True, allowed_tools={_FOREIGN_TOOL}
+        )
+        self.assertIn(_FOREIGN_TOOL, self._search(server))
+        result = self._execute(server, _FOREIGN_TOOL)
+        self.assertNotIn("Unknown tool", str(result))
+
+    def test_withheld_names_appear_at_debug_level(self, mock_client):
+        """Dynamic mode omits tools silently, so it must log its own names.
+
+        This path never calls server.remove_tool, so without an explicit debug line
+        --debug would report a count with nothing behind it.
+        """
+        mock_client.return_value.authenticate.return_value = True
+        with self.assertLogs("falcon_mcp.dynamic", level="DEBUG") as captured:
+            FalconMCPServer(
+                enabled_modules={_MODULE}, dynamic=True, excluded_tools={_MUTATING_TOOL}
+            )
+        self.assertTrue(
+            any(f"Withheld tool: {_MUTATING_TOOL}" in m for m in captured.output),
+            captured.output,
+        )
+
+    def test_allowed_tool_still_reaches_its_handler(self, mock_client):
+        """The filter withholds tools; it must not break the ones it keeps."""
+        server = self._dynamic_server(mock_client, allowed_tools={_READ_ONLY_TOOL})
+        module = server.modules[_MODULE]
+        module.client.command = MagicMock(
+            return_value={"status_code": 200, "body": {"resources": [], "meta": {}}}
+        )
+        result = self._execute(server, _READ_ONLY_TOOL)
+        self.assertNotIn("error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -172,6 +172,44 @@ class TestToolPolicy(unittest.TestCase):
         self.assertEqual(resolved.withheld_by_rule, {"falcon_denied", "falcon_mutator"})
         self.assertEqual(resolved.removed, resolved.withheld_by_rule | {"falcon_sibling"})
 
+    def test_reasons_name_the_rule_that_decided_each_tool(self):
+        """falcon_denied is read-only, so only the deny-list can have withheld it.
+
+        Attribution follows the documented precedence rather than reporting every
+        active rule, which would misdirect an operator debugging their config. A tool
+        the module gate dropped is not attributed at all.
+        """
+        p = ToolPolicy(
+            read_only=True, excluded={"falcon_denied"}, enabled_modules={"m"}
+        )
+        resolved = p.resolve(
+            _catalog(
+                ("falcon_denied", "m", _READ_ONLY_ANNOTATIONS),
+                ("falcon_mutator", "m", _MUTATING_ANNOTATIONS),
+                ("falcon_sibling", "off", _READ_ONLY_ANNOTATIONS),
+            )
+        )
+        self.assertEqual(
+            dict(resolved.reasons),
+            {"falcon_denied": "deny-list", "falcon_mutator": "read-only"},
+        )
+        self.assertNotIn("falcon_sibling", resolved.reasons)
+
+    def test_reasons_keys_match_withheld_by_rule(self):
+        """The two must not drift — an unattributed withholding cites no cause."""
+        p = ToolPolicy(
+            read_only=True, excluded={"falcon_denied"}, enabled_modules={"m"}
+        )
+        resolved = p.resolve(
+            _catalog(
+                ("falcon_denied", "m", _READ_ONLY_ANNOTATIONS),
+                ("falcon_mutator", "m", _MUTATING_ANNOTATIONS),
+                ("falcon_kept", "m", _READ_ONLY_ANNOTATIONS),
+                ("falcon_sibling", "off", _READ_ONLY_ANNOTATIONS),
+            )
+        )
+        self.assertEqual(set(resolved.reasons), resolved.withheld_by_rule)
+
     def test_mutating_tool_is_not_withheld_by_rule_when_read_only_is_off(self):
         """A mutator dropped by the module gate must not be blamed on read-only."""
         p = ToolPolicy(allowed={"falcon_a"}, enabled_modules={"enabled"})
@@ -907,6 +945,41 @@ class TestWithheldToolsAreAttributable(unittest.TestCase):
 
         self.assertIn("deny-list", error)
         self.assertNotIn("Unknown tool", error)
+
+    def test_error_cites_only_the_rule_that_withheld_this_tool(self, mock_client):
+        """With both rules on, each tool must name its own cause, not the server's.
+
+        _READ_ONLY_TOOL is read-only, so --read-only cannot have withheld it; only the
+        deny-list did. Citing every active rule would send an operator debugging their
+        config to the wrong flag.
+        """
+        server = self._server(
+            mock_client,
+            dynamic=True,
+            read_only=True,
+            excluded_tools={_READ_ONLY_TOOL},
+        )
+
+        denied = self._execute(server, _READ_ONLY_TOOL)["error"]
+        self.assertIn("deny-list", denied)
+        self.assertNotIn("read-only", denied)
+
+        mutating = self._execute(server, _MUTATING_TOOL)["error"]
+        self.assertIn("read-only", mutating)
+        self.assertNotIn("deny-list", mutating)
+
+    def test_error_does_not_suppress_unrelated_tool_use(self, mock_client):
+        """Blanket 'do not look for another tool' would stall legitimate work.
+
+        On a read-only server the agent often guesses a mutator when a served read
+        tool answers the real question, so the message must scope its warning to
+        reproducing the withheld effect rather than to using tools at all.
+        """
+        server = self._server(mock_client, dynamic=True, read_only=True)
+        error = self._execute(server, _MUTATING_TOOL)["error"]
+
+        self.assertNotIn("do not look for another tool", error)
+        self.assertIn("other tools remain available", error)
 
     def test_withheld_tool_is_still_not_executed(self, mock_client):
         """Naming the cause must not resurrect the tool — omission is the enforcement."""

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -33,7 +33,7 @@ _FOREIGN_TOOL = "falcon_search_applications"
 # Always registered regardless of filtering, so tests subtract them out.
 _META_TOOLS = {
     "falcon_list_enabled_modules",
-    "falcon_list_modules",
+    "falcon_list_enabled_tools",
     "falcon_check_connectivity",
 }
 
@@ -559,6 +559,51 @@ class TestServerToolFiltering(unittest.TestCase):
         self.assertNotIn(_MUTATING_TOOL, tracked)
         self.assertEqual(tracked, tracked & set(server.server._tool_manager._tools))
 
+    def _list_enabled_tools(self, server: FalconMCPServer) -> list[str]:
+        tool = server.server._tool_manager._tools["falcon_list_enabled_tools"]
+        return run_async(tool.run({}))["tools"]
+
+    def test_list_enabled_tools_is_exactly_the_served_module_tools(self, mock_client):
+        """Regression guard for the falcon_list_modules bug: it reported every
+        installed module regardless of filtering."""
+        server = self._server(mock_client)
+        self.assertEqual(
+            set(self._list_enabled_tools(server)), self._module_tools(server)
+        )
+
+    def test_list_enabled_tools_omits_read_only_withheld(self, mock_client):
+        names = self._list_enabled_tools(self._server(mock_client, read_only=True))
+        self.assertIn(_READ_ONLY_TOOL, names)
+        self.assertNotIn(_MUTATING_TOOL, names)
+
+    def test_list_enabled_tools_omits_denied_tool(self, mock_client):
+        names = self._list_enabled_tools(
+            self._server(mock_client, excluded_tools={_READ_ONLY_TOOL})
+        )
+        self.assertNotIn(_READ_ONLY_TOOL, names)
+
+    def test_list_enabled_tools_omits_absent_sibling_of_allowed_tool(self, mock_client):
+        """Both live in `discover`, so allow-listing one must not imply the other."""
+        names = self._list_enabled_tools(
+            self._server(mock_client, allowed_tools={_FOREIGN_TOOL})
+        )
+        self.assertIn(_FOREIGN_TOOL, names)
+        self.assertNotIn("falcon_search_unmanaged_assets", names)
+
+    def test_list_enabled_tools_reports_a_matching_total(self, mock_client):
+        server = self._server(mock_client, read_only=True)
+        tool = server.server._tool_manager._tools["falcon_list_enabled_tools"]
+        result = run_async(tool.run({}))
+        self.assertEqual(result["total"], len(result["tools"]))
+        self.assertEqual(result["tools"], sorted(result["tools"]))
+
+    def test_list_enabled_tools_excludes_meta_tools(self, mock_client):
+        """Capability tools only, as the docstring promises — meta-tools are always
+        present and would be noise in a capability inventory."""
+        names = set(self._list_enabled_tools(self._server(mock_client)))
+        self.assertEqual(names & _META_TOOLS, set())
+        self.assertIn(_READ_ONLY_TOOL, names)
+
     def test_fql_resources_survive_tool_level_filtering(self, mock_client):
         """A withheld tool's guide stays readable.
 
@@ -668,9 +713,11 @@ class TestDynamicModeToolFiltering(unittest.TestCase):
     def _search(self, server: FalconMCPServer, query: str = "") -> list[str]:
         tool = server.server._tool_manager._tools["falcon_search_tools"]
         result = run_async(tool.run({"query": query, "limit": 100}))
-        if isinstance(result, dict):
-            return []
-        return [entry["name"] for entry in result]
+        return [entry["name"] for entry in result["results"]]
+
+    def _list_enabled_tools(self, server: FalconMCPServer) -> list[str]:
+        tool = server.server._tool_manager._tools["falcon_list_enabled_tools"]
+        return run_async(tool.run({}))["tools"]
 
     def _execute(self, server: FalconMCPServer, tool_name: str) -> Any:
         tool = server.server._tool_manager._tools["falcon_execute_tool"]
@@ -680,8 +727,72 @@ class TestDynamicModeToolFiltering(unittest.TestCase):
         server = self._dynamic_server(mock_client)
         self.assertEqual(
             set(server.server._tool_manager._tools),
-            {"falcon_list_enabled_modules", "falcon_search_tools", "falcon_execute_tool"},
+            {"falcon_list_enabled_tools", "falcon_search_tools", "falcon_execute_tool"},
         )
+
+    def test_dynamic_mode_omits_list_enabled_modules(self, mock_client):
+        """Module info stays reachable via falcon_search_tools' module field/filter."""
+        server = self._dynamic_server(mock_client)
+        self.assertNotIn(
+            "falcon_list_enabled_modules", server.server._tool_manager._tools
+        )
+
+    def test_list_enabled_tools_matches_dynamic_catalog(self, mock_client):
+        """The enumeration must equal what falcon_execute_tool will actually accept."""
+        server = self._dynamic_server(mock_client)
+        served = self._list_enabled_tools(server)
+        self.assertIn(_READ_ONLY_TOOL, served)
+        self.assertIn(_MUTATING_TOOL, served)
+        # Not enabled here, so it must not be advertised.
+        self.assertNotIn(_FOREIGN_TOOL, served)
+
+    def test_list_enabled_tools_omits_absent_sibling_of_allowed_tool(self, mock_client):
+        """Both live in `discover`, so allow-listing one must not imply the other."""
+        server = self._dynamic_server(mock_client, allowed_tools={_FOREIGN_TOOL})
+        served = self._list_enabled_tools(server)
+        self.assertIn(_FOREIGN_TOOL, served)
+        self.assertNotIn("falcon_search_unmanaged_assets", served)
+
+    def test_list_enabled_tools_omits_read_only_withheld(self, mock_client):
+        names = self._list_enabled_tools(self._dynamic_server(mock_client, read_only=True))
+        self.assertIn(_READ_ONLY_TOOL, names)
+        self.assertNotIn(_MUTATING_TOOL, names)
+
+    def test_list_enabled_tools_omits_denied_tool(self, mock_client):
+        names = self._list_enabled_tools(
+            self._dynamic_server(mock_client, excluded_tools={_READ_ONLY_TOOL})
+        )
+        self.assertNotIn(_READ_ONLY_TOOL, names)
+
+    def test_search_tools_reports_total_and_truncation(self, mock_client):
+        """A capped result set must say so rather than silently dropping matches."""
+        server = self._dynamic_server(mock_client)
+        tool = server.server._tool_manager._tools["falcon_search_tools"]
+        served = len(self._list_enabled_tools(server))
+
+        capped = run_async(tool.run({"query": "", "limit": 2}))
+        self.assertEqual(capped["total"], served)
+        self.assertEqual(len(capped["results"]), 2)
+        self.assertTrue(capped["truncated"])
+        self.assertIn("falcon_list_enabled_tools", capped["hint"])
+
+        full = run_async(tool.run({"query": "", "limit": 500}))
+        self.assertEqual(full["total"], served)
+        self.assertEqual(len(full["results"]), served)
+        self.assertFalse(full["truncated"])
+
+    def test_search_tools_zero_hit_hint_names_the_absent_capability(self, mock_client):
+        """The dead-end hint must steer to enumeration and to telling the user."""
+        server = self._dynamic_server(mock_client)
+        tool = server.server._tool_manager._tools["falcon_search_tools"]
+        result = run_async(tool.run({"query": "unmanaged assets", "limit": 20}))
+
+        self.assertEqual(result["results"], [])
+        self.assertEqual(result["total"], 0)
+        self.assertFalse(result["truncated"])
+        self.assertIn("unmanaged assets", result["hint"])
+        self.assertIn("falcon_list_enabled_tools", result["hint"])
+        self.assertIn("tell the user", result["hint"])
 
     def test_read_only_hides_mutating_tool_from_search(self, mock_client):
         names = self._search(self._dynamic_server(mock_client, read_only=True))

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -2,8 +2,11 @@
 Tests for tool-level filtering (read-only mode, allow-list, deny-list).
 """
 
+import argparse
 import asyncio
+import os
 import re
+import sys
 import unittest
 from collections.abc import Coroutine
 from typing import Any, TypeVar
@@ -12,7 +15,7 @@ from unittest.mock import MagicMock, patch
 from mcp.types import ToolAnnotations
 
 from falcon_mcp import registry
-from falcon_mcp.server import FalconMCPServer, parse_tools_list
+from falcon_mcp.server import FalconMCPServer, parse_args, parse_tools_list
 from falcon_mcp.tool_filter import ToolPolicy, ToolRecord
 
 _T = TypeVar("_T")
@@ -202,6 +205,67 @@ class TestParseToolsList(unittest.TestCase):
     def test_strips_whitespace_and_blanks(self):
         self.assertEqual(
             parse_tools_list(" falcon_a , falcon_b ,, "), ["falcon_a", "falcon_b"]
+        )
+
+
+class TestCLIDefaultsReachTheServer(unittest.TestCase):
+    """The CLI must hand the server the same thing the tests construct directly.
+
+    Unit tests call FalconMCPServer(allowed_tools=...) with enabled_modules unset,
+    but argparse supplies a default for --modules. If that default is a fully
+    expanded module list, `--tools X` alone silently serves every tool: the server
+    sees a truthy enabled_modules and never takes the "--tools alone" branch. Caught
+    by an agent-level run, invisible to every direct-construction test.
+    """
+
+    def setUp(self):
+        self._saved = {
+            k: os.environ.pop(k, None)
+            for k in ("FALCON_MCP_MODULES", "FALCON_MCP_TOOLS", "FALCON_MCP_EXCLUDE_TOOLS")
+        }
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+    def _args(self, argv: list[str]) -> argparse.Namespace:
+        with patch.object(sys, "argv", ["falcon-mcp", *argv]):
+            return parse_args()
+
+    def test_tools_alone_does_not_preselect_every_module(self):
+        args = self._args(["--tools", "falcon_search_detections"])
+        self.assertEqual(args.tools, ["falcon_search_detections"])
+        self.assertFalse(
+            args.modules,
+            "--modules defaulted to a populated list, so --tools alone cannot "
+            f"restrict the surface: {args.modules}",
+        )
+
+    def test_no_flags_still_means_all_modules(self):
+        """The default must stay 'everything' when no restriction is requested."""
+        args = self._args([])
+        mock = MagicMock()
+        mock.return_value.authenticate.return_value = True
+        with patch("falcon_mcp.server.FalconClient", mock):
+            server = FalconMCPServer(enabled_modules=set(args.modules))
+        self.assertEqual(server.enabled_modules, set(registry.get_module_names()))
+
+    def test_explicit_modules_are_honored(self):
+        args = self._args(["--modules", "detections"])
+        self.assertEqual(args.modules, ["detections"])
+
+    def test_tools_alone_through_the_cli_path_registers_only_that_tool(self):
+        """End-to-end through argparse: the surface must be just the named tool."""
+        args = self._args(["--tools", _FOREIGN_TOOL])
+        mock = MagicMock()
+        mock.return_value.authenticate.return_value = True
+        with patch("falcon_mcp.server.FalconClient", mock):
+            server = FalconMCPServer(
+                enabled_modules=set(args.modules), allowed_tools=set(args.tools)
+            )
+        self.assertEqual(
+            set(server.server._tool_manager._tools) - _META_TOOLS, {_FOREIGN_TOOL}
         )
 
 


### PR DESCRIPTION
`--modules` is all-or-nothing per module, so enabling one to get its search tools also hands over every mutating tool it carries. Three new options narrow that. `--read-only` keeps only tools annotated read-only, `--tools` is an additive allow-list of individual names, and `--exclude-tools` is a deny-list. The subtracting rules always win, so `--read-only` and `--exclude-tools` hold as a floor that an additive `--tools` list can't widen past. An unrecognized name aborts startup instead of being ignored, so a typo in a deny-list won't quietly leave a tool exposed.

Filtering runs after registration rather than trying to predict which module owns what. Guide resources stay registered either way, since most tool descriptions name their guide by URI and withholding one would point a model at nothing.

Also adds `falcon_list_enabled_tools`. It's registered in both modes and exempt from filtering, so there's always a way to ask what a server actually serves. Returns the served names, plus a `filters_active` field when a rule is in effect.