### PR TITLE
fix(tests): unwrap the search envelope in three modules' integration guards

### DIFF
--- a/tests/integration/test_data_protection.py
+++ b/tests/integration/test_data_protection.py
@@ -35,7 +35,9 @@ class TestDataProtectionIntegration(BaseIntegrationTest):
 
     def test_search_classifications_returns_full_details(self):
         """Test that classifications include full entity details."""
-        result = self.call_method(self.module.search_data_protection_classifications, limit=2)
+        result = self._unwrap_results(
+            self.call_method(self.module.search_data_protection_classifications, limit=2)
+        )
 
         if not result or isinstance(result, dict):
             self.skip_with_warning("No classifications found", "classifications details")
@@ -96,10 +98,12 @@ class TestDataProtectionIntegration(BaseIntegrationTest):
 
     def test_search_policies_returns_full_details(self):
         """Test that policies include full entity details."""
-        result = self.call_method(
-            self.module.search_data_protection_policies,
-            platform_name="win",
-            limit=2,
+        result = self._unwrap_results(
+            self.call_method(
+                self.module.search_data_protection_policies,
+                platform_name="win",
+                limit=2,
+            )
         )
 
         if not result or isinstance(result, dict):
@@ -136,7 +140,9 @@ class TestDataProtectionIntegration(BaseIntegrationTest):
 
     def test_search_content_patterns_returns_full_details(self):
         """Test that content patterns include full entity details."""
-        result = self.call_method(self.module.search_data_protection_content_patterns, limit=2)
+        result = self._unwrap_results(
+            self.call_method(self.module.search_data_protection_content_patterns, limit=2)
+        )
 
         if not result or isinstance(result, dict):
             self.skip_with_warning("No content patterns found", "content patterns details")

--- a/tests/integration/test_exclusions.py
+++ b/tests/integration/test_exclusions.py
@@ -32,8 +32,10 @@ class TestExclusionsIntegration(BaseIntegrationTest):
 
     def _scopes_available(self, exclusion_type: str) -> bool:
         """Return True if a search for the given type does not error on scope."""
-        result = self.call_method(
-            self.module.search_exclusions, exclusion_type=exclusion_type, limit=1
+        result = self._unwrap_results(
+            self.call_method(
+                self.module.search_exclusions, exclusion_type=exclusion_type, limit=1
+            )
         )
         # A scope/permission failure surfaces as an error dict or error list.
         if isinstance(result, dict) and "error" in result:
@@ -72,10 +74,12 @@ class TestExclusionsIntegration(BaseIntegrationTest):
         mocked unit tests would pass.
         """
         for exclusion_type in ("ioa", "ml", "sensor_visibility", "certificate"):
-            result = self.call_method(
-                self.module.search_exclusions,
-                exclusion_type=exclusion_type,
-                limit=1,
+            result = self._unwrap_results(
+                self.call_method(
+                    self.module.search_exclusions,
+                    exclusion_type=exclusion_type,
+                    limit=1,
+                )
             )
             # Empty results return the FQL guide dict (acceptable); only a true
             # error indicates a bad operation name or missing scope.
@@ -105,11 +109,13 @@ class TestExclusionsIntegration(BaseIntegrationTest):
             if not self._scopes_available(exclusion_type):
                 continue
             for field in fields:
-                result = self.call_method(
-                    self.module.search_exclusions,
-                    exclusion_type=exclusion_type,
-                    sort=f"{field}.desc",
-                    limit=1,
+                result = self._unwrap_results(
+                    self.call_method(
+                        self.module.search_exclusions,
+                        exclusion_type=exclusion_type,
+                        sort=f"{field}.desc",
+                        limit=1,
+                    )
                 )
                 if isinstance(result, list) and result and isinstance(result[0], dict):
                     assert "error" not in result[0], (
@@ -141,8 +147,10 @@ class TestExclusionsIntegration(BaseIntegrationTest):
         for exclusion_type, fields in documented_filters.items():
             if not self._scopes_available(exclusion_type):
                 continue
-            entity_result = self.call_method(
-                self.module.search_exclusions, exclusion_type=exclusion_type, limit=1
+            entity_result = self._unwrap_results(
+                self.call_method(
+                    self.module.search_exclusions, exclusion_type=exclusion_type, limit=1
+                )
             )
             # Empty environment returns the FQL guide dict; nothing to assert on.
             if not entity_result or isinstance(entity_result, dict):
@@ -172,11 +180,13 @@ class TestExclusionsIntegration(BaseIntegrationTest):
                     else:
                         filter_expr = f"{field}:'{value}'"
 
-                result = self.call_method(
-                    self.module.search_exclusions,
-                    exclusion_type=exclusion_type,
-                    filter=filter_expr,
-                    limit=1,
+                result = self._unwrap_results(
+                    self.call_method(
+                        self.module.search_exclusions,
+                        exclusion_type=exclusion_type,
+                        filter=filter_expr,
+                        limit=1,
+                    )
                 )
                 assert result and not isinstance(result, dict), (
                     f"Documented filter field '{field}' returned no results for "
@@ -209,8 +219,10 @@ class TestExclusionsIntegration(BaseIntegrationTest):
         for exclusion_type, field in targets.items():
             if not self._scopes_available(exclusion_type):
                 continue
-            entities = self.call_method(
-                self.module.search_exclusions, exclusion_type=exclusion_type, limit=20
+            entities = self._unwrap_results(
+                self.call_method(
+                    self.module.search_exclusions, exclusion_type=exclusion_type, limit=20
+                )
             )
             if not entities or isinstance(entities, dict):
                 self.skip_with_warning(
@@ -241,11 +253,13 @@ class TestExclusionsIntegration(BaseIntegrationTest):
                 )
                 continue
 
-            wildcard = self.call_method(
-                self.module.search_exclusions,
-                exclusion_type=exclusion_type,
-                filter=f"{field}:*'*{substr}*'",
-                limit=1,
+            wildcard = self._unwrap_results(
+                self.call_method(
+                    self.module.search_exclusions,
+                    exclusion_type=exclusion_type,
+                    filter=f"{field}:*'*{substr}*'",
+                    limit=1,
+                )
             )
             assert wildcard and not isinstance(wildcard, dict), (
                 f"`:*` wildcard substring match returned nothing for "
@@ -264,8 +278,10 @@ class TestExclusionsIntegration(BaseIntegrationTest):
         if not self._scopes_available("ioa"):
             self.skip_with_warning("IOA Exclusions scope not available", "search ioa")
             return
-        result = self.call_method(
-            self.module.search_exclusions, exclusion_type="ioa", limit=2
+        result = self._unwrap_results(
+            self.call_method(
+                self.module.search_exclusions, exclusion_type="ioa", limit=2
+            )
         )
         if not result or isinstance(result, dict):
             self.skip_with_warning("No IOA exclusions found", "search ioa details")
@@ -279,8 +295,10 @@ class TestExclusionsIntegration(BaseIntegrationTest):
         if not self._scopes_available("ml"):
             self.skip_with_warning("ML Exclusions scope not available", "search ml")
             return
-        result = self.call_method(
-            self.module.search_exclusions, exclusion_type="ml", limit=2
+        result = self._unwrap_results(
+            self.call_method(
+                self.module.search_exclusions, exclusion_type="ml", limit=2
+            )
         )
         if not result or isinstance(result, dict):
             self.skip_with_warning("No ML exclusions found", "search ml details")
@@ -296,10 +314,12 @@ class TestExclusionsIntegration(BaseIntegrationTest):
                 "Sensor Visibility Exclusions scope not available", "search sv"
             )
             return
-        result = self.call_method(
-            self.module.search_exclusions,
-            exclusion_type="sensor_visibility",
-            limit=2,
+        result = self._unwrap_results(
+            self.call_method(
+                self.module.search_exclusions,
+                exclusion_type="sensor_visibility",
+                limit=2,
+            )
         )
         if not result or isinstance(result, dict):
             self.skip_with_warning("No SV exclusions found", "search sv details")
@@ -315,8 +335,10 @@ class TestExclusionsIntegration(BaseIntegrationTest):
                 "Certificate exclusion scope not available", "search cert"
             )
             return
-        result = self.call_method(
-            self.module.search_exclusions, exclusion_type="certificate", limit=2
+        result = self._unwrap_results(
+            self.call_method(
+                self.module.search_exclusions, exclusion_type="certificate", limit=2
+            )
         )
         if not result or isinstance(result, dict):
             self.skip_with_warning("No certificate exclusions found", "search cert")
@@ -416,8 +438,10 @@ class TestExclusionsIntegration(BaseIntegrationTest):
             self.skip_with_warning("IOA Exclusions scope not available", "ioa roundtrip")
             return
 
-        existing = self.call_method(
-            self.module.search_exclusions, exclusion_type="ioa", limit=1
+        existing = self._unwrap_results(
+            self.call_method(
+                self.module.search_exclusions, exclusion_type="ioa", limit=1
+            )
         )
         if not existing or isinstance(existing, dict):
             self.skip_with_warning(

--- a/tests/integration/test_policies.py
+++ b/tests/integration/test_policies.py
@@ -63,8 +63,10 @@ class TestPoliciesIntegration(BaseIntegrationTest):
 
     def _scopes_available(self, policy_type: str) -> bool:
         """Return True if a search for the given type does not error on scope."""
-        result = self.call_method(
-            self.module.search_policies, policy_type=policy_type, limit=1
+        result = self._unwrap_results(
+            self.call_method(
+                self.module.search_policies, policy_type=policy_type, limit=1
+            )
         )
         if isinstance(result, dict) and "error" in result:
             return False
@@ -75,8 +77,10 @@ class TestPoliciesIntegration(BaseIntegrationTest):
 
     def _first_entity(self, policy_type: str):
         """Return one policy entity for the type, or None (empty/scopeless)."""
-        result = self.call_method(
-            self.module.search_policies, policy_type=policy_type, limit=1
+        result = self._unwrap_results(
+            self.call_method(
+                self.module.search_policies, policy_type=policy_type, limit=1
+            )
         )
         if not result or isinstance(result, dict):
             return None
@@ -107,8 +111,10 @@ class TestPoliciesIntegration(BaseIntegrationTest):
                     f"{policy_type} policy scope not available", "operation names"
                 )
                 continue
-            result = self.call_method(
-                self.module.search_policies, policy_type=policy_type, limit=1
+            result = self._unwrap_results(
+                self.call_method(
+                    self.module.search_policies, policy_type=policy_type, limit=1
+                )
             )
             if isinstance(result, list) and result and isinstance(result[0], dict):
                 assert "error" not in result[0], (
@@ -121,8 +127,10 @@ class TestPoliciesIntegration(BaseIntegrationTest):
         for policy_type in POLICY_TYPES:
             if not self._scopes_available(policy_type):
                 continue
-            result = self.call_method(
-                self.module.search_policies, policy_type=policy_type, limit=2
+            result = self._unwrap_results(
+                self.call_method(
+                    self.module.search_policies, policy_type=policy_type, limit=2
+                )
             )
             if not result or isinstance(result, dict):
                 continue
@@ -144,8 +152,10 @@ class TestPoliciesIntegration(BaseIntegrationTest):
                 "Device Control Policies scope not available", "dc v2 fields"
             )
             return
-        result = self.call_method(
-            self.module.search_policies, policy_type="device_control", limit=1
+        result = self._unwrap_results(
+            self.call_method(
+                self.module.search_policies, policy_type="device_control", limit=1
+            )
         )
         if not result or isinstance(result, dict):
             self.skip_with_warning(
@@ -197,11 +207,13 @@ class TestPoliciesIntegration(BaseIntegrationTest):
                     else:
                         filter_expr = f"{field}:'{value}'"
 
-                result = self.call_method(
-                    self.module.search_policies,
-                    policy_type=policy_type,
-                    filter=filter_expr,
-                    limit=1,
+                result = self._unwrap_results(
+                    self.call_method(
+                        self.module.search_policies,
+                        policy_type=policy_type,
+                        filter=filter_expr,
+                        limit=1,
+                    )
                 )
                 assert result and not isinstance(result, dict), (
                     f"Documented filter field '{field}' returned no results for "
@@ -235,11 +247,13 @@ class TestPoliciesIntegration(BaseIntegrationTest):
                 continue
             name = entity["name"]
             filter_expr = f"name:{operator}'{name}'"
-            result = self.call_method(
-                self.module.search_policies,
-                policy_type=policy_type,
-                filter=filter_expr,
-                limit=1,
+            result = self._unwrap_results(
+                self.call_method(
+                    self.module.search_policies,
+                    policy_type=policy_type,
+                    filter=filter_expr,
+                    limit=1,
+                )
             )
             assert result and not isinstance(result, dict), (
                 f"Documented name operator '{operator}' returned nothing for "
@@ -279,11 +293,13 @@ class TestPoliciesIntegration(BaseIntegrationTest):
             policy_id = entity.get("id")
             if not policy_id:
                 continue
-            members = self.call_method(
-                self.module.search_policy_members,
-                policy_type=policy_type,
-                id=policy_id,
-                limit=1,
+            members = self._unwrap_results(
+                self.call_method(
+                    self.module.search_policy_members,
+                    policy_type=policy_type,
+                    id=policy_id,
+                    limit=1,
+                )
             )
             if not members or isinstance(members, dict):
                 continue


### PR DESCRIPTION
Fifteen integration tests across data_protection, policies, and exclusions were skipping unconditionally and reporting green. The guards read `if not result or isinstance(result, dict): skip("No X found")`, which was correct back when search tools returned a bare list and a dict meant an error. Since #470 those tools return the pagination envelope, so a dict is now exactly what success looks like and the guard fired every time. The tenant is not remotely empty — 308 classifications, 404 prevention policies, 35 IOA exclusions.

Unwrapping with `_unwrap_results` before the guard is the same fix detections got in faca09a. A few of these tests then go on to index `result[0]` or pull fields straight off the entity, which would have blown up on the envelope dict. The skip was hiding that too.

Grepping the tree turned up two things past the reported line numbers. `_scopes_available` in both policies and exclusions was treating a scope failure as available, because an FQL-error dict keeps its error inside `results` instead of at the top level. `search_policy_members` returns the envelope as well, so that guard needed the same treatment.

I also broke each test on purpose to make sure it could actually fail — stripping hydrated records down to IDs, no-oping a supplied filter, flattening the wrapped IOA create body. All 33 pass now with zero skips, up from 18 passed and 15 skipped.