### PR TITLE
feat(modules/cases): add aggregate tools for case configuration and files

### DIFF
--- a/docs/modules/cases.md
+++ b/docs/modules/cases.md
@@ -48,6 +48,96 @@ Returns the updated case record.
 
 - "Add these NGSIEM event IDs to the case as evidence"
 
+### `falcon_aggregate_case_access_tags`
+
+**Required scopes:** `Case Templates:read`
+
+Count case access tags grouped by a field.
+
+Use this to see which access tags control case visibility in your tenant
+and how many of each exist. Access tags accept a narrower field set than
+the other case aggregates — only key, id, and cid. Consult
+falcon://cases/aggregates/fql-guide before constructing filter
+expressions. Returns buckets of `label` and `count`. Requires the
+Case Templates:read scope.
+
+**Example prompts:**
+
+- "What access tags are used to restrict case visibility, and how many of each?"
+
+### `falcon_aggregate_case_file_details`
+
+**Required scopes:** `Cases:read`
+
+Report the files attached to cases, grouped and counted by a field.
+
+Use this whenever a question mentions files, attachments or screenshots
+on a case, including "what files are attached to case X" and "how many
+files does case X have" — pass the case IDs as case_ids. Case records
+from falcon_get_cases do not list attachments; their
+`analysis_results.files` field holds forensic artifacts from detections
+and is empty for cases that do have attachments. Consult
+falcon://cases/file-aggregates/fql-guide before constructing filter
+expressions. Returns buckets of `label` and `count`. Requires the
+Cases:read scope.
+
+**Example prompts:**
+
+- "What file names show up most often across case attachments?"
+- "How many files are attached to these two cases?"
+
+### `falcon_aggregate_case_notification_groups`
+
+**Required scopes:** `Case Templates:read`
+
+Count case notification groups grouped by a field.
+
+Use this to summarize the notification groups that receive case updates,
+such as how many are configured or who created them. Consult
+falcon://cases/aggregates/fql-guide before constructing filter
+expressions. Returns buckets of `label` and `count`. Requires the
+Case Templates:read scope.
+
+**Example prompts:**
+
+- "How many case notification groups are configured?"
+- "Show notification group counts by creator"
+
+### `falcon_aggregate_case_slas`
+
+**Required scopes:** `Case Templates:read`
+
+Count case SLA definitions grouped by a field.
+
+Use this to summarize the SLA policies configured in your tenant — for
+example how many exist, or who created them — rather than to list them
+individually. Consult falcon://cases/aggregates/fql-guide before
+constructing filter expressions. Returns buckets of `label` and `count`.
+Requires the Case Templates:read scope.
+
+**Example prompts:**
+
+- "How many case SLA policies do we have?"
+- "Break down our case SLAs by who created them"
+
+### `falcon_aggregate_case_templates`
+
+**Required scopes:** `Case Templates:read`
+
+Count case templates grouped by a field.
+
+Use this to summarize the case templates configured in your tenant, such
+as how many exist or which users author them; falcon_list_case_templates
+returns the individual template records instead. Consult
+falcon://cases/aggregates/fql-guide before constructing filter
+expressions. Returns buckets of `label` and `count`. Requires the
+Case Templates:read scope.
+
+**Example prompts:**
+
+- "How many case templates has each person created?"
+- "Count the case templates added in the last 30 days"
+
 ### `falcon_create_case`
 
 > [!NOTE]
@@ -73,8 +163,11 @@ created case record.
 Retrieve details for case IDs you already have.
 
 Use when you have specific case IDs from search results or external
-references. For discovering cases by criteria, use falcon_search_cases
-instead. Returns full case records.
+references. For discovering cases by criteria, use falcon_search_cases;
+for files attached to a case, use falcon_aggregate_case_file_details.
+Returns full case records. Their `analysis_results.files` field lists
+forensic artifacts from detections, not attachments, and is empty for
+cases that do have attachments.
 
 **Example prompts:**
 
@@ -149,3 +242,5 @@ updated case record with incremented version.
 ## Resources
 
 - **`falcon://cases/search/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_cases` tool.
+- **`falcon://cases/aggregates/fql-guide`**: Contains the guide for the `filter` param of the `falcon_aggregate_case_slas`, `falcon_aggregate_case_templates`, `falcon_aggregate_case_access_tags`, and `falcon_aggregate_case_notification_groups` tools.
+- **`falcon://cases/file-aggregates/fql-guide`**: Contains the guide for the `filter` param of the `falcon_aggregate_case_file_details` tool.

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -152,6 +152,12 @@ API_SCOPE_REQUIREMENTS = {
     # Case Templates operations
     "queries_templates_get_v1": ["Case Templates:read"],
     "entities_templates_get_v1": ["Case Templates:read"],
+    # Case Management aggregate operations
+    "aggregates_slas_post_v1": ["Case Templates:read"],
+    "aggregates_templates_post_v1": ["Case Templates:read"],
+    "aggregates_access_tags_post_v1": ["Case Templates:read"],
+    "aggregates_notification_groups_post_v2": ["Case Templates:read"],
+    "aggregates_file_details_post_v1": ["Cases:read"],
     # Correlation Rules operations
     "combined_rules_get_v2": ["Correlation Rules:read"],
     "entities_rules_post_v1": ["Correlation Rules:write"],

--- a/falcon_mcp/filter_hints.py
+++ b/falcon_mcp/filter_hints.py
@@ -42,6 +42,39 @@ FILTER_HINTS: dict[str, str] = {
         "severity (Integer 1-100: Informational=1, Low~25, Medium~50, High~75, Critical=100), "
         "name, assigned_to_name, created_timestamp (UTC datetime), tags."
     ),
+    "falcon_aggregate_case_slas": (
+        "Common fields: name, id, cid, created_by_name, updated_by_name, "
+        "created_timestamp, updated_timestamp. "
+        "Substring match uses :* (name:*'*Corp*'); ~ and 'val*' return nothing. "
+        "Date filters: created_timestamp:>'now-30d' (relative). "
+        "Ex: created_timestamp:>'now-30d'"
+    ),
+    "falcon_aggregate_case_templates": (
+        "Common fields: name, id, cid, created_by_name, updated_by_name, "
+        "created_timestamp, updated_timestamp. "
+        "Substring match uses :* (name:*'*Case*'); ~ and 'val*' return nothing. "
+        "Date filters: created_timestamp:>'now-30d' (relative). "
+        "Ex: created_by_name:'analyst@example.com'"
+    ),
+    "falcon_aggregate_case_access_tags": (
+        "Common fields: key, id, cid — access tags accept no other field. "
+        "Substring match uses :* (key:*'*ANALYST*'); ~ and 'val*' return nothing. "
+        "Ex: key:'ANALYST1'"
+    ),
+    "falcon_aggregate_case_notification_groups": (
+        "Common fields: name, id, cid, created_by_name, updated_by_name, "
+        "created_timestamp, updated_timestamp. "
+        "Substring match uses :* (name:*'*Analyst*'); ~ and 'val*' return nothing. "
+        "Date filters: created_timestamp:>'now-90d' (relative). "
+        "Ex: name:*'*Analyst*'"
+    ),
+    "falcon_aggregate_case_file_details": (
+        "Common fields: name (file name), case_id, id (file id), cid, "
+        "file_size (a string such as '114.8 KB', not a number). "
+        "Substring match uses :* (name:*'*.png'); ~ returns nothing. "
+        "Prefer the case_ids parameter over a case_id filter. "
+        "Ex: name:*'*.png'"
+    ),
     # === Cloud: Kubernetes Containers ===
     "falcon_search_kubernetes_containers": (
         "Common fields: cluster_name, namespace, container_name, "

--- a/falcon_mcp/modules/cases.py
+++ b/falcon_mcp/modules/cases.py
@@ -5,7 +5,7 @@ This module provides tools for managing CrowdStrike cases, including searching,
 creating, updating, and managing evidence and tags.
 """
 
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
@@ -15,9 +15,38 @@ from pydantic import AnyUrl, Field
 from falcon_mcp.common.errors import _format_error_response
 from falcon_mcp.common.logging import get_logger
 from falcon_mcp.modules.base import BaseModule
-from falcon_mcp.resources.cases import SEARCH_CASES_FQL_DOCUMENTATION
+from falcon_mcp.resources.cases import (
+    AGGREGATE_CASE_CONFIG_FQL_DOCUMENTATION,
+    AGGREGATE_CASE_FILE_DETAILS_FQL_DOCUMENTATION,
+    SEARCH_CASES_FQL_DOCUMENTATION,
+)
 
 logger = get_logger(__name__)
+
+
+def _is_filter_error(error: dict[str, Any]) -> bool:
+    """Report whether an aggregate error blames the FQL filter.
+
+    Reads the API's own messages rather than the assembled error string, which
+    carries generic filter-syntax advice on every 400.
+
+    Args:
+        error: An error dict from `_base_aggregate`
+
+    Returns:
+        True when a message points at the filter rather than at the
+        aggregation field or type
+    """
+    details = error.get("details")
+    body = details.get("body") if isinstance(details, dict) else None
+    api_errors = body.get("errors") if isinstance(body, dict) else None
+    if not isinstance(api_errors, list):
+        return False
+    return any(
+        "filter" in str(item.get("message", "")).lower()
+        for item in api_errors
+        if isinstance(item, dict)
+    )
 
 
 class CasesModule(BaseModule):
@@ -95,6 +124,31 @@ class CasesModule(BaseModule):
             method=self.list_case_templates,
             name="list_case_templates",
         )
+        self._add_tool(
+            server=server,
+            method=self.aggregate_case_slas,
+            name="aggregate_case_slas",
+        )
+        self._add_tool(
+            server=server,
+            method=self.aggregate_case_templates,
+            name="aggregate_case_templates",
+        )
+        self._add_tool(
+            server=server,
+            method=self.aggregate_case_access_tags,
+            name="aggregate_case_access_tags",
+        )
+        self._add_tool(
+            server=server,
+            method=self.aggregate_case_notification_groups,
+            name="aggregate_case_notification_groups",
+        )
+        self._add_tool(
+            server=server,
+            method=self.aggregate_case_file_details,
+            name="aggregate_case_file_details",
+        )
 
     def register_resources(self, server: FastMCP) -> None:
         resource = TextResource(
@@ -104,6 +158,32 @@ class CasesModule(BaseModule):
             text=SEARCH_CASES_FQL_DOCUMENTATION,
         )
         self._add_resource(server, resource)
+        self._add_resource(
+            server,
+            TextResource(
+                uri=AnyUrl("falcon://cases/aggregates/fql-guide"),
+                name="falcon_aggregate_case_config_fql_guide",
+                description=(
+                    "Contains the guide for the `filter` param of the "
+                    "`falcon_aggregate_case_slas`, `falcon_aggregate_case_templates`, "
+                    "`falcon_aggregate_case_access_tags`, and "
+                    "`falcon_aggregate_case_notification_groups` tools."
+                ),
+                text=AGGREGATE_CASE_CONFIG_FQL_DOCUMENTATION,
+            ),
+        )
+        self._add_resource(
+            server,
+            TextResource(
+                uri=AnyUrl("falcon://cases/file-aggregates/fql-guide"),
+                name="falcon_aggregate_case_file_details_fql_guide",
+                description=(
+                    "Contains the guide for the `filter` param of the "
+                    "`falcon_aggregate_case_file_details` tool."
+                ),
+                text=AGGREGATE_CASE_FILE_DETAILS_FQL_DOCUMENTATION,
+            ),
+        )
 
     def search_cases(
         self,
@@ -181,8 +261,11 @@ class CasesModule(BaseModule):
         """Retrieve details for case IDs you already have.
 
         Use when you have specific case IDs from search results or external
-        references. For discovering cases by criteria, use falcon_search_cases
-        instead. Returns full case records.
+        references. For discovering cases by criteria, use falcon_search_cases;
+        for files attached to a case, use falcon_aggregate_case_file_details.
+        Returns full case records. Their `analysis_results.files` field lists
+        forensic artifacts from detections, not attachments, and is empty for
+        cases that do have attachments.
         """
         return self._base_get_by_ids(
             operation="entities_cases_post_v2",
@@ -510,3 +593,347 @@ class CasesModule(BaseModule):
 
         # Preserve the query-step order in case the details endpoint reorders results.
         return self._reorder_by_ids(template_ids, details, id_field="id")
+
+    def _aggregate_case_config(
+        self,
+        operation: str,
+        entity: str,
+        agg_type: Literal["terms", "date_range"],
+        field: str,
+        filter: str | None,
+        size: int | None,
+        from_: int | None,
+        date_ranges: list[dict[str, Any]] | None,
+        name: str | None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Run one aggregation against a /casemgmt/aggregates/* endpoint.
+
+        These four endpoints share the reduced `api.MSAAggregateQueryRequest`
+        dialect, so they differ only in operation name and which fields they
+        accept.
+        """
+        result = self._base_aggregate(
+            operation=operation,
+            agg_type=agg_type,
+            field=field,
+            filter=filter,
+            size=size,
+            from_=from_,
+            date_ranges=date_ranges,
+            name=name,
+            error_message=f"Failed to aggregate case {entity}",
+        )
+
+        # Only a filter problem is worth answering with the FQL guide; an
+        # unsupported aggregation field or type is a different fix.
+        if self._is_error(result):
+            if _is_filter_error(result):
+                return self._format_fql_error_response(
+                    [result], filter, AGGREGATE_CASE_CONFIG_FQL_DOCUMENTATION
+                )
+            return [result]
+
+        return result
+
+    def aggregate_case_slas(
+        self,
+        field: str = Field(
+            description="Field to aggregate on. Supported: name, id, cid, created_by_name, updated_by_name, created_timestamp, updated_timestamp.",
+            examples=["name", "created_by_name"],
+        ),
+        agg_type: Literal["terms", "date_range"] = Field(
+            default="terms",
+            description="Aggregation type. 'terms' counts records per distinct value; 'date_range' counts records per date_ranges bucket.",
+        ),
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter expression. See `falcon://cases/aggregates/fql-guide` for syntax.",
+            examples=["created_timestamp:>'now-30d'", "name:*'*Corp*'"],
+        ),
+        size: int | None = Field(
+            default=None,
+            ge=1,
+            description="Maximum number of buckets to return. Omit for all buckets.",
+        ),
+        from_: int | None = Field(
+            default=None,
+            ge=0,
+            description="Bucket offset, for paging through a large bucket list.",
+        ),
+        date_ranges: list[dict[str, Any]] | None = Field(
+            default=None,
+            description="Date buckets for agg_type='date_range', each {'from': ISO8601, 'to': ISO8601}.",
+        ),
+        name: str | None = Field(
+            default=None,
+            description="Label echoed back on the result to identify this aggregation.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Count case SLA definitions grouped by a field.
+
+        Use this to summarize the SLA policies configured in your tenant — for
+        example how many exist, or who created them — rather than to list them
+        individually. Consult falcon://cases/aggregates/fql-guide before
+        constructing filter expressions. Returns buckets of `label` and `count`.
+        Requires the Case Templates:read scope.
+        """
+        return self._aggregate_case_config(
+            operation="aggregates_slas_post_v1",
+            entity="SLAs",
+            agg_type=agg_type,
+            field=field,
+            filter=filter,
+            size=size,
+            from_=from_,
+            date_ranges=date_ranges,
+            name=name,
+        )
+
+    def aggregate_case_templates(
+        self,
+        field: str = Field(
+            description="Field to aggregate on. Supported: name, id, cid, created_by_name, updated_by_name, created_timestamp, updated_timestamp.",
+            examples=["name", "created_by_name"],
+        ),
+        agg_type: Literal["terms", "date_range"] = Field(
+            default="terms",
+            description="Aggregation type. 'terms' counts records per distinct value; 'date_range' counts records per date_ranges bucket.",
+        ),
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter expression. See `falcon://cases/aggregates/fql-guide` for syntax.",
+            examples=["created_timestamp:>'now-30d'", "created_by_name:'analyst@example.com'"],
+        ),
+        size: int | None = Field(
+            default=None,
+            ge=1,
+            description="Maximum number of buckets to return. Omit for all buckets.",
+        ),
+        from_: int | None = Field(
+            default=None,
+            ge=0,
+            description="Bucket offset, for paging through a large bucket list.",
+        ),
+        date_ranges: list[dict[str, Any]] | None = Field(
+            default=None,
+            description="Date buckets for agg_type='date_range', each {'from': ISO8601, 'to': ISO8601}.",
+        ),
+        name: str | None = Field(
+            default=None,
+            description="Label echoed back on the result to identify this aggregation.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Count case templates grouped by a field.
+
+        Use this to summarize the case templates configured in your tenant, such
+        as how many exist or which users author them; falcon_list_case_templates
+        returns the individual template records instead. Consult
+        falcon://cases/aggregates/fql-guide before constructing filter
+        expressions. Returns buckets of `label` and `count`. Requires the
+        Case Templates:read scope.
+        """
+        return self._aggregate_case_config(
+            operation="aggregates_templates_post_v1",
+            entity="templates",
+            agg_type=agg_type,
+            field=field,
+            filter=filter,
+            size=size,
+            from_=from_,
+            date_ranges=date_ranges,
+            name=name,
+        )
+
+    def aggregate_case_access_tags(
+        self,
+        field: str = Field(
+            description="Field to aggregate on. Access tags support only: key, id, cid.",
+            examples=["key"],
+        ),
+        agg_type: Literal["terms", "date_range"] = Field(
+            default="terms",
+            description="Aggregation type. 'terms' counts records per distinct value; 'date_range' counts records per date_ranges bucket.",
+        ),
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter expression. See `falcon://cases/aggregates/fql-guide` for syntax.",
+            examples=["key:'ANALYST1'", "key:*'*ANALYST*'"],
+        ),
+        size: int | None = Field(
+            default=None,
+            ge=1,
+            description="Maximum number of buckets to return. Omit for all buckets.",
+        ),
+        from_: int | None = Field(
+            default=None,
+            ge=0,
+            description="Bucket offset, for paging through a large bucket list.",
+        ),
+        date_ranges: list[dict[str, Any]] | None = Field(
+            default=None,
+            description="Date buckets for agg_type='date_range', each {'from': ISO8601, 'to': ISO8601}.",
+        ),
+        name: str | None = Field(
+            default=None,
+            description="Label echoed back on the result to identify this aggregation.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Count case access tags grouped by a field.
+
+        Use this to see which access tags control case visibility in your tenant
+        and how many of each exist. Access tags accept a narrower field set than
+        the other case aggregates — only key, id, and cid. Consult
+        falcon://cases/aggregates/fql-guide before constructing filter
+        expressions. Returns buckets of `label` and `count`. Requires the
+        Case Templates:read scope.
+        """
+        return self._aggregate_case_config(
+            operation="aggregates_access_tags_post_v1",
+            entity="access tags",
+            agg_type=agg_type,
+            field=field,
+            filter=filter,
+            size=size,
+            from_=from_,
+            date_ranges=date_ranges,
+            name=name,
+        )
+
+    def aggregate_case_notification_groups(
+        self,
+        field: str = Field(
+            description="Field to aggregate on. Supported: name, id, cid, created_by_name, updated_by_name, created_timestamp, updated_timestamp.",
+            examples=["name", "created_by_name"],
+        ),
+        agg_type: Literal["terms", "date_range"] = Field(
+            default="terms",
+            description="Aggregation type. 'terms' counts records per distinct value; 'date_range' counts records per date_ranges bucket.",
+        ),
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter expression. See `falcon://cases/aggregates/fql-guide` for syntax.",
+            examples=["name:*'*Analyst*'", "created_timestamp:>'now-90d'"],
+        ),
+        size: int | None = Field(
+            default=None,
+            ge=1,
+            description="Maximum number of buckets to return. Omit for all buckets.",
+        ),
+        from_: int | None = Field(
+            default=None,
+            ge=0,
+            description="Bucket offset, for paging through a large bucket list.",
+        ),
+        date_ranges: list[dict[str, Any]] | None = Field(
+            default=None,
+            description="Date buckets for agg_type='date_range', each {'from': ISO8601, 'to': ISO8601}.",
+        ),
+        name: str | None = Field(
+            default=None,
+            description="Label echoed back on the result to identify this aggregation.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Count case notification groups grouped by a field.
+
+        Use this to summarize the notification groups that receive case updates,
+        such as how many are configured or who created them. Consult
+        falcon://cases/aggregates/fql-guide before constructing filter
+        expressions. Returns buckets of `label` and `count`. Requires the
+        Case Templates:read scope.
+        """
+        return self._aggregate_case_config(
+            operation="aggregates_notification_groups_post_v2",
+            entity="notification groups",
+            agg_type=agg_type,
+            field=field,
+            filter=filter,
+            size=size,
+            from_=from_,
+            date_ranges=date_ranges,
+            name=name,
+        )
+
+    def aggregate_case_file_details(
+        self,
+        field: str = Field(
+            description="Field to aggregate on. Supported: name, case_id, id, cid, file_size (a human-readable string such as '114.8 KB').",
+            examples=["name", "case_id"],
+        ),
+        agg_type: Literal["terms", "date_range"] = Field(
+            default="terms",
+            description="Aggregation type. 'terms' counts files per distinct value; 'date_range' counts files per date_ranges bucket.",
+        ),
+        case_ids: list[str] | None = Field(
+            default=None,
+            description="Case ID(s) to restrict the aggregation to. Omit to aggregate files across all cases.",
+        ),
+        filter: str | None = Field(
+            default=None,
+            description="FQL filter expression. See `falcon://cases/file-aggregates/fql-guide` for syntax.",
+            examples=["name:*'*.png'"],
+        ),
+        size: int | None = Field(
+            default=None,
+            ge=1,
+            description="Maximum number of buckets to return. Omit for all buckets.",
+        ),
+        from_: int | None = Field(
+            default=None,
+            ge=0,
+            description="Bucket offset, for paging through a large bucket list.",
+        ),
+        date_ranges: list[dict[str, Any]] | None = Field(
+            default=None,
+            description="Date buckets for agg_type='date_range', each {'from': ISO8601, 'to': ISO8601}.",
+        ),
+        name: str | None = Field(
+            default=None,
+            description="Label echoed back on the result to identify this aggregation.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Report the files attached to cases, grouped and counted by a field.
+
+        Use this whenever a question mentions files, attachments or screenshots
+        on a case, including "what files are attached to case X" and "how many
+        files does case X have" — pass the case IDs as case_ids. Case records
+        from falcon_get_cases do not list attachments; their
+        `analysis_results.files` field holds forensic artifacts from detections
+        and is empty for cases that do have attachments. Consult
+        falcon://cases/file-aggregates/fql-guide before constructing filter
+        expressions. Returns buckets of `label` and `count`. Requires the
+        Cases:read scope.
+        """
+        # The endpoint's `ids` query parameter does not narrow the result set
+        # (live-validated), so case scoping is expressed as a case_id filter,
+        # which does. `ids` is still sent because the API marks it required.
+        scoped_filter = filter
+        if case_ids:
+            id_list = ",".join(f"'{case_id}'" for case_id in case_ids)
+            scope = f"case_id:[{id_list}]"
+            # The caller's filter is parenthesized so an OR inside it cannot
+            # widen the result beyond the requested cases.
+            scoped_filter = f"{scope}+({filter})" if filter else scope
+
+        result = self._base_aggregate(
+            operation="aggregates_file_details_post_v1",
+            agg_type=agg_type,
+            field=field,
+            filter=scoped_filter,
+            size=size,
+            from_=from_,
+            date_ranges=date_ranges,
+            name=name,
+            error_message="Failed to aggregate case file details",
+            parameters={"ids": case_ids} if case_ids else None,
+        )
+
+        if self._is_error(result):
+            if _is_filter_error(result):
+                return self._format_fql_error_response(
+                    [result],
+                    scoped_filter,
+                    AGGREGATE_CASE_FILE_DETAILS_FQL_DOCUMENTATION,
+                )
+            return [result]
+
+        return result

--- a/falcon_mcp/resources/cases.py
+++ b/falcon_mcp/resources/cases.py
@@ -304,3 +304,203 @@ assigned_to_uuid:!'*'+severity:>70
 # Cases with cloud evidence
 cloud_providers:'aws'+status:'new'
 """
+
+
+# The four /casemgmt/aggregates/* endpoints share one filterable field set, except
+# access-tags, which accepts only id, cid, and key (live-validated 2026-07-28).
+AGGREGATE_CASE_CONFIG_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Description",
+    ),
+    (
+        "name",
+        "String",
+        """
+        Display name of the SLA, template, or notification group.
+        Not available on access tags. Exact match or `:*` substring.
+        Ex: 'BarelyTea Corp SLA'
+        """,
+    ),
+    (
+        "key",
+        "String",
+        """
+        Access tag key. Access tags only.
+        Ex: 'ANALYST1'
+        """,
+    ),
+    (
+        "id",
+        "String",
+        "Unique identifier of the record.",
+    ),
+    (
+        "cid",
+        "String",
+        "Customer ID owning the record.",
+    ),
+    (
+        "created_by_name",
+        "String",
+        """
+        Username that created the record. Not available on access tags.
+        Ex: 'analyst@example.com'
+        """,
+    ),
+    (
+        "updated_by_name",
+        "String",
+        """
+        Username that last updated the record. Not available on access tags.
+        Ex: 'analyst@example.com'
+        """,
+    ),
+    (
+        "created_timestamp",
+        "Timestamp",
+        """
+        Creation time (UTC). Not available on access tags.
+        Ex: >'now-30d' or >'2026-01-01T00:00:00Z'
+        """,
+    ),
+    (
+        "updated_timestamp",
+        "Timestamp",
+        """
+        Last update time (UTC). Not available on access tags.
+        Ex: >'now-7d'
+        """,
+    ),
+]
+
+AGGREGATE_CASE_CONFIG_FQL_DOCUMENTATION = (
+    r"""Falcon Query Language (FQL) - Case Configuration Aggregates Guide
+
+Filters the records counted by falcon_aggregate_case_slas,
+falcon_aggregate_case_templates, falcon_aggregate_case_access_tags, and
+falcon_aggregate_case_notification_groups. These endpoints aggregate case
+*configuration* objects, not cases themselves — to filter cases, see
+falcon://cases/search/fql-guide.
+
+=== OPERATORS (live-validated) ===
+
+Exact match:      name:'BarelyTea Corp SLA'
+Substring match:  name:*'*Corp*'
+Comparison:       created_timestamp:>'now-30d'
+AND:              name:*'*SLA*'+created_timestamp:>'now-90d'
+OR:               name:'Analyst 1',name:'Analyst 2'
+
+`~` (contains) and a trailing wildcard inside quotes ('Corp*') return no results on
+these endpoints — use `:*` for substring matching.
+
+An unsupported filter field returns an error naming the problem rather than an empty
+result, so a failed filter is visible rather than silent.
+
+=== AVAILABLE FIELDS ===
+
+"""
+    + generate_md_table(AGGREGATE_CASE_CONFIG_FQL_FILTERS)
+    + r"""
+Access tags accept only `id`, `cid`, and `key`. The other endpoints accept every
+field except `key`.
+
+=== EXAMPLES ===
+
+# Templates created in the last 30 days
+created_timestamp:>'now-30d'
+
+# Notification groups whose name mentions an analyst
+name:*'*Analyst*'
+
+# Records created by a specific user
+created_by_name:'analyst@example.com'
+
+# Access tags for a given key
+key:'ANALYST1'
+"""
+)
+
+
+AGGREGATE_CASE_FILE_DETAILS_FQL_FILTERS = [
+    (
+        "Name",
+        "Type",
+        "Description",
+    ),
+    (
+        "name",
+        "String",
+        """
+        File name of the attachment, including extension.
+        Ex: *'*.png'
+        """,
+    ),
+    (
+        "case_id",
+        "String",
+        """
+        ID of the case the file is attached to. Prefer the case_ids parameter,
+        which builds this filter for you.
+        Ex: '019f449a-558e-71ea-ba8f-106d7b265036'
+        """,
+    ),
+    (
+        "id",
+        "String",
+        "Unique identifier of the file itself.",
+    ),
+    (
+        "cid",
+        "String",
+        "Customer ID owning the file.",
+    ),
+    (
+        "file_size",
+        "String",
+        """
+        Human-readable file size, not a number — compare it as a string.
+        Ex: '114.8 KB'
+        """,
+    ),
+]
+
+AGGREGATE_CASE_FILE_DETAILS_FQL_DOCUMENTATION = (
+    r"""Falcon Query Language (FQL) - Case File Aggregates Guide
+
+Filters the files counted by falcon_aggregate_case_file_details. This aggregates
+files uploaded to cases, not the cases themselves — to filter cases, see
+falcon://cases/search/fql-guide.
+
+These are uploaded attachments. They are distinct from a case record's
+`analysis_results.files`, which lists forensic artifacts (malware paths and
+hashes) observed in detections; that field is empty for cases that do have
+attachments, so it cannot be used to answer questions about them.
+
+=== OPERATORS (live-validated) ===
+
+Exact match:      name:'report.pdf'
+Substring match:  name:*'*.png'
+AND:              case_id:'019f449a-558e-71ea-ba8f-106d7b265036'+name:*'*.png'
+OR:               name:*'*.png',name:*'*.jpg'
+
+`~` (contains) returns no results here — use `:*` for substring matching.
+
+=== AVAILABLE FIELDS ===
+
+"""
+    + generate_md_table(AGGREGATE_CASE_FILE_DETAILS_FQL_FILTERS)
+    + r"""
+=== EXAMPLES ===
+
+# Screenshots attached to any case
+name:*'*.png'
+
+# Files on one specific case
+case_id:'019f449a-558e-71ea-ba8f-106d7b265036'
+
+# PDFs or Word documents
+name:*'*.pdf',name:*'*.docx'
+"""
+)

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -94,6 +94,25 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     "falcon_list_case_templates": [
         "What case templates are available?",
     ],
+    "falcon_aggregate_case_slas": [
+        "How many case SLA policies do we have?",
+        "Break down our case SLAs by who created them",
+    ],
+    "falcon_aggregate_case_templates": [
+        "How many case templates has each person created?",
+        "Count the case templates added in the last 30 days",
+    ],
+    "falcon_aggregate_case_access_tags": [
+        "What access tags are used to restrict case visibility, and how many of each?",
+    ],
+    "falcon_aggregate_case_notification_groups": [
+        "How many case notification groups are configured?",
+        "Show notification group counts by creator",
+    ],
+    "falcon_aggregate_case_file_details": [
+        "What file names show up most often across case attachments?",
+        "How many files are attached to these two cases?",
+    ],
     # Correlation Rules
     "falcon_search_correlation_rules": [
         "Show me all active high-severity correlation rules",

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -57,9 +57,10 @@ class TestCasesIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_cases")
         self.assert_valid_list_response(result, min_length=0, context="search_cases")
 
-        if len(result) > 0:
+        cases = self._unwrap_results(result)
+        if len(cases) > 0:
             self.assert_search_returns_details(
-                result,
+                cases,
                 expected_fields=["id", "name", "status", "severity"],
                 context="search_cases full details",
             )
@@ -109,7 +110,9 @@ class TestCasesIntegration(BaseIntegrationTest):
 
     def test_get_cases_with_valid_id(self):
         """Test get_cases with a valid case ID from search."""
-        search_result = self.call_method(self.module.search_cases, limit=1)
+        search_result = self._unwrap_results(
+            self.call_method(self.module.search_cases, limit=1)
+        )
 
         if not search_result or len(search_result) == 0:
             self.skip_with_warning(

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -272,3 +272,227 @@ class TestCasesIntegration(BaseIntegrationTest):
         )
 
         self.assert_no_error(result, context="FQL combined filter")
+
+    # -------------------------------------------------------------------------
+    # Aggregate Tests
+    # -------------------------------------------------------------------------
+
+    AGGREGATE_METHODS = (
+        ("aggregate_case_slas", "name"),
+        ("aggregate_case_templates", "name"),
+        ("aggregate_case_access_tags", "key"),
+        ("aggregate_case_notification_groups", "name"),
+    )
+
+    def _aggregate(self, method_name, **kwargs):
+        """Call an aggregate tool with every optional argument defaulted."""
+        defaults = {
+            "agg_type": "terms",
+            "filter": None,
+            "size": None,
+            "from_": None,
+            "date_ranges": None,
+            "name": None,
+        }
+        if method_name == "aggregate_case_file_details":
+            defaults["case_ids"] = None
+        defaults.update(kwargs)
+        return self.call_method(getattr(self.module, method_name), **defaults)
+
+    def test_operation_names_aggregates(self):
+        """Validate the four /casemgmt/aggregates operation names are correct."""
+        for method_name, field in self.AGGREGATE_METHODS:
+            result = self._aggregate(method_name, field=field)
+            self.assert_no_error(result, context=f"{method_name} operation name")
+
+    def test_operation_name_aggregate_file_details(self):
+        """Validate aggregates_file_details_post_v1 is correct."""
+        result = self._aggregate("aggregate_case_file_details", field="name")
+        self.assert_no_error(
+            result, context="aggregate_case_file_details operation name"
+        )
+
+    def test_aggregates_return_labeled_buckets(self):
+        """Test that aggregates return buckets keyed on label and count."""
+        for method_name, field in self.AGGREGATE_METHODS:
+            result = self._aggregate(method_name, field=field, name="probe")
+
+            self.assert_no_error(result, context=f"{method_name} buckets")
+            assert isinstance(result, list), f"{method_name} should return a list"
+            if not result:
+                self.skip_with_warning(
+                    f"No aggregate resources for {method_name}", "bucket shape"
+                )
+                continue
+
+            assert result[0].get("name") == "probe", (
+                f"{method_name} should echo the aggregation name back"
+            )
+            for bucket in result[0].get("buckets") or []:
+                assert "label" in bucket, f"{method_name} bucket missing label"
+                assert "count" in bucket, f"{method_name} bucket missing count"
+
+    def test_aggregate_size_limits_buckets(self):
+        """Test that size actually caps the number of buckets returned."""
+        unbounded = self._aggregate("aggregate_case_templates", field="name")
+        self.assert_no_error(unbounded, context="templates unbounded")
+
+        if not unbounded or len(unbounded[0].get("buckets") or []) < 2:
+            self.skip_with_warning("Fewer than 2 template buckets", "size limit")
+            return
+
+        limited = self._aggregate("aggregate_case_templates", field="name", size=1)
+        self.assert_no_error(limited, context="templates size=1")
+        assert len(limited[0]["buckets"]) == 1, "size=1 should return exactly 1 bucket"
+
+    def test_aggregate_access_tags_supports_key_only(self):
+        """Test the access-tags field set: key works, name is rejected.
+
+        Access tags accept a narrower field set than the other case aggregates,
+        so a shared field list would silently break this tool.
+        """
+        ok = self._aggregate("aggregate_case_access_tags", field="key")
+        self.assert_no_error(ok, context="access tags field=key")
+
+        rejected = self._aggregate("aggregate_case_access_tags", field="name")
+        assert isinstance(rejected, list) and "error" in rejected[0], (
+            "access tags should reject field=name with an error"
+        )
+
+    def test_aggregate_unsupported_field_returns_error(self):
+        """Test that an unsupported aggregation field errors rather than returning empty.
+
+        These endpoints validate the field server-side, so a typo is visible
+        instead of silently producing zero buckets.
+        """
+        result = self._aggregate("aggregate_case_templates", field="not_a_real_field")
+
+        assert isinstance(result, list), "unsupported field should return a list"
+        assert "error" in result[0], "unsupported field should return an error"
+        # The FQL guide documents the filter param, not the aggregation field.
+        assert "fql_guide" not in result[0], (
+            "a field error should not be reported as a filter problem"
+        )
+
+    def test_aggregate_bad_filter_returns_fql_guide(self):
+        """Test that an unsupported filter field surfaces the FQL guide."""
+        result = self._aggregate(
+            "aggregate_case_templates", field="name", filter="not_a_real_field:'x'"
+        )
+
+        assert isinstance(result, dict), "filter error should return a dict"
+        assert "fql_guide" in result, "filter error should attach the FQL guide"
+
+    def test_aggregate_date_range_type(self):
+        """Test that agg_type='date_range' returns range buckets."""
+        result = self._aggregate(
+            "aggregate_case_templates",
+            field="created_timestamp",
+            agg_type="date_range",
+            date_ranges=[
+                {"from": "2025-01-01T00:00:00Z", "to": "2030-01-01T00:00:00Z"}
+            ],
+        )
+
+        self.assert_no_error(result, context="templates date_range")
+        if not result:
+            self.skip_with_warning("No date_range resources", "date_range shape")
+            return
+        buckets = result[0].get("buckets") or []
+        assert buckets, "date_range should return at least one bucket"
+        assert "count" in buckets[0], "date_range bucket missing count"
+
+    def test_aggregate_fql_filter_narrows_results(self):
+        """Test that a documented FQL filter genuinely reduces the aggregated count.
+
+        Guards the FQL guide: an unsupported filter field or operator would leave
+        the count unchanged or error, either of which fails here.
+        """
+        unfiltered = self._aggregate("aggregate_case_templates", field="name")
+        self.assert_no_error(unfiltered, context="templates unfiltered")
+
+        buckets = (unfiltered[0].get("buckets") or []) if unfiltered else []
+        if len(buckets) < 2:
+            self.skip_with_warning("Fewer than 2 template buckets", "FQL narrowing")
+            return
+
+        target = buckets[0]["label"]
+        filtered = self._aggregate(
+            "aggregate_case_templates", field="name", filter=f"name:'{target}'"
+        )
+        self.assert_no_error(filtered, context="templates name filter")
+        assert filtered, "filter on a known name should return a resource"
+        assert len(filtered[0].get("buckets") or []) < len(buckets), (
+            "filtering on one known name should return fewer buckets than unfiltered"
+        )
+
+    def test_aggregate_substring_operator(self):
+        """Test that the documented :* substring operator returns results.
+
+        The guide documents `:*` rather than `~` or a quoted trailing wildcard;
+        this asserts the documented form is the one that works.
+        """
+        unfiltered = self._aggregate("aggregate_case_templates", field="name")
+        buckets = (unfiltered[0].get("buckets") or []) if unfiltered else []
+        if not buckets:
+            self.skip_with_warning("No template buckets", "substring operator")
+            return
+
+        fragment = str(buckets[0]["label"])[:3]
+        result = self._aggregate(
+            "aggregate_case_templates", field="name", filter=f"name:*'*{fragment}*'"
+        )
+
+        self.assert_no_error(result, context="templates :* substring")
+        assert result and (result[0].get("buckets") or []), (
+            f"substring filter name:*'*{fragment}*' should match at least one record"
+        )
+
+    def test_aggregate_file_details_case_ids_scopes_results(self):
+        """Test that case_ids narrows file aggregation to the named cases.
+
+        The endpoint's ids query param does not filter, so this asserts the
+        case_id filter path that does.
+        """
+        unscoped = self._aggregate("aggregate_case_file_details", field="case_id")
+        self.assert_no_error(unscoped, context="file details unscoped")
+
+        buckets = (unscoped[0].get("buckets") or []) if unscoped else []
+        if len(buckets) < 2:
+            self.skip_with_warning(
+                "Fewer than 2 cases with attached files", "case_ids scoping"
+            )
+            return
+
+        target = buckets[0]["label"]
+        scoped = self._aggregate(
+            "aggregate_case_file_details", field="case_id", case_ids=[target]
+        )
+
+        self.assert_no_error(scoped, context="file details scoped")
+        scoped_labels = [b["label"] for b in (scoped[0].get("buckets") or [])]
+        assert scoped_labels == [target], (
+            f"case_ids=[{target}] should return only that case, got {scoped_labels}"
+        )
+
+    def test_aggregate_file_details_file_size_is_filterable(self):
+        """Test that file_size works as a filter, matched as a string not a number."""
+        sizes = self._aggregate("aggregate_case_file_details", field="file_size")
+        self.assert_no_error(sizes, context="file details file_size")
+
+        buckets = (sizes[0].get("buckets") or []) if sizes else []
+        if not buckets:
+            self.skip_with_warning("No files with a size", "file_size filter")
+            return
+
+        target = buckets[0]["label"]
+        filtered = self._aggregate(
+            "aggregate_case_file_details",
+            field="file_size",
+            filter=f"file_size:'{target}'",
+        )
+
+        self.assert_no_error(filtered, context="file details file_size filter")
+        assert filtered and (filtered[0].get("buckets") or []), (
+            f"file_size:'{target}' should match at least one file"
+        )

--- a/tests/modules/test_base.py
+++ b/tests/modules/test_base.py
@@ -1262,6 +1262,39 @@ class TestBaseAggregate(TestModules):
             "PostAggregatesAlertsV2", body=[{"type": "terms", "field": "status"}]
         )
 
+    def test_parameters_are_sent_alongside_the_body(self):
+        """A few aggregate endpoints take query params as well as the body."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"name": "t", "buckets": []}]},
+        }
+
+        self.module._base_aggregate(
+            "PostAggregatesFileDetailsV1",
+            agg_type="terms",
+            field="name",
+            parameters={"ids": ["case-a"]},
+        )
+
+        self.mock_client.command.assert_called_once_with(
+            "PostAggregatesFileDetailsV1",
+            body=[{"type": "terms", "field": "name"}],
+            parameters={"ids": ["case-a"]},
+        )
+
+    def test_parameters_omitted_when_not_given(self):
+        """Endpoints without query params get a body-only call."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"name": "t", "buckets": []}]},
+        }
+
+        self.module._base_aggregate(
+            "PostAggregatesAlertsV2", agg_type="terms", field="status"
+        )
+
+        self.assertNotIn("parameters", self.mock_client.command.call_args[1])
+
     def test_multi_spec_passes_through_in_one_list(self):
         """N specs go out in a single list body; N results come back."""
         self.mock_client.command.return_value = {

--- a/tests/modules/test_cases.py
+++ b/tests/modules/test_cases.py
@@ -7,7 +7,7 @@ import unittest
 from mcp.types import ToolAnnotations
 
 from falcon_mcp.modules.base import READ_ONLY_ANNOTATIONS
-from falcon_mcp.modules.cases import CasesModule
+from falcon_mcp.modules.cases import CasesModule, _is_filter_error
 from tests.modules.utils.test_modules import TestModules
 
 
@@ -23,7 +23,7 @@ class TestCasesModule(TestModules):
     # -------------------------------------------------------------------------
 
     def test_register_tools(self):
-        """Test that all 8 case management tools are registered with correct prefixed names."""
+        """Test that all 13 case management tools are registered with correct prefixed names."""
         expected_tools = [
             "falcon_search_cases",
             "falcon_get_cases",
@@ -33,13 +33,20 @@ class TestCasesModule(TestModules):
             "falcon_add_case_event_evidence",
             "falcon_manage_case_tags",
             "falcon_list_case_templates",
+            "falcon_aggregate_case_slas",
+            "falcon_aggregate_case_templates",
+            "falcon_aggregate_case_access_tags",
+            "falcon_aggregate_case_notification_groups",
+            "falcon_aggregate_case_file_details",
         ]
         self.assert_tools_registered(expected_tools)
 
     def test_register_resources(self):
-        """Test that the FQL guide resource is registered."""
+        """Test that the FQL guide resources are registered."""
         expected_resources = [
             "falcon_search_cases_fql_guide",
+            "falcon_aggregate_case_config_fql_guide",
+            "falcon_aggregate_case_file_details_fql_guide",
         ]
         self.assert_resources_registered(expected_resources)
 
@@ -705,6 +712,534 @@ class TestCasesModule(TestModules):
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
         self.assertIn("error", result[0])
+
+    # -------------------------------------------------------------------------
+    # Aggregate Tool Tests
+    # -------------------------------------------------------------------------
+
+    def _agg_ok(self, buckets=None):
+        """Stub a successful aggregate response."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"name": "t", "buckets": buckets or [{"label": "a", "count": 2}]}
+                ],
+                "errors": [],
+            },
+        }
+
+    def _sent_body(self):
+        """Return the single aggregate spec sent to the API."""
+        body = self.mock_client.command.call_args[1]["body"]
+        self.assertIsInstance(body, list, "aggregate body must be list-wrapped")
+        self.assertEqual(len(body), 1)
+        return body[0]
+
+    def test_aggregate_tools_are_read_only(self):
+        """Test that all five aggregate tools register as read-only."""
+        self.module.register_tools(self.mock_server)
+
+        for tool in (
+            "falcon_aggregate_case_slas",
+            "falcon_aggregate_case_templates",
+            "falcon_aggregate_case_access_tags",
+            "falcon_aggregate_case_notification_groups",
+            "falcon_aggregate_case_file_details",
+        ):
+            self.assert_tool_annotations(tool, READ_ONLY_ANNOTATIONS)
+
+    def test_aggregate_tools_use_correct_operations(self):
+        """Test that each aggregate tool calls its own verified FalconPy operation."""
+        cases = [
+            (self.module.aggregate_case_slas, "aggregates_slas_post_v1", "name"),
+            (self.module.aggregate_case_templates, "aggregates_templates_post_v1", "name"),
+            (
+                self.module.aggregate_case_access_tags,
+                "aggregates_access_tags_post_v1",
+                "key",
+            ),
+            (
+                self.module.aggregate_case_notification_groups,
+                "aggregates_notification_groups_post_v2",
+                "name",
+            ),
+        ]
+        for method, operation, field in cases:
+            with self.subTest(operation=operation):
+                self.mock_client.command.reset_mock()
+                self._agg_ok()
+
+                result = method(
+                    field=field,
+                    agg_type="terms",
+                    filter=None,
+                    size=None,
+                    from_=None,
+                    date_ranges=None,
+                    name=None,
+                )
+
+                self.assertEqual(
+                    self.mock_client.command.call_args[0][0], operation
+                )
+                self.assertEqual(self._sent_body(), {"type": "terms", "field": field})
+                self.assertEqual(result[0]["buckets"], [{"label": "a", "count": 2}])
+
+    def test_aggregate_notification_groups_avoids_deprecated_v1(self):
+        """Test that the deprecated v1 notification-groups operation is never called."""
+        self._agg_ok()
+
+        self.module.aggregate_case_notification_groups(
+            field="name",
+            agg_type="terms",
+            filter=None,
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        operation = self.mock_client.command.call_args[0][0]
+        self.assertEqual(operation, "aggregates_notification_groups_post_v2")
+        self.assertNotEqual(operation, "aggregates_notification_groups_post_v1")
+
+    def test_aggregate_forwards_reduced_dialect_fields(self):
+        """Test that the reduced-dialect fields reach the API under their wire names."""
+        self._agg_ok()
+
+        self.module.aggregate_case_templates(
+            field="created_timestamp",
+            agg_type="date_range",
+            filter="created_by_name:'a@example.com'",
+            size=5,
+            from_=2,
+            date_ranges=[{"from": "2026-01-01T00:00:00Z", "to": "2026-02-01T00:00:00Z"}],
+            name="by_quarter",
+        )
+
+        self.assertEqual(
+            self._sent_body(),
+            {
+                "type": "date_range",
+                "field": "created_timestamp",
+                "filter": "created_by_name:'a@example.com'",
+                "from": 2,
+                "name": "by_quarter",
+                "size": 5,
+                "date_ranges": [
+                    {"from": "2026-01-01T00:00:00Z", "to": "2026-02-01T00:00:00Z"}
+                ],
+            },
+        )
+
+    def test_aggregate_omits_unset_fields(self):
+        """Test that unset optional fields are omitted rather than sent as null."""
+        self._agg_ok()
+
+        self.module.aggregate_case_slas(
+            field="name",
+            agg_type="terms",
+            filter=None,
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertEqual(sorted(self._sent_body()), ["field", "type"])
+
+    def test_aggregate_does_not_send_sort(self):
+        """Test that no aggregate tool sends sort, which the API ignores."""
+        self._agg_ok()
+
+        self.module.aggregate_case_templates(
+            field="name",
+            agg_type="terms",
+            filter=None,
+            size=3,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertNotIn("sort", self._sent_body())
+
+    def test_aggregate_filter_error_returns_fql_guide(self):
+        """Test that a filter error is surfaced with the FQL guide attached."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [],
+                "errors": [{"code": 400, "message": "unexpected filter field"}],
+            },
+        }
+
+        result = self.module.aggregate_case_templates(
+            field="name",
+            agg_type="terms",
+            filter="status:'new'",
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("fql_guide", result)
+        self.assertIn("name", result["fql_guide"])
+        self.assertIn("error", result["results"][0])
+
+    def test_aggregate_non_filter_error_omits_fql_guide(self):
+        """Test that a bad aggregation field is not blamed on the filter.
+
+        The FQL guide covers the `filter` param, so attaching it to a `field`
+        or `agg_type` failure would point the caller at the wrong argument.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [],
+                "errors": [
+                    {"code": 400, "message": "unsupported field for aggregation: status"}
+                ],
+            },
+        }
+
+        result = self.module.aggregate_case_templates(
+            field="status",
+            agg_type="terms",
+            filter=None,
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertIsInstance(result, list)
+        self.assertIn("error", result[0])
+        self.assertNotIn("fql_guide", result[0])
+
+    def test_aggregate_invalid_agg_type_error_omits_fql_guide(self):
+        """Test that an invalid aggregate type is not reported as a filter error."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [],
+                "errors": [{"code": 400, "message": 'invalid aggregate type: "avg"'}],
+            },
+        }
+
+        result = self.module.aggregate_case_slas(
+            field="name",
+            agg_type="avg",
+            filter=None,
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertIsInstance(result, list)
+        self.assertIn("error", result[0])
+        self.assertNotIn("fql_guide", result[0])
+
+    def test_aggregate_date_range_without_date_ranges_skips_the_api(self):
+        """Test that a date_range aggregation missing its buckets never reaches the API.
+
+        The API answers such a spec with an opaque 500, so `_base_aggregate`
+        rejects it up front. The reply is not a filter problem, so it must not
+        carry the FQL guide.
+        """
+        for tool in (
+            self.module.aggregate_case_slas,
+            self.module.aggregate_case_templates,
+            self.module.aggregate_case_access_tags,
+            self.module.aggregate_case_notification_groups,
+        ):
+            with self.subTest(tool=tool.__name__):
+                self.mock_client.command.reset_mock()
+
+                result = tool(
+                    field="name",
+                    agg_type="date_range",
+                    filter=None,
+                    size=None,
+                    from_=None,
+                    date_ranges=None,
+                    name=None,
+                )
+
+                self.mock_client.command.assert_not_called()
+                self.assertIsInstance(result, list)
+                self.assertIn("error", result[0])
+                self.assertIn("date_ranges", result[0]["error"])
+                self.assertNotIn("fql_guide", result[0])
+
+    def test_aggregate_file_details_date_range_without_date_ranges_skips_the_api(self):
+        """Test that the file-details tool also rejects the spec before any call."""
+        result = self.module.aggregate_case_file_details(
+            field="name",
+            agg_type="date_range",
+            case_ids=None,
+            filter=None,
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.mock_client.command.assert_not_called()
+        self.assertIsInstance(result, list)
+        self.assertIn("error", result[0])
+        self.assertIn("date_ranges", result[0]["error"])
+        self.assertNotIn("fql_guide", result[0])
+
+    def test_aggregate_http_400_field_error_omits_fql_guide(self):
+        """Test that a real 400 field error is not mistaken for a filter error.
+
+        `handle_api_response` prepends generic filter-syntax advice to every
+        400, so classification must read the API's own messages instead.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {
+                "errors": [
+                    {
+                        "code": 400,
+                        "message": "unsupported field for aggregation: not_a_real_field",
+                    }
+                ]
+            },
+        }
+
+        result = self.module.aggregate_case_templates(
+            field="not_a_real_field",
+            agg_type="terms",
+            filter="name:'x'",
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertIsInstance(result, list)
+        self.assertIn("error", result[0])
+        self.assertNotIn("fql_guide", result[0])
+
+    def test_aggregate_http_400_filter_error_returns_fql_guide(self):
+        """Test that a real 400 filter error still surfaces the FQL guide."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"code": 400, "message": "unexpected filter field"}]},
+        }
+
+        result = self.module.aggregate_case_templates(
+            field="name",
+            agg_type="terms",
+            filter="not_a_real_field:'x'",
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("fql_guide", result)
+
+    def test_is_filter_error_tolerates_malformed_error_shapes(self):
+        """Test that error classification never raises on an unexpected shape.
+
+        A crash here would replace a useful API error with a TypeError, so every
+        shape `_base_aggregate` can return must classify rather than blow up.
+        """
+        shapes = [
+            {"error": "boom"},
+            {"error": "boom", "details": None},
+            {"error": "boom", "details": "not a dict"},
+            {"error": "boom", "details": {"status_code": 403}},
+            {"error": "boom", "details": {"body": None}},
+            {"error": "boom", "details": {"body": {"resources": []}}},
+            {"error": "boom", "details": {"body": {"errors": None}}},
+            {"error": "boom", "details": {"body": {"errors": []}}},
+            {"error": "boom", "details": {"body": {"errors": [{"code": 403}]}}},
+            {"error": "boom", "details": {"body": {"errors": [{"message": None}]}}},
+            {"error": "boom", "details": {"body": {"errors": ["filter"]}}},
+            {"error": "boom", "details": {"body": {"errors": {"message": "filter"}}}},
+        ]
+        for shape in shapes:
+            with self.subTest(shape=shape):
+                self.assertFalse(_is_filter_error(shape))
+
+    def test_is_filter_error_detects_api_filter_messages(self):
+        """Test that a filter message is recognized, including past a sibling error."""
+        self.assertTrue(
+            _is_filter_error(
+                {
+                    "error": "boom",
+                    "details": {
+                        "body": {"errors": [{"message": "unexpected filter field"}]}
+                    },
+                }
+            )
+        )
+        self.assertTrue(
+            _is_filter_error(
+                {
+                    "error": "boom",
+                    "details": {
+                        "body": {
+                            "errors": [
+                                {"message": "something else"},
+                                {"message": "failed to parse filter"},
+                            ]
+                        }
+                    },
+                }
+            )
+        )
+        self.assertFalse(
+            _is_filter_error(
+                {
+                    "error": "boom",
+                    "details": {
+                        "body": {
+                            "errors": [
+                                {"message": "unsupported field for aggregation: x"}
+                            ]
+                        }
+                    },
+                }
+            )
+        )
+
+    def test_aggregate_access_tags_error_names_supported_fields(self):
+        """Test that an access-tags filter failure returns its narrow field set."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [],
+                "errors": [{"code": 400, "message": "unexpected filter field"}],
+            },
+        }
+
+        result = self.module.aggregate_case_access_tags(
+            field="key",
+            agg_type="terms",
+            filter="name:'x'",
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertIn("key", result["fql_guide"])
+
+    def test_aggregate_file_details_uses_correct_operation(self):
+        """Test that file details calls its own operation and sends no ids when unscoped."""
+        self._agg_ok()
+
+        self.module.aggregate_case_file_details(
+            field="name",
+            agg_type="terms",
+            case_ids=None,
+            filter=None,
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertEqual(
+            self.mock_client.command.call_args[0][0],
+            "aggregates_file_details_post_v1",
+        )
+        self.assertNotIn("parameters", self.mock_client.command.call_args[1])
+        self.assertEqual(self._sent_body(), {"type": "terms", "field": "name"})
+
+    def test_aggregate_file_details_scopes_case_ids_via_filter(self):
+        """Test that case_ids becomes a case_id filter, since the ids param does not narrow."""
+        self._agg_ok()
+
+        self.module.aggregate_case_file_details(
+            field="name",
+            agg_type="terms",
+            case_ids=["case-a", "case-b"],
+            filter=None,
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertEqual(
+            self._sent_body()["filter"], "case_id:['case-a','case-b']"
+        )
+        # Still sent as a query param, because the API declares ids required.
+        self.assertEqual(
+            self.mock_client.command.call_args[1]["parameters"],
+            {"ids": ["case-a", "case-b"]},
+        )
+
+    def test_aggregate_file_details_parenthesizes_user_filter(self):
+        """Test that an OR in the caller's filter cannot widen the case scope."""
+        self._agg_ok()
+
+        self.module.aggregate_case_file_details(
+            field="name",
+            agg_type="terms",
+            case_ids=["case-a"],
+            filter="name:'x',name:*'*.png'",
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertEqual(
+            self._sent_body()["filter"],
+            "case_id:['case-a']+(name:'x',name:*'*.png')",
+        )
+
+    def test_aggregate_file_details_filter_only(self):
+        """Test that a filter with no case_ids is passed through unwrapped."""
+        self._agg_ok()
+
+        self.module.aggregate_case_file_details(
+            field="name",
+            agg_type="terms",
+            case_ids=None,
+            filter="name:*'*.png'",
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertEqual(self._sent_body()["filter"], "name:*'*.png'")
+
+    def test_aggregate_file_details_error_returns_file_guide(self):
+        """Test that a file-details failure returns the file guide, not the config guide."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "failed to parse filter"}]},
+        }
+
+        result = self.module.aggregate_case_file_details(
+            field="name",
+            agg_type="terms",
+            case_ids=["case-a"],
+            filter="name:::",
+            size=None,
+            from_=None,
+            date_ranges=None,
+            name=None,
+        )
+
+        self.assertIn("case_id", result["fql_guide"])
+        self.assertIn("Case File Aggregates", result["fql_guide"])
+        # The composed filter, not the caller's fragment, is what the API saw.
+        self.assertEqual(result["filter_used"], "case_id:['case-a']+(name:::)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Five read-only aggregate tools for the Case Management module: `falcon_aggregate_case_slas`, `falcon_aggregate_case_templates`, `falcon_aggregate_case_access_tags`, `falcon_aggregate_case_notification_groups`, and `falcon_aggregate_case_file_details`. They need two FQL guides rather than one, because the four `/casemgmt/aggregates` endpoints share a field set and the file endpoint has its own. Notification groups uses the v2 operation since swagger marks v1 deprecated.

Testing against a live tenant changed a few decisions. The four casemgmt endpoints use the reduced `api.MSAAggregateQueryRequest` dialect and silently ignore anything outside it, so these tools expose only the eight schema fields. A parameter that quietly does nothing seemed worse than one that isn't there. `sort` is a no-op on all four, so it's not exposed either; `size` and `from` do work. Field sets differ per entity too. Access tags accept only `key`, `id` and `cid`, so a shared field list would have broken that tool.

The file endpoint's `ids` query parameter doesn't narrow anything, so scoping goes through the FQL `case_id` field instead. A caller's filter gets wrapped in parens, otherwise an `OR` inside it could widen results past the cases you asked for.

Worth knowing about one field, since getting it wrong looks like a real answer: a case record's `analysis_results.files` is not its attachments. It lists forensic artifacts seen in detections, and it comes back empty for cases that do have files attached. Both `falcon_get_cases` and the file aggregate say so explicitly.

Error handling tells a filter problem apart from a bad aggregation field or type, so the FQL guide only shows up when the filter is actually at fault. All five tools expose `date_range` with `date_ranges` optional, which means they inherit the companion-key check in `_base_aggregate`: a `date_range` spec with no buckets gets rejected before any request goes out, and that reply carries no FQL guide.

The second commit is unrelated. Two guards in the cases integration tests measured the search envelope instead of the cases inside it, so `len()` came out to 3 no matter how many cases the tenant held. One test ended up running its detail assertions against the envelope dict; the other's skip was unreachable. Unwrapping first is the same fix #492 applied to three other modules, which didn't cover cases. I broke both tests on purpose to confirm they can fail, stripping the hydrated records back to IDs.
