### PR TITLE
docs(modules): recommend dot form for FQL sort separator

### DIFF
--- a/falcon_mcp/modules/cases.py
+++ b/falcon_mcp/modules/cases.py
@@ -208,7 +208,7 @@ class CasesModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="Sort order. Fields: created_timestamp, updated_timestamp, severity, status, name, reference_id. Formats: 'field.desc', 'field|asc'. Example: 'created_timestamp.desc'",
+            description="Sort order. Fields: created_timestamp, updated_timestamp, severity, status, name, reference_id. Prefer the dot separator ('field.desc'), which is supported on every Falcon sort endpoint; the pipe form ('field|asc') also works here. Example: 'created_timestamp.desc'",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Find cases by criteria and return their complete details.

--- a/falcon_mcp/modules/cloud.py
+++ b/falcon_mcp/modules/cloud.py
@@ -219,8 +219,10 @@ class CloudModule(BaseModule):
                 first_seen: Timestamp when the container was first seen
                 running_status: Container running status which is either true or false
 
-                Sort either asc (ascending) or desc (descending).
-                Both formats are supported: 'container_name.desc' or 'container_name|desc'
+                Sort either asc (ascending) or desc (descending). Use the dot
+                separator ('container_name.desc'), which is supported on every
+                Falcon sort endpoint. The pipe form ('container_name|desc') is
+                accepted here but rejected by some endpoints, so prefer the dot form.
 
                 When searching containers running vulnerable images, use 'image_vulnerability_count.desc' to get container with most images vulnerabilities.
 
@@ -319,8 +321,10 @@ class CloudModule(BaseModule):
                 cvss_score: CVSS score of the image vulnerability
                 images_impacted: Number of images impacted by the vulnerability
 
-                Sort either asc (ascending) or desc (descending).
-                Both formats are supported: 'container_name.desc' or 'container_name|desc'
+                Sort either asc (ascending) or desc (descending). Use the dot
+                separator ('cvss_score.desc'), which is supported on every Falcon
+                sort endpoint. The pipe form ('cvss_score|desc') is accepted here
+                but rejected by some endpoints, so prefer the dot form.
 
                 Examples: 'cvss_score.desc', 'cps_current_rating.asc'
             """
@@ -384,8 +388,10 @@ class CloudModule(BaseModule):
                 creation_time: When the asset was created
                 updated_at: When the asset was last updated
 
-                Sort either asc (ascending) or desc (descending).
-                Both formats are supported: 'updated_at.desc' or 'updated_at|desc'
+                Sort either asc (ascending) or desc (descending). Use the dot
+                separator ('updated_at.desc'), which is supported on every Falcon
+                sort endpoint. The pipe form ('updated_at|desc') is accepted here
+                but rejected by some endpoints, so prefer the dot form.
 
                 Examples: 'updated_at.desc', 'resource_type.asc'
             """
@@ -586,7 +592,8 @@ class CloudModule(BaseModule):
             default=None,
             description=dedent(
                 """
-                Sort IOM findings. Use |asc or |desc suffix to specify direction.
+                Sort IOM findings. Use a .asc or .desc suffix to specify direction.
+                Prefer the dot separator, supported on every Falcon sort endpoint.
 
                 Common sort fields:
                 severity: Finding severity level
@@ -596,10 +603,10 @@ class CloudModule(BaseModule):
                 service: Cloud service name
                 status: Finding status
 
-                Examples: 'severity|desc', 'last_detected|desc', 'first_detected|asc'
+                Examples: 'severity.desc', 'last_detected.desc', 'first_detected.asc'
             """
             ).strip(),
-            examples=["severity|desc", "last_detected|desc"],
+            examples=["severity.desc", "last_detected.desc"],
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for CSPM Indicators of Misconfiguration (IOM) findings.
@@ -667,13 +674,14 @@ class CloudModule(BaseModule):
         sort: str | None = Field(
             default=None,
             description=(
-                "Sort risks using field|asc or field|desc syntax.\n\n"
+                "Sort risks using field.asc or field.desc syntax. Prefer the dot "
+                "separator, supported on every Falcon sort endpoint.\n\n"
                 "Supported fields: account_id, account_name, asset_id, asset_name, "
                 "asset_region, asset_type, cloud_provider, first_seen, last_seen, "
                 "resolved_at, rule_name, service_category, severity, status\n\n"
-                "Examples: 'severity|desc', 'first_seen|desc', 'account_name|asc'"
+                "Examples: 'severity.desc', 'first_seen.desc', 'account_name.asc'"
             ),
-            examples=["severity|desc", "first_seen|desc", "account_name|asc"],
+            examples=["severity.desc", "first_seen.desc", "account_name.asc"],
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for cloud risks in your CrowdStrike environment.
@@ -726,8 +734,8 @@ class CloudModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="Sort groups. Default: name|asc. Examples: 'name|asc', 'created_at|desc'",
-            examples=["name|asc", "created_at|desc"],
+            description="Sort groups. Default: name.asc. Prefer the dot separator, supported on every Falcon sort endpoint. Examples: 'name.asc', 'created_at.desc'",
+            examples=["name.asc", "created_at.desc"],
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """List cloud groups in your CrowdStrike environment.

--- a/falcon_mcp/modules/detections.py
+++ b/falcon_mcp/modules/detections.py
@@ -128,8 +128,10 @@ class DetectionsModule(BaseModule):
                 confidence: Confidence level of the detection (1-100)
                 agent_id: Agent ID associated with the detection
 
-                Sort either asc (ascending) or desc (descending).
-                Both formats are supported: 'severity.desc' or 'severity|desc'
+                Sort either asc (ascending) or desc (descending). Use the dot
+                separator ('severity.desc'), which is supported on every Falcon
+                sort endpoint. The pipe form ('severity|desc') is accepted here
+                but rejected by some endpoints, so prefer the dot form.
 
                 When searching for high severity detections, use 'severity.desc' to get the
                 highest severity detections first.

--- a/falcon_mcp/modules/discover.py
+++ b/falcon_mcp/modules/discover.py
@@ -156,8 +156,10 @@ class DiscoverModule(BaseModule):
                 country: Country location
                 criticality: Criticality level
 
-                Sort either asc (ascending) or desc (descending).
-                Both formats are supported: 'hostname.desc' or 'hostname|desc'
+                Sort either asc (ascending) or desc (descending). Use the dot
+                separator ('hostname.desc'), which is supported on every Falcon
+                sort endpoint. The pipe form ('hostname|desc') is accepted here
+                but rejected by some endpoints, so prefer the dot form.
 
                 Examples: 'hostname.asc', 'last_seen_timestamp.desc', 'criticality.desc'
             """).strip(),

--- a/falcon_mcp/modules/firewall.py
+++ b/falcon_mcp/modules/firewall.py
@@ -101,9 +101,11 @@ class FirewallModule(BaseModule):
             description=dedent("""
                 Sort firewall rules using FQL syntax.
 
-                Supported examples: name.asc, modified_on.desc, platform|asc
+                Supported examples: name.asc, modified_on.desc. Prefer the dot
+                separator ('modified_on.desc'), which is supported on every Falcon
+                sort endpoint; the pipe form ('platform|asc') also works here.
             """).strip(),
-            examples=["modified_on.desc", "name|asc"],
+            examples=["modified_on.desc", "name.asc"],
         ),
         q: str | None = Field(
             default=None,

--- a/falcon_mcp/modules/host_groups.py
+++ b/falcon_mcp/modules/host_groups.py
@@ -144,7 +144,9 @@ class HostGroupsModule(BaseModule):
                 modified_timestamp: When the group was last modified
 
                 Sort either asc (ascending) or desc (descending).
-                Both formats are supported: 'name.desc' or 'name|desc'
+                Use the dot separator ('name.desc'), which is supported on every
+                Falcon sort endpoint. The pipe form ('name|desc') is accepted
+                here but rejected by some endpoints, so prefer the dot form.
 
                 Examples: 'name.asc', 'created_timestamp.desc'
             """).strip(),

--- a/falcon_mcp/modules/hosts.py
+++ b/falcon_mcp/modules/hosts.py
@@ -132,8 +132,10 @@ class HostsModule(BaseModule):
                 os_version: Operating system version
                 external_ip: External IP address
 
-                Sort either asc (ascending) or desc (descending).
-                Both formats are supported: 'hostname.desc' or 'hostname|desc'
+                Sort either asc (ascending) or desc (descending). Use the dot
+                separator ('hostname.desc'), which is supported on every Falcon
+                sort endpoint. The pipe form ('hostname|desc') is accepted here
+                but rejected by some endpoints, so prefer the dot form.
 
                 Examples: 'hostname.asc', 'last_seen.desc', 'platform_name.asc'
             """).strip(),

--- a/falcon_mcp/modules/intel.py
+++ b/falcon_mcp/modules/intel.py
@@ -129,11 +129,12 @@ class IntelModule(BaseModule):
             default=None,
             description=(
                 "The field and direction to sort results on. The format is "
-                "{field}|{asc/desc}. Valid values include: name, target_countries, "
+                "{field}.{asc/desc}. Valid values include: name, target_countries, "
                 "target_industries, type, created_date, last_activity_date and "
-                "last_modified_date. Ex: created_date|desc"
+                "last_modified_date. Prefer the dot separator, supported on every "
+                "Falcon sort endpoint. Ex: created_date.desc"
             ),
-            examples={"created_date|desc"},
+            examples={"created_date.desc"},
         ),
         q: str | None = Field(
             default=None,
@@ -190,10 +191,12 @@ class IntelModule(BaseModule):
             default=None,
             description=(
                 "The field and direction to sort results on. The format is "
-                "{field}|{asc/desc}. Valid values are: id, indicator, type, "
-                "published_date, last_updated, and _marker. Ex: published_date|desc"
+                "{field}.{asc/desc}. Valid values are: id, indicator, type, "
+                "published_date, last_updated, and _marker. Prefer the dot "
+                "separator, supported on every Falcon sort endpoint. Ex: "
+                "published_date.desc"
             ),
-            examples={"published_date|desc"},
+            examples={"published_date.desc"},
         ),
         q: str | None = Field(
             default=None,
@@ -266,9 +269,9 @@ class IntelModule(BaseModule):
                 "The field and direction to sort results on in the format of: "
                 "{field}.{asc}or {field}.{desc}. Valid values include: name, "
                 "target_countries, target_industries, type, created_date, "
-                "last_modified_date. Ex: created_date|desc"
+                "last_modified_date. Ex: created_date.desc"
             ),
-            examples={"created_date|desc"},
+            examples={"created_date.desc"},
         ),
         q: str | None = Field(
             default=None,

--- a/falcon_mcp/modules/ioc.py
+++ b/falcon_mcp/modules/ioc.py
@@ -100,10 +100,12 @@ class IOCModule(BaseModule):
                 action, applied_globally, created_on, expiration, modified_on,
                 severity_number, source, type, value
 
-                Supported formats: 'field.asc', 'field.desc', 'field|asc', 'field|desc'
-                Examples: 'modified_on.desc', 'severity_number|desc'
+                Prefer the dot separator ('field.desc'), which is supported on
+                every Falcon sort endpoint. The pipe form ('field|desc') also
+                works here.
+                Examples: 'modified_on.desc', 'severity_number.desc'
             """).strip(),
-            examples={"modified_on.desc", "severity_number|desc"},
+            examples={"modified_on.desc", "severity_number.desc"},
         ),
         after: str | None = Field(
             default=None,

--- a/falcon_mcp/modules/quarantine.py
+++ b/falcon_mcp/modules/quarantine.py
@@ -101,7 +101,7 @@ class QuarantineModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="Sort quarantined files using FQL syntax such as `date_updated|desc` or `hostname|asc`.",
+            description="Sort quarantined files using FQL syntax such as `date_updated.desc` or `hostname.asc`. Prefer the dot separator, supported on every Falcon sort endpoint.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search quarantined files and return full quarantine metadata.

--- a/falcon_mcp/modules/recon.py
+++ b/falcon_mcp/modules/recon.py
@@ -133,10 +133,10 @@ class ReconModule(BaseModule):
                 created_date: When the notification was created
                 updated_date: When the notification was last updated
 
-                Append |asc or |desc for direction (default desc).
-                Examples: 'created_date|desc', 'updated_date|asc'
+                Append .asc or .desc for direction (default desc).
+                Examples: 'created_date.desc', 'updated_date.asc'
             """).strip(),
-            examples=["created_date|desc", "updated_date|asc"],
+            examples=["created_date.desc", "updated_date.asc"],
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search Falcon Intelligence Recon notifications (also called recon alerts)
@@ -229,10 +229,10 @@ class ReconModule(BaseModule):
                 priority: Rule priority level
                 topic: Rule topic category
 
-                Append |asc or |desc for direction (default desc).
-                Examples: 'created_timestamp|desc', 'priority|asc'
+                Append .asc or .desc for direction (default desc).
+                Examples: 'created_timestamp.desc', 'priority.asc'
             """).strip(),
-            examples=["created_timestamp|desc", "last_updated_timestamp|desc"],
+            examples=["created_timestamp.desc", "last_updated_timestamp.desc"],
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search Falcon Intelligence Recon monitoring rules and return their full details.
@@ -321,10 +321,10 @@ class ReconModule(BaseModule):
                 created_date: When the record was created
                 exposure_date: When the data was exposed/breached
 
-                Append |asc or |desc for direction (default desc).
-                Examples: 'created_date|desc', 'exposure_date|desc'
+                Append .asc or .desc for direction (default desc).
+                Examples: 'created_date.desc', 'exposure_date.desc'
             """).strip(),
-            examples=["created_date|desc", "exposure_date|desc"],
+            examples=["created_date.desc", "exposure_date.desc"],
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search Falcon Intelligence Recon exposed-data records and return their full details.

--- a/falcon_mcp/modules/rtr.py
+++ b/falcon_mcp/modules/rtr.py
@@ -288,10 +288,11 @@ class RTRModule(BaseModule):
         sort: str | None = Field(
             default=None,
             description=dedent("""
-                Sort RTR audit sessions by a supported audit property using pipe syntax:
-                `created_at|desc`, `updated_at|asc`, or `deleted_at|desc`.
+                Sort RTR audit sessions by a supported audit property using the
+                dot separator, supported on every Falcon sort endpoint:
+                `created_at.desc`, `updated_at.asc`, or `deleted_at.desc`.
             """).strip(),
-            examples=["created_at|desc", "updated_at|asc"],
+            examples=["created_at.desc", "updated_at.asc"],
         ),
         with_command_info: bool = Field(
             default=False,

--- a/falcon_mcp/modules/spotlight.py
+++ b/falcon_mcp/modules/spotlight.py
@@ -76,14 +76,15 @@ class SpotlightModule(BaseModule):
                 • updated_timestamp: When the vulnerability was last updated
 
                 Sort either asc (ascending) or desc (descending).
-                Format: 'field|direction'
+                Format: 'field.direction' — prefer the dot separator, supported
+                on every Falcon sort endpoint.
 
-                Examples: 'created_timestamp|desc', 'updated_timestamp|desc', 'closed_timestamp|asc'
+                Examples: 'created_timestamp.desc', 'updated_timestamp.desc', 'closed_timestamp.asc'
             """).strip(),
             examples=[
-                "created_timestamp|desc",
-                "updated_timestamp|desc",
-                "closed_timestamp|asc",
+                "created_timestamp.desc",
+                "updated_timestamp.desc",
+                "closed_timestamp.asc",
             ],
         ),
         after: str | None = Field(


### PR DESCRIPTION
The sort-separator advice in our tool docstrings was inconsistent. Hosts and detections said both `field.desc` and `field|desc` work, while several cloud, intel, recon, quarantine, spotlight, and RTR tools advertised the pipe form only.

That matters because the pipe form isn't universally accepted. On `queryMLExclusionsV1`, for example, `last_modified.desc` returns 200 but `last_modified|desc` returns 400. So a tool that recommends pipe-only can steer a consumer straight into a failure on some endpoints.

This change reconciles all the entity-sort docstrings to recommend the dot form as the safe default. Where the pipe form still happens to work I note that it's accepted but not preferred. The one thing I deliberately left alone is aggregate bucket sort (`_count|desc`, `_key|asc`), since pipe really is the only form those accept.

This revives the work from #510, which was closed after its branch was deleted. Rebased onto current main. Closes #503.