### PR TITLE
fix(modules/detections): chunk update_detections requests over 1000 ids

### DIFF
--- a/docs/modules/detections.md
+++ b/docs/modules/detections.md
@@ -81,9 +81,12 @@ Use to change status (new, in_progress, reopened, closed), assign to a user by U
 email address, or full name, unassign, append a comment, hide/show detections in the UI,
 or add/remove tags. Resolution is tag-based: applying the conventional tags true_positive,
 false_positive, or ignored is what populates the console's Resolution view. At least one
-update parameter must be provided. Returns `[]` (empty list) on success, or
+update parameter must be provided. Requests covering more than 1000 detection IDs are
+chunked automatically so none are silently dropped. Returns `[]` (empty list) on success, or
 `{"result": [], "hint": "..."}` when closing without adding a resolution tag in this call;
-returns an error dict on failure.
+returns an error dict on failure. If a later chunk fails after earlier chunks already
+applied, the error dict carries a `partial_success` block listing the already-updated ids so
+the caller can retry only the remainder rather than re-applying non-idempotent actions.
 
 **Example prompts:**
 

--- a/falcon_mcp/modules/detections.py
+++ b/falcon_mcp/modules/detections.py
@@ -20,6 +20,10 @@ from falcon_mcp.resources.detections import (
 
 logger = get_logger(__name__)
 
+# PatchEntitiesAlertsV3 rejects requests carrying more than this many composite
+# IDs with HTTP 413 ("request too large").
+MAX_UPDATE_COMPOSITE_IDS = 1000
+
 
 class DetectionsModule(BaseModule):
     """Module for accessing and analyzing CrowdStrike Falcon detections."""
@@ -456,9 +460,12 @@ class DetectionsModule(BaseModule):
         email address, or full name, unassign, append a comment, hide/show detections in the UI,
         or add/remove tags. Resolution is tag-based: applying the conventional tags true_positive,
         false_positive, or ignored is what populates the console's Resolution view. At least one
-        update parameter must be provided. Returns `[]` (empty list) on success, or
+        update parameter must be provided. Requests covering more than 1000 detection IDs are
+        chunked automatically so none are silently dropped. Returns `[]` (empty list) on success, or
         `{"result": [], "hint": "..."}` when closing without adding a resolution tag in this call;
-        returns an error dict on failure.
+        returns an error dict on failure. If a later chunk fails after earlier chunks already
+        applied, the error dict carries a `partial_success` block listing the already-updated ids so
+        the caller can retry only the remainder rather than re-applying non-idempotent actions.
         """
         # Validate mutually exclusive assignment parameters
         assignment_params = [assign_to_uuid, assign_to_user_id, assign_to_name]
@@ -524,17 +531,36 @@ class DetectionsModule(BaseModule):
         if not action_parameters:
             return {"error": "At least one update parameter must be provided."}
 
-        body = {
-            "composite_ids": ids,
-            "action_parameters": action_parameters,
-        }
+        body_base = {"action_parameters": action_parameters}
 
-        result = self._base_query_api_call(
-            operation="PatchEntitiesAlertsV3",
-            body_params=body,
-            error_message="Failed to update detections",
-            default_result=[],
-        )
+        # PatchEntitiesAlertsV3 rejects more than MAX_UPDATE_COMPOSITE_IDS ids per
+        # request with HTTP 413, so chunk larger requests and fail loudly if any
+        # batch errors rather than reporting success on a truncated update.
+        result: list[dict[str, Any]] | dict[str, Any] = []
+        for i in range(0, len(ids), MAX_UPDATE_COMPOSITE_IDS):
+            batch = ids[i : i + MAX_UPDATE_COMPOSITE_IDS]
+            batch_result = self._base_query_api_call(
+                operation="PatchEntitiesAlertsV3",
+                body_params={**body_base, "composite_ids": batch},
+                error_message="Failed to update detections",
+                default_result=[],
+            )
+
+            if self._is_error(batch_result):
+                # The API applies each batch independently and cannot roll back, so
+                # ids before this batch are already updated. Report how many so the
+                # caller can retry only the remainder instead of re-applying
+                # non-idempotent actions (e.g. append_comment) to earlier ids.
+                if i > 0:
+                    batch_result["partial_success"] = {
+                        "updated_ids": ids[:i],
+                        "updated_count": i,
+                        "failed_and_remaining_ids": ids[i:],
+                    }
+                return batch_result
+
+            if isinstance(batch_result, list):
+                result.extend(batch_result)
 
         # Soft hint: closing without adding a resolution tag in this call may leave the
         # detection out of the console's Resolution view. Non-fatal — only wraps the success

--- a/tests/modules/test_detections.py
+++ b/tests/modules/test_detections.py
@@ -1525,6 +1525,132 @@ class TestDetectionsModule(TestModules):
         param_names = [p["name"] for p in call_body["action_parameters"]]
         self.assertNotIn("unassign", param_names)
 
+    def test_update_detections_single_batch_no_chunking(self):
+        """Exactly 1000 ids stay in one call (the API cap is inclusive)."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+        ids = [f"id{i}" for i in range(1000)]
+
+        result = self.module.update_detections(
+            ids=ids,
+            status="closed",
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=["true_positive"],
+            remove_tags=None,
+            remove_tags_by_prefix=None,
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        self.assertEqual(
+            self.mock_client.command.call_args[1]["body"]["composite_ids"], ids
+        )
+        self.assertEqual(result, [])
+
+    def test_update_detections_chunks_over_1000_ids(self):
+        """More than 1000 ids are split into batches of the API max and aggregated."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": []},
+        }
+        ids = [f"id{i}" for i in range(2500)]
+
+        result = self.module.update_detections(
+            ids=ids,
+            status="in_progress",
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
+        )
+
+        # 2500 ids -> 1000 + 1000 + 500
+        self.assertEqual(self.mock_client.command.call_count, 3)
+        batches = [
+            call.kwargs["body"]["composite_ids"]
+            for call in self.mock_client.command.call_args_list
+        ]
+        self.assertEqual([len(b) for b in batches], [1000, 1000, 500])
+        # Every id is covered exactly once, in order, with no overlap or gaps.
+        self.assertEqual([cid for b in batches for cid in b], ids)
+        # Each batch carries the same action parameters.
+        for call in self.mock_client.command.call_args_list:
+            self.assertEqual(
+                call.kwargs["body"]["action_parameters"],
+                [{"name": "update_status", "value": "in_progress"}],
+            )
+        self.assertEqual(result, [])
+
+    def test_update_detections_failing_batch_surfaces_error(self):
+        """A failure on any batch returns an error dict and stops further calls."""
+        ok = {"status_code": 200, "body": {"resources": []}}
+        boom = {"status_code": 500, "body": {"errors": [{"message": "boom"}]}}
+        # First batch succeeds, second fails; third must never be attempted.
+        self.mock_client.command.side_effect = [ok, boom, ok]
+        ids = [f"id{i}" for i in range(2500)]
+
+        result = self.module.update_detections(
+            ids=ids,
+            status="closed",
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=["true_positive"],
+            remove_tags=None,
+            remove_tags_by_prefix=None,
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 2)
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+        # The first batch already mutated its ids on the backend (no rollback), so
+        # the error must report them for a safe partial retry.
+        self.assertIn("partial_success", result)
+        self.assertEqual(result["partial_success"]["updated_count"], 1000)
+        self.assertEqual(result["partial_success"]["updated_ids"], ids[:1000])
+        self.assertEqual(result["partial_success"]["failed_and_remaining_ids"], ids[1000:])
+
+    def test_update_detections_first_batch_failure_has_no_partial_success(self):
+        """A failure on the very first batch reports no partial success (nothing applied)."""
+        self.mock_client.command.return_value = {
+            "status_code": 500,
+            "body": {"errors": [{"message": "boom"}]},
+        }
+        ids = [f"id{i}" for i in range(2500)]
+
+        result = self.module.update_detections(
+            ids=ids,
+            status="in_progress",
+            assign_to_uuid=None,
+            assign_to_user_id=None,
+            assign_to_name=None,
+            unassign=None,
+            append_comment=None,
+            show_in_ui=None,
+            add_tags=None,
+            remove_tags=None,
+            remove_tags_by_prefix=None,
+        )
+
+        self.assertEqual(self.mock_client.command.call_count, 1)
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+        self.assertNotIn("partial_success", result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #505. The detections update endpoint accepts at most 1000 composite ids per request and rejects anything larger, so update_detections silently applied only the first batch of a bigger request while still reporting success. This chunks requests into batches of 1000 and returns an error right away if any batch fails, instead of masking a truncated update.

Because the API applies each batch on its own with no rollback, a failure after earlier batches already succeeded now includes a partial_success block naming the ids that were already updated, so a caller can retry just the remainder rather than re-applying non-idempotent actions like appended comments.