### PR TITLE
refactor(common): remove dead dict-to-FQL branch in prepare_api_parameters

### DIFF
--- a/falcon_mcp/common/utils.py
+++ b/falcon_mcp/common/utils.py
@@ -42,11 +42,6 @@ def prepare_api_parameters(params: dict[str, Any]) -> dict[str, Any]:
     # Remove None values
     filtered = filter_none_values(params)
 
-    # Handle special parameter formatting if needed
-    if "filter" in filtered and isinstance(filtered["filter"], dict):
-        # Convert filter dict to FQL string if needed
-        pass
-
     return filtered
 
 


### PR DESCRIPTION
The `prepare_api_parameters` helper had a branch that checked whether `filter` was a dict and then did nothing but `pass`. Since every tool types `filter` as a string, that branch never ran. It just misled anyone reading the code into thinking a dict filter would get converted to FQL, when in reality it would have been handed to the API unchanged.

Removed the branch and its comment. No caller needs dict-to-FQL conversion, so nothing speculative was added in its place. Existing `prepare_api_parameters` tests still pass.

Closes #502