### PR TITLE
fix(modules): return FQL guide on filter errors for hosts, spotlight, and intel searches

### DIFF
--- a/falcon_mcp/modules/hosts.py
+++ b/falcon_mcp/modules/hosts.py
@@ -160,7 +160,9 @@ class HostsModule(BaseModule):
         )
 
         if self._is_error(device_ids):
-            return [device_ids]
+            return self._format_fql_error_response(
+                [device_ids], filter, SEARCH_HOSTS_FQL_DOCUMENTATION
+            )
 
         if not device_ids:
             return self._build_pagination_envelope([], pagination, filter)

--- a/falcon_mcp/modules/intel.py
+++ b/falcon_mcp/modules/intel.py
@@ -161,7 +161,9 @@ class IntelModule(BaseModule):
         )
 
         if self._is_error(api_response):
-            return [api_response]
+            return self._format_fql_error_response(
+                [api_response], filter, QUERY_ACTOR_ENTITIES_FQL_DOCUMENTATION
+            )
 
         return self._build_pagination_envelope(api_response or [], pagination, filter)
 
@@ -234,7 +236,9 @@ class IntelModule(BaseModule):
         )
 
         if self._is_error(api_response):
-            return [api_response]
+            return self._format_fql_error_response(
+                [api_response], filter, QUERY_INDICATOR_ENTITIES_FQL_DOCUMENTATION
+            )
 
         return self._build_pagination_envelope(api_response or [], pagination, filter)
 
@@ -291,7 +295,9 @@ class IntelModule(BaseModule):
         )
 
         if self._is_error(api_response):
-            return [api_response]
+            return self._format_fql_error_response(
+                [api_response], filter, QUERY_REPORT_ENTITIES_FQL_DOCUMENTATION
+            )
 
         return self._build_pagination_envelope(api_response or [], pagination, filter)
 

--- a/falcon_mcp/modules/spotlight.py
+++ b/falcon_mcp/modules/spotlight.py
@@ -134,6 +134,8 @@ class SpotlightModule(BaseModule):
         )
 
         if self._is_error(vulnerabilities):
-            return [vulnerabilities]
+            return self._format_fql_error_response(
+                [vulnerabilities], filter, SEARCH_VULNERABILITIES_FQL_DOCUMENTATION
+            )
 
         return self._build_pagination_envelope(vulnerabilities or [], pagination, filter)

--- a/tests/modules/test_hosts.py
+++ b/tests/modules/test_hosts.py
@@ -7,6 +7,7 @@ import unittest
 from mcp.types import ToolAnnotations
 
 from falcon_mcp.modules.hosts import HostsModule
+from falcon_mcp.resources.hosts import SEARCH_HOSTS_FQL_DOCUMENTATION
 from tests.modules.utils.test_modules import TestModules
 
 
@@ -140,7 +141,7 @@ class TestHostsModule(TestModules):
         self.assertEqual(result["pagination"]["total"], 2)
 
     def test_search_hosts_error(self):
-        """Test searching for hosts with API error."""
+        """Test searching for hosts with a filter error returns the FQL guide."""
         # Setup mock response with error
         mock_response = {
             "status_code": 400,
@@ -151,10 +152,14 @@ class TestHostsModule(TestModules):
         # Call search_hosts
         result = self.module.search_hosts(filter="invalid_filter")
 
-        # Verify result contains error
-        self.assertEqual(len(result), 1)
-        self.assertIn("error", result[0])
-        self.assertIn("details", result[0])
+        # Verify result contains the error wrapped alongside the FQL guide and hint
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("error", result["results"][0])
+        self.assertIn("fql_guide", result)
+        self.assertEqual(result["fql_guide"], SEARCH_HOSTS_FQL_DOCUMENTATION)
+        self.assertIn("hint", result)
+        self.assertEqual(result["filter_used"], "invalid_filter")
 
     def test_search_hosts_no_results(self):
         """Test searching for hosts with no results."""

--- a/tests/modules/test_intel.py
+++ b/tests/modules/test_intel.py
@@ -5,6 +5,11 @@ Tests for the Intel module.
 import unittest
 
 from falcon_mcp.modules.intel import IntelModule
+from falcon_mcp.resources.intel import (
+    QUERY_ACTOR_ENTITIES_FQL_DOCUMENTATION,
+    QUERY_INDICATOR_ENTITIES_FQL_DOCUMENTATION,
+    QUERY_REPORT_ENTITIES_FQL_DOCUMENTATION,
+)
 from tests.modules.utils.test_modules import TestModules
 
 
@@ -93,7 +98,7 @@ class TestIntelModule(TestModules):
         self.assertEqual(result["results"], [])
 
     def test_search_actors_error(self):
-        """Test searching actors with API error."""
+        """Test searching actors with a filter error returns the FQL guide."""
         # Setup mock response with error
         mock_response = {
             "status_code": 400,
@@ -102,14 +107,19 @@ class TestIntelModule(TestModules):
         self.mock_client.command.return_value = mock_response
 
         # Call search_actors
-        results = self.module.query_actor_entities(filter="invalid query")
-        result = results[0]
+        result = self.module.query_actor_entities(filter="invalid query")
 
-        # Verify result contains error
-        self.assertIn("error", result)
-        self.assertIn("details", result)
-        # Check that the error message starts with the expected prefix
-        self.assertTrue(result["error"].startswith("Failed to search actors"))
+        # Verify result wraps the error alongside the FQL guide and hint
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("error", result["results"][0])
+        self.assertTrue(
+            result["results"][0]["error"].startswith("Failed to search actors")
+        )
+        self.assertIn("fql_guide", result)
+        self.assertEqual(result["fql_guide"], QUERY_ACTOR_ENTITIES_FQL_DOCUMENTATION)
+        self.assertIn("hint", result)
+        self.assertEqual(result["filter_used"], "invalid query")
 
     def test_query_indicator_entities_success(self):
         """Test querying indicator entities with successful response."""
@@ -182,7 +192,7 @@ class TestIntelModule(TestModules):
         self.assertEqual(result["results"], [])
 
     def test_query_indicator_entities_error(self):
-        """Test querying indicator entities with API error."""
+        """Test querying indicator entities with a filter error returns the FQL guide."""
         # Setup mock response with error
         mock_response = {
             "status_code": 400,
@@ -193,12 +203,19 @@ class TestIntelModule(TestModules):
         # Call query_indicator_entities
         result = self.module.query_indicator_entities(filter="invalid query")
 
-        # Verify result contains error
-        self.assertEqual(len(result), 1)
-        self.assertIn("error", result[0])
-        self.assertIn("details", result[0])
-        # Check that the error message starts with the expected prefix
-        self.assertTrue(result[0]["error"].startswith("Failed to search indicators"))
+        # Verify result wraps the error alongside the FQL guide and hint
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("error", result["results"][0])
+        self.assertTrue(
+            result["results"][0]["error"].startswith("Failed to search indicators")
+        )
+        self.assertIn("fql_guide", result)
+        self.assertEqual(
+            result["fql_guide"], QUERY_INDICATOR_ENTITIES_FQL_DOCUMENTATION
+        )
+        self.assertIn("hint", result)
+        self.assertEqual(result["filter_used"], "invalid query")
 
     def test_query_report_entities_success(self):
         """Test querying report entities with successful response."""
@@ -267,7 +284,7 @@ class TestIntelModule(TestModules):
         self.assertEqual(result["results"], [])
 
     def test_query_report_entities_error(self):
-        """Test querying report entities with API error."""
+        """Test querying report entities with a filter error returns the FQL guide."""
         # Setup mock response with error
         mock_response = {
             "status_code": 400,
@@ -278,12 +295,17 @@ class TestIntelModule(TestModules):
         # Call query_report_entities
         result = self.module.query_report_entities(filter="invalid query")
 
-        # Verify result contains error
-        self.assertEqual(len(result), 1)
-        self.assertIn("error", result[0])
-        self.assertIn("details", result[0])
-        # Check that the error message starts with the expected prefix
-        self.assertTrue(result[0]["error"].startswith("Failed to search reports"))
+        # Verify result wraps the error alongside the FQL guide and hint
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("error", result["results"][0])
+        self.assertTrue(
+            result["results"][0]["error"].startswith("Failed to search reports")
+        )
+        self.assertIn("fql_guide", result)
+        self.assertEqual(result["fql_guide"], QUERY_REPORT_ENTITIES_FQL_DOCUMENTATION)
+        self.assertIn("hint", result)
+        self.assertEqual(result["filter_used"], "invalid query")
 
     def test_get_mitre_report_success(self):
         """Test getting MITRE report with successful response.

--- a/tests/modules/test_spotlight.py
+++ b/tests/modules/test_spotlight.py
@@ -5,6 +5,7 @@ Tests for the Spotlight module.
 import unittest
 
 from falcon_mcp.modules.spotlight import SpotlightModule
+from falcon_mcp.resources.spotlight import SEARCH_VULNERABILITIES_FQL_DOCUMENTATION
 from tests.modules.utils.test_modules import TestModules
 
 
@@ -231,7 +232,7 @@ class TestSpotlightModule(TestModules):
         self.assertEqual(result["results"], [])
 
     def test_search_vulnerabilities_error(self):
-        """Test searching vulnerabilities with API error."""
+        """Test searching vulnerabilities with a filter error returns the FQL guide."""
         # Setup mock response with error
         mock_response = {
             "status_code": 400,
@@ -240,14 +241,19 @@ class TestSpotlightModule(TestModules):
         self.mock_client.command.return_value = mock_response
 
         # Call search_vulnerabilities
-        results = self.module.search_vulnerabilities(filter="invalid query")
-        result = results[0]
+        result = self.module.search_vulnerabilities(filter="invalid query")
 
-        # Verify result contains error
-        self.assertIn("error", result)
-        self.assertIn("details", result)
-        # Check that the error message starts with the expected prefix
-        self.assertTrue(result["error"].startswith("Failed to search vulnerabilities"))
+        # Verify result wraps the error alongside the FQL guide and hint
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("error", result["results"][0])
+        self.assertTrue(
+            result["results"][0]["error"].startswith("Failed to search vulnerabilities")
+        )
+        self.assertIn("fql_guide", result)
+        self.assertEqual(result["fql_guide"], SEARCH_VULNERABILITIES_FQL_DOCUMENTATION)
+        self.assertIn("hint", result)
+        self.assertEqual(result["filter_used"], "invalid query")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When `search_hosts`, `search_vulnerabilities`, or the intel search tools (actors, indicators, reports) hit an API filter error, they returned a bare list-wrapped error with no `fql_guide` or `hint`. So an agent that wrote a bad filter got a 400 back and nothing to help it fix the query, unlike `search_detections` and the other FQL search tools, which return the guide on that path.

These modules already imported their guide constants; they just weren't using them on the error path. This routes their filter-error branch through `_format_fql_error_response` with the guide they already have, matching the detections pattern. The secondary details-fetch error path is left alone since it's past FQL concerns.

Existing error-path tests for the five affected tools now assert the guide, hint, and `filter_used` ride along on a 400.

Closes #501