### PR TITLE
fix(modules/exclusions): reject IOA regex zero-width assertions pre-flight

### DIFF
--- a/falcon_mcp/modules/exclusions.py
+++ b/falcon_mcp/modules/exclusions.py
@@ -30,6 +30,53 @@ logger = get_logger(__name__)
 # Valid exclusion types (the discriminator values exposed to the agent).
 EXCLUSION_TYPES = ("ioa", "ml", "sensor_visibility", "certificate")
 
+# Zero-width regex assertions the IOA exclusion API rejects. 
+def _find_zero_width_assertion(regex: str) -> str | None:
+    """Return the first zero-width assertion token in ``regex``, else None.
+
+    Ignores escaped anchors (``\\^``, ``\\$``) and anything inside a character
+    class ``[...]``, which the regex engine treats as literals rather than
+    position assertions. A ``]`` in the first position of a class (or right
+    after a leading ``^`` negation) is itself a literal member, not the class
+    terminator.
+    """
+    index = 0
+    in_class = False
+    # Members seen since the current class opened, excluding a leading `^`.
+    class_members = 0
+    length = len(regex)
+    while index < length:
+        char = regex[index]
+        if char == "\\" and index + 1 < length:
+            nxt = regex[index + 1]
+            if not in_class and nxt in ("b", "A", "Z"):
+                return f"\\{nxt}"
+            if in_class:
+                class_members += 1
+            index += 2
+            continue
+        if not in_class:
+            if char == "[":
+                in_class = True
+                class_members = 0
+            elif char in ("^", "$"):
+                return char
+            index += 1
+            continue
+        # Inside a character class.
+        if char == "^" and class_members == 0:
+            # Leading negation is not itself a member.
+            index += 1
+            continue
+        if char == "]" and class_members > 0:
+            in_class = False
+            index += 1
+            continue
+        # Any other char, including a `]` in the first member position.
+        class_members += 1
+        index += 1
+    return None
+
 
 class ExclusionsModule(BaseModule):
     """Module for managing CrowdStrike exclusions across all four types."""
@@ -340,6 +387,29 @@ class ExclusionsModule(BaseModule):
                 "'.*' (this would exclude everything). Provide more specific regexes.",
                 operation=self._OPERATIONS["ioa"]["create"],
             )
+
+        # IOA regexes must not contain zero-width assertions (^ $ \b \A \Z); the
+        # API rejects them, so fail fast with the offending field and token.
+        regex_fields = {
+            "ifn_regex": ifn_regex,
+            "cl_regex": cl_regex,
+            "parent_ifn_regex": parent_ifn_regex,
+            "parent_cl_regex": parent_cl_regex,
+            "grandparent_ifn_regex": grandparent_ifn_regex,
+            "grandparent_cl_regex": grandparent_cl_regex,
+        }
+        for field_name, field_value in regex_fields.items():
+            if not field_value:
+                continue
+            token = _find_zero_width_assertion(field_value)
+            if token is not None:
+                return _format_error_response(
+                    f"IOA exclusion rejected: '{field_name}' contains the "
+                    f"zero-width assertion '{token}', which the IOA regex engine "
+                    "does not support. Remove ^, $, \\b, \\A, and \\Z (escape them "
+                    "as \\\\^ / \\\\$ or use a character class if you need a literal).",
+                    operation=self._OPERATIONS["ioa"]["create"],
+                )
 
         exclusion: dict[str, Any] = {
             "name": name,

--- a/tests/modules/test_exclusions.py
+++ b/tests/modules/test_exclusions.py
@@ -513,6 +513,120 @@ class TestExclusionsModule(TestModules):
         self.assertIn("error", result[0])
         self.assertEqual(self.mock_client.command.call_count, 0)
 
+    def test_create_ioa_rejects_zero_width_assertions(self):
+        """IOA create rejects each zero-width regex assertion pre-flight, naming it."""
+        for token in ["^", "$", r"\b", r"\A", r"\Z"]:
+            with self.subTest(token=token):
+                self.mock_client.command.reset_mock()
+                result = self.module.create_exclusion(
+                    exclusion_type="ioa",
+                    **self._create_kwargs(
+                        name="n",
+                        pattern_id="1",
+                        ifn_regex=f"{token}foo",
+                        cl_regex="/tmp/bar",
+                    ),
+                )
+                self.assertIn("error", result[0])
+                self.assertIn(token, result[0]["error"])
+                self.assertIn("ifn_regex", result[0]["error"])
+                self.assertEqual(self.mock_client.command.call_count, 0)
+
+    def test_create_ioa_rejects_zero_width_in_any_regex_field(self):
+        """Zero-width assertions are caught in optional IOA regex fields too."""
+        for field in ["cl_regex", "parent_ifn_regex", "grandparent_cl_regex"]:
+            with self.subTest(field=field):
+                self.mock_client.command.reset_mock()
+                kwargs = self._create_kwargs(
+                    name="n", pattern_id="1", ifn_regex="/tmp/x", cl_regex="/tmp/y"
+                )
+                kwargs[field] = r"\bfoo"
+                result = self.module.create_exclusion(exclusion_type="ioa", **kwargs)
+                self.assertIn("error", result[0])
+                self.assertIn(field, result[0]["error"])
+                self.assertEqual(self.mock_client.command.call_count, 0)
+
+    def test_create_ioa_valid_regex_passes(self):
+        """A valid IOA regex with no zero-width assertion reaches the API unchanged."""
+        self.mock_client.command.return_value = self._create_response(
+            {"id": "ioa-1", "name": "n"}
+        )
+        result = self.module.create_exclusion(
+            exclusion_type="ioa",
+            **self._create_kwargs(
+                name="n",
+                pattern_id="1",
+                ifn_regex="/usr/bin/foo",
+                cl_regex="--flag value",
+            ),
+        )
+        call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(call[0][0], "ss_ioa_exclusions_create_v2")
+        self.assertEqual(
+            call[1]["body"]["exclusions"][0]["ifn_regex"], "/usr/bin/foo"
+        )
+        self.assertEqual(result[0]["id"], "ioa-1")
+
+    def test_create_ioa_escaped_and_char_class_tokens_pass(self):
+        """Escaped ^/$ and char-class contexts are literals, not assertions."""
+        self.mock_client.command.return_value = self._create_response(
+            {"id": "ioa-1", "name": "n"}
+        )
+        result = self.module.create_exclusion(
+            exclusion_type="ioa",
+            **self._create_kwargs(
+                name="n",
+                pattern_id="1",
+                ifn_regex=r"/tmp/\$cache",
+                cl_regex=r"[$^]value",
+            ),
+        )
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        self.assertEqual(result[0]["id"], "ioa-1")
+
+    def test_create_ioa_leading_bracket_class_member_passes(self):
+        """A ] as the first class member is a literal, so the class still absorbs
+        following ^/$ tokens (e.g. `[]^]`) rather than false-flagging them."""
+        self.mock_client.command.return_value = self._create_response(
+            {"id": "ioa-1", "name": "n"}
+        )
+        result = self.module.create_exclusion(
+            exclusion_type="ioa",
+            **self._create_kwargs(
+                name="n",
+                pattern_id="1",
+                ifn_regex="/bin/foo[]^]",
+                cl_regex="[^]$]bar",
+            ),
+        )
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        self.assertEqual(result[0]["id"], "ioa-1")
+
+    def test_create_ml_value_with_caret_unaffected(self):
+        """Non-IOA types are not subject to the IOA regex assertion check."""
+        self.mock_client.command.return_value = self._create_response(
+            {"id": "ml-1", "value": "^weird$"}
+        )
+        result = self.module.create_exclusion(
+            exclusion_type="ml",
+            **self._create_kwargs(value="^weird$", host_groups=["grp-1"]),
+        )
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        self.assertEqual(result[0]["id"], "ml-1")
+
+    def test_update_ioa_rejects_zero_width_assertion(self):
+        """IOA update shares the builder, so it also rejects assertions pre-flight."""
+        result = self.module.update_exclusion(
+            exclusion_type="ioa",
+            id="ioa-1",
+            **self._create_kwargs(
+                name="n", pattern_id="1", ifn_regex="^foo", cl_regex="/tmp/y"
+            ),
+        )
+        self.assertIn("error", result[0])
+        self.assertIn("^", result[0]["error"])
+        self.assertEqual(self.mock_client.command.call_count, 0)
+
     def test_create_sv_empty_host_groups(self):
         """Sensor visibility create with no host_groups returns a guiding error."""
         result = self.module.create_exclusion(


### PR DESCRIPTION
IOA exclusions reject zero-width regex assertions like `^`, `$`, `\b`, `\A`, and `\Z`, but `create_exclusion` only found that out after the write hit the API and bounced back. This adds a pre-flight check on the IOA regex fields so the failure happens locally, and the error names the field and the offending token instead of relaying a generic API rejection.

It only applies to IOA exclusions. The check understands regex context too, so escaped anchors and characters inside a class (including a leading `]`, which is a literal member) pass through untouched.

Closes #506.
