### PR TITLE
docs(modules/spotlight): recommend after-based pagination for large pulls

### DIFF
--- a/falcon_mcp/modules/spotlight.py
+++ b/falcon_mcp/modules/spotlight.py
@@ -63,7 +63,7 @@ class SpotlightModule(BaseModule):
             default=10,
             ge=1,
             le=5000,
-            description="Maximum number of results to return. (Max: 5000, Default: 10)",
+            description="Maximum number of results to return. (Max: 5000, Default: 10) For large pulls, a single big page can time out on busy tenants; prefer smaller pages combined with `after`-based pagination (pass `pagination.next` from the previous response as the `after` parameter) instead of raising this to the maximum.",
         ),
         sort: str | None = Field(
             default=None,


### PR DESCRIPTION
Large single-page pulls from the Spotlight combined vulnerabilities endpoint can time out on busy tenants when `limit` is pushed toward the maximum. This updates the `limit` parameter description in `falcon_search_vulnerabilities` to point callers at `after`-based cursor paging (feeding `pagination.next` back in as `after`) for large result sets. No behavior change — the `after` cursor already worked; this just steers people toward it. Closes #504.