### PR TITLE
fix(modules/detections): send include_hidden as a query parameter

### DIFF
--- a/docs/modules/detections.md
+++ b/docs/modules/detections.md
@@ -42,7 +42,8 @@ Retrieve details for detection IDs you already have.
 
 Use when you have specific composite detection ID(s). For discovering detections
 by criteria (severity, status, hostname, etc.), use falcon_search_detections
-instead. Returns full detection records.
+instead. Returns full detection records; IDs hidden from the Falcon UI are
+omitted when include_hidden is False.
 
 **Example prompts:**
 

--- a/falcon_mcp/modules/base.py
+++ b/falcon_mcp/modules/base.py
@@ -149,9 +149,14 @@ class BaseModule(ABC):
         ids: list[str],
         id_key: str = "ids",
         use_params: bool = False,
+        parameters: dict[str, Any] | None = None,
         **additional_params: Any,
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Helper method for API operations that retrieve entities by IDs.
+
+        Whether a given option belongs in the body or the query string varies by
+        operation; check the endpoint definition and pass it accordingly. An
+        option sent in the wrong place is often ignored without an error.
 
         Args:
             operation: The API operation name
@@ -159,7 +164,10 @@ class BaseModule(ABC):
             id_key: The key name for IDs in the request (default: "ids")
             use_params: If True, send IDs as query parameters (GET).
                        If False, send as request body (POST). Default: False
-            **additional_params: Additional parameters to include in the request
+            parameters: Query-string parameters, for operations that declare an
+                option `in: query` even when the IDs travel in a POST body
+            **additional_params: Additional parameters to include alongside the
+                IDs, in the body or query string per `use_params`
 
         Returns:
             List of entity details or error dict
@@ -169,10 +177,13 @@ class BaseModule(ABC):
         request_params.update(additional_params)
 
         prepared = prepare_api_parameters(request_params)
+        query_params = prepare_api_parameters(parameters) if parameters else {}
 
         # Make the API request using either parameters (GET) or body (POST)
         if use_params:
-            response = self.client.command(operation, parameters=prepared)
+            response = self.client.command(operation, parameters={**prepared, **query_params})
+        elif query_params:
+            response = self.client.command(operation, body=prepared, parameters=query_params)
         else:
             response = self.client.command(operation, body=prepared)
 

--- a/falcon_mcp/modules/detections.py
+++ b/falcon_mcp/modules/detections.py
@@ -135,7 +135,13 @@ class DetectionsModule(BaseModule):
             """).strip(),
             examples=["severity.desc", "timestamp.desc"],
         ),
-        include_hidden: bool = Field(default=True),
+        include_hidden: bool = Field(
+            default=True,
+            description=(
+                "Whether to include hidden detections (default: True). Set False to "
+                "match the detection totals shown in the Falcon console."
+            ),
+        ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Find detections (also called alerts) by criteria and return their complete details.
 
@@ -155,6 +161,7 @@ class DetectionsModule(BaseModule):
                 "offset": offset,
                 "q": q,
                 "sort": sort,
+                "include_hidden": include_hidden,
             },
             error_message="Failed to search detections",
         )
@@ -174,7 +181,7 @@ class DetectionsModule(BaseModule):
             operation="PostEntitiesAlertsV2",
             ids=detection_ids,
             id_key="composite_ids",
-            include_hidden=include_hidden,
+            parameters={"include_hidden": include_hidden},
         )
 
         if self._is_error(details):
@@ -202,7 +209,8 @@ class DetectionsModule(BaseModule):
 
         Use when you have specific composite detection ID(s). For discovering detections
         by criteria (severity, status, hostname, etc.), use falcon_search_detections
-        instead. Returns full detection records.
+        instead. Returns full detection records; IDs hidden from the Falcon UI are
+        omitted when include_hidden is False.
         """
         logger.debug("Getting detection details for ID(s): %s", ids)
 
@@ -210,7 +218,7 @@ class DetectionsModule(BaseModule):
             operation="PostEntitiesAlertsV2",
             ids=ids,
             id_key="composite_ids",
-            include_hidden=include_hidden,
+            parameters={"include_hidden": include_hidden},
         )
 
     def aggregate_detections(

--- a/tests/integration/test_detections.py
+++ b/tests/integration/test_detections.py
@@ -95,6 +95,116 @@ class TestDetectionsIntegration(BaseIntegrationTest):
             context="get_detection_details",
         )
 
+    def _find_hidden_detection_id(self, context: str):
+        """Return the composite_id of a detection hidden from the Falcon UI.
+
+        Hidden detections are the only ones that distinguish include_hidden=True
+        from include_hidden=False; a visible detection is returned either way.
+        Skips the calling test when the tenant has none.
+        """
+        result = self.call_method(
+            self.module.search_detections,
+            filter="show_in_ui:false",
+            limit=1,
+            include_hidden=True,
+        )
+        self.assert_no_error(result, context=f"{context}: finding a hidden detection")
+
+        hidden = self._unwrap_results(result)
+        if not hidden:
+            self.skip_with_warning(
+                "No hidden detections (show_in_ui:false) in this tenant; "
+                "include_hidden cannot be distinguished from the default",
+                context=context,
+            )
+
+        detection_id = self.get_first_id(hidden, id_field="composite_id")
+        if not detection_id:
+            self.skip_with_warning(
+                "Could not extract composite_id for a hidden detection",
+                context=context,
+            )
+        return detection_id
+
+    def test_search_detections_include_hidden_excludes_hidden_detections(self):
+        """include_hidden=False must drop hidden detections from results and the total.
+
+        The query step decides which IDs and what `pagination.total` come back, so
+        this catches include_hidden never reaching GetQueriesAlertsV2.
+        """
+        context = "test_search_detections_include_hidden_excludes_hidden_detections"
+        self._find_hidden_detection_id(context)
+
+        shown = self.call_method(
+            self.module.search_detections,
+            filter="show_in_ui:false",
+            limit=1,
+            include_hidden=False,
+        )
+        everything = self.call_method(
+            self.module.search_detections,
+            filter="show_in_ui:false",
+            limit=1,
+            include_hidden=True,
+        )
+
+        self.assert_no_error(shown, context=f"{context}: include_hidden=False")
+        self.assert_no_error(everything, context=f"{context}: include_hidden=True")
+
+        assert not self._unwrap_results(shown), (
+            "include_hidden=False still returned hidden detections: "
+            f"{self._unwrap_results(shown)}"
+        )
+        assert self._unwrap_results(everything), (
+            "include_hidden=True returned no hidden detections, "
+            "but one was found moments earlier"
+        )
+
+        # `pagination.total` comes from the query step and must respect the flag too.
+        assert shown["pagination"]["total"] == 0, (
+            "include_hidden=False counted hidden detections in pagination.total: "
+            f"{shown['pagination']['total']}"
+        )
+        assert (everything["pagination"]["total"] or 0) > 0, (
+            "include_hidden=True reported no hidden detections in pagination.total: "
+            f"{everything['pagination']['total']}"
+        )
+
+    def test_get_detection_details_include_hidden_excludes_hidden_detection(self):
+        """include_hidden=False must omit a hidden detection from a by-ID lookup.
+
+        PostEntitiesAlertsV2 declares include_hidden `in: query`; sent in the POST
+        body it is silently ignored and the hidden detection comes back anyway.
+        """
+        context = "test_get_detection_details_include_hidden_excludes_hidden_detection"
+        detection_id = self._find_hidden_detection_id(context)
+
+        visible_only = self.call_method(
+            self.module.get_detection_details,
+            ids=[detection_id],
+            include_hidden=False,
+        )
+        with_hidden = self.call_method(
+            self.module.get_detection_details,
+            ids=[detection_id],
+            include_hidden=True,
+        )
+
+        self.assert_no_error(visible_only, context=f"{context}: include_hidden=False")
+        self.assert_no_error(with_hidden, context=f"{context}: include_hidden=True")
+
+        assert visible_only == [], (
+            "include_hidden=False returned a hidden detection: "
+            f"{visible_only}"
+        )
+        assert with_hidden, (
+            f"include_hidden=True returned nothing for hidden detection {detection_id}"
+        )
+        assert with_hidden[0].get("show_in_ui") is False, (
+            "expected a detection hidden from the UI, got show_in_ui="
+            f"{with_hidden[0].get('show_in_ui')!r}"
+        )
+
     def test_operation_names_are_correct(self):
         """Validate that FalconPy operation names are correct.
 

--- a/tests/integration/test_detections.py
+++ b/tests/integration/test_detections.py
@@ -371,7 +371,9 @@ class TestDetectionsIntegration(BaseIntegrationTest):
 
         Skips gracefully if Alerts:write scope is not available.
         """
-        search_result = self.call_method(self.module.search_detections, limit=1)
+        search_result = self._unwrap_results(
+            self.call_method(self.module.search_detections, limit=1)
+        )
         if not search_result or isinstance(search_result, dict):
             self.skip_with_warning(
                 "No detections available to test update_detections",
@@ -458,7 +460,9 @@ class TestDetectionsIntegration(BaseIntegrationTest):
 
         Skips gracefully if Alerts:write scope is not available.
         """
-        search_result = self.call_method(self.module.search_detections, limit=1)
+        search_result = self._unwrap_results(
+            self.call_method(self.module.search_detections, limit=1)
+        )
         if not search_result or isinstance(search_result, dict):
             self.skip_with_warning(
                 "No detections available to test update_detections tags",
@@ -610,7 +614,9 @@ class TestDetectionsIntegration(BaseIntegrationTest):
 
         Skips gracefully if Alerts:write scope is not available.
         """
-        search_result = self.call_method(self.module.search_detections, limit=1)
+        search_result = self._unwrap_results(
+            self.call_method(self.module.search_detections, limit=1)
+        )
         if not search_result or isinstance(search_result, dict):
             self.skip_with_warning(
                 "No detections available to test update_detections show_in_ui",

--- a/tests/modules/test_base.py
+++ b/tests/modules/test_base.py
@@ -154,6 +154,68 @@ class TestBaseModule(TestModules):
         expected_result = [{"composite_id": "alert1", "status": "new", "hidden": False}]
         self.assertEqual(result, expected_result)
 
+    def test_base_get_by_ids_with_query_parameters(self):
+        """Test _base_get_by_ids sends `parameters` as query params, separate from the body."""
+        mock_response = {
+            "status_code": 200,
+            "body": {"resources": [{"composite_id": "alert1", "status": "new"}]},
+        }
+        self.mock_client.command.return_value = mock_response
+
+        result = self.module._base_get_by_ids(
+            "PostEntitiesAlertsV2",
+            ["alert1"],
+            id_key="composite_ids",
+            parameters={"include_hidden": False},
+        )
+
+        # The query param must not be folded into the POST body — some endpoints
+        # declare it `in: query` and silently ignore a body copy.
+        self.mock_client.command.assert_called_once_with(
+            "PostEntitiesAlertsV2",
+            body={"composite_ids": ["alert1"]},
+            parameters={"include_hidden": False},
+        )
+        self.assertEqual(result, [{"composite_id": "alert1", "status": "new"}])
+
+    def test_base_get_by_ids_omits_empty_parameters(self):
+        """Test that no `parameters` argument leaves existing callers' calls unchanged."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "test1"}]},
+        }
+
+        for parameters in (None, {}):
+            with self.subTest(parameters=parameters):
+                self.mock_client.command.reset_mock()
+
+                self.module._base_get_by_ids(
+                    "TestOperation", ["test1"], parameters=parameters
+                )
+
+                self.mock_client.command.assert_called_once_with(
+                    "TestOperation", body={"ids": ["test1"]}
+                )
+
+    def test_base_get_by_ids_query_parameters_with_use_params(self):
+        """Test that `parameters` merges into the query string when use_params=True."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "test1"}]},
+        }
+
+        self.module._base_get_by_ids(
+            "TestGetOperation",
+            ["test1"],
+            use_params=True,
+            parameters={"include_hidden": False},
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "TestGetOperation",
+            parameters={"ids": ["test1"], "include_hidden": False},
+        )
+
     def test_base_get_by_ids_error_handling(self):
         """Test _base_get_by_ids error handling."""
         # Setup mock error response

--- a/tests/modules/test_detections.py
+++ b/tests/modules/test_detections.py
@@ -65,10 +65,8 @@ class TestDetectionsModule(TestModules):
         self.assertEqual(first_call[1]["parameters"]["limit"], 10)
         self.mock_client.command.assert_any_call(
             "PostEntitiesAlertsV2",
-            body={
-                "composite_ids": ["detection1", "detection2"],
-                "include_hidden": True,
-            },
+            body={"composite_ids": ["detection1", "detection2"]},
+            parameters={"include_hidden": True},
         )
 
         # Verify result is paginated envelope with empty results
@@ -113,10 +111,8 @@ class TestDetectionsModule(TestModules):
         self.assertEqual(first_call[1]["parameters"]["limit"], 10)
         self.mock_client.command.assert_any_call(
             "PostEntitiesAlertsV2",
-            body={
-                "composite_ids": ["detection1", "detection2"],
-                "include_hidden": True,
-            },
+            body={"composite_ids": ["detection1", "detection2"]},
+            parameters={"include_hidden": True},
         )
 
         # Verify result is paginated envelope
@@ -222,7 +218,8 @@ class TestDetectionsModule(TestModules):
         # Verify client command was called correctly
         self.mock_client.command.assert_called_once_with(
             "PostEntitiesAlertsV2",
-            body={"composite_ids": ["detection1"], "include_hidden": True},
+            body={"composite_ids": ["detection1"]},
+            parameters={"include_hidden": True},
         )
 
         # Verify result - handle_api_response returns a list of resources
@@ -269,10 +266,8 @@ class TestDetectionsModule(TestModules):
         # Check that the second call includes include_hidden=False
         self.mock_client.command.assert_any_call(
             "PostEntitiesAlertsV2",
-            body={
-                "composite_ids": ["detection1", "detection2"],
-                "include_hidden": False,
-            },
+            body={"composite_ids": ["detection1", "detection2"]},
+            parameters={"include_hidden": False},
         )
 
         # Verify result is paginated envelope
@@ -281,6 +276,64 @@ class TestDetectionsModule(TestModules):
         self.assertEqual(len(result["results"]), 1)
         self.assertEqual(result["results"][0]["composite_id"], "detection1")
         self.assertEqual(result["pagination"]["total"], 2)
+
+    def test_search_detections_include_hidden_reaches_query_step(self):
+        """include_hidden must reach the GetQueriesAlertsV2 query step.
+
+        The query step is what decides which IDs — and therefore
+        `pagination.total` — come back. Forwarding include_hidden only to the
+        hydration step leaves hidden alerts in the result set and the count.
+        """
+        for include_hidden in (True, False):
+            with self.subTest(include_hidden=include_hidden):
+                self.mock_client.command.reset_mock()
+                self.mock_client.command.side_effect = [
+                    {
+                        "status_code": 200,
+                        "body": {
+                            "resources": ["detection1"],
+                            "meta": {"pagination": {"offset": 0, "limit": 10, "total": 1}},
+                        },
+                    },
+                    {
+                        "status_code": 200,
+                        "body": {"resources": [{"composite_id": "detection1"}]},
+                    },
+                ]
+
+                self.module.search_detections(include_hidden=include_hidden)
+
+                query_call = self.mock_client.command.call_args_list[0]
+                self.assertEqual(query_call[0][0], "GetQueriesAlertsV2")
+                self.assertEqual(
+                    query_call[1]["parameters"].get("include_hidden"),
+                    include_hidden,
+                )
+
+    def test_search_detections_include_hidden_is_query_param_not_body(self):
+        """The hydration step must send include_hidden as a query param, not in the body.
+
+        PostEntitiesAlertsV2 declares include_hidden `in: query`; a copy in the
+        POST body is silently ignored, so asserting only that the value was
+        "passed somewhere" would not catch the bug.
+        """
+        self.mock_client.command.side_effect = [
+            {
+                "status_code": 200,
+                "body": {
+                    "resources": ["detection1"],
+                    "meta": {"pagination": {"offset": 0, "limit": 10, "total": 1}},
+                },
+            },
+            {"status_code": 200, "body": {"resources": [{"composite_id": "detection1"}]}},
+        ]
+
+        self.module.search_detections(include_hidden=False)
+
+        details_call = self.mock_client.command.call_args_list[1]
+        self.assertEqual(details_call[0][0], "PostEntitiesAlertsV2")
+        self.assertEqual(details_call[1]["parameters"], {"include_hidden": False})
+        self.assertNotIn("include_hidden", details_call[1]["body"])
 
     def test_get_detection_details_include_hidden_false(self):
         """Test getting detection details with include_hidden=False."""
@@ -297,12 +350,35 @@ class TestDetectionsModule(TestModules):
         # Verify client command was called correctly with include_hidden=False
         self.mock_client.command.assert_called_once_with(
             "PostEntitiesAlertsV2",
-            body={"composite_ids": ["detection1"], "include_hidden": False},
+            body={"composite_ids": ["detection1"]},
+            parameters={"include_hidden": False},
         )
 
         # Verify result
         expected_result = [{"id": "detection1", "name": "Test Detection 1"}]
         self.assertEqual(result, expected_result)
+
+    def test_get_detection_details_include_hidden_is_query_param_not_body(self):
+        """include_hidden must land in query parameters, never in the POST body.
+
+        PostEntitiesAlertsV2 declares it `in: query`; the API silently ignores a
+        body copy, so a test that accepts either placement reproduces the bug.
+        """
+        for include_hidden in (True, False):
+            with self.subTest(include_hidden=include_hidden):
+                self.mock_client.command.reset_mock()
+                self.mock_client.command.return_value = {
+                    "status_code": 200,
+                    "body": {"resources": [{"composite_id": "detection1"}]},
+                }
+
+                self.module.get_detection_details(
+                    ["detection1"], include_hidden=include_hidden
+                )
+
+                kwargs = self.mock_client.command.call_args[1]
+                self.assertEqual(kwargs["parameters"], {"include_hidden": include_hidden})
+                self.assertNotIn("include_hidden", kwargs["body"])
 
 
     def test_format_fql_error_response_error(self):
@@ -1393,6 +1469,38 @@ class TestDetectionsModule(TestModules):
         self.assertIsInstance(result, dict)
         self.assertIn("error", result)
         self.assertNotIn("hint", result)
+
+    def test_update_detections_omits_include_hidden(self):
+        """update_detections must not send include_hidden at all.
+
+        PatchEntitiesAlertsV3 declares the parameter, but sending False makes
+        updates to hidden alerts fail outright (live-validated: 400 "no visible
+        alert present in the update query"), which would make it impossible to
+        un-hide an alert previously hidden via show_in_ui=False. Omitting it
+        keeps the endpoint's own default.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+
+        self.module.update_detections(
+            ids=["id1"],
+            status="new",
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
+        )
+
+        kwargs = self.mock_client.command.call_args[1]
+        self.assertNotIn("parameters", kwargs)
+        self.assertNotIn("include_hidden", kwargs["body"])
 
     def test_update_detections_unassign_false_is_noop(self):
         """Test that unassign=False does not add the action parameter."""


### PR DESCRIPTION
`include_hidden` did nothing on `falcon_search_detections` and `falcon_get_detection_details`. Passing `False` still returned hidden alerts, and still counted them in `pagination.total`.

Two causes, unrelated to each other. `search_detections` never forwarded the parameter into the query step, so `GetQueriesAlertsV2` never saw it at all. And `_base_get_by_ids` folded extra kwargs into the POST body, but `PostEntitiesAlertsV2` declares `include_hidden` as a query parameter, so the API just ignored it.

`_base_get_by_ids` now takes an optional `parameters` argument for query-string options that ride alongside a POST body, same as `_base_aggregate` already does. Nothing else was passing one, so the other modules are untouched.

I left `include_hidden` off `update_detections` deliberately. `PatchEntitiesAlertsV3` declares it, but sending `False` makes updates to hidden alerts fail outright, so an alert you'd hidden via `show_in_ui=False` could never be un-hidden again. Omitting it keeps the endpoint's own default.

One test fix rides along: three `update_detections` integration tests had been skipping unconditionally ever since the pagination envelope landed, because their no-results guard read the envelope dict as an empty result. They were never reaching `PatchEntitiesAlertsV3`. Same pattern shows up in the data_protection, exclusions and policies suites; tracked separately.

Closes #482