### PR TITLE
chore(deps): bump falconpy 1.6.4, cryptography 50.0.0, mcp 1.28.1

### DIFF
--- a/falcon_mcp/client.py
+++ b/falcon_mcp/client.py
@@ -67,7 +67,7 @@ class FalconClient:
             )
 
         # Build APIHarnessV2 initialization parameters
-        api_params = {
+        api_params: dict[str, Any] = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
             "base_url": self.base_url,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 ]
 dependencies = [
     "anyio>=4.5",
-    "crowdstrike-falconpy>=1.3.0",
-    "mcp>=1.12.1,<2.0.0",
+    "crowdstrike-falconpy>=1.6.4",
+    "mcp>=1.28.1,<2.0.0",
     "python-dotenv>=1.1.1",
 ]
 
@@ -47,7 +47,7 @@ constraint-dependencies = [
     "pyjwt>=2.12.0",
     "idna>=3.15",
     "requests>=2.33.0",
-    "cryptography>=48.0.1",
+    "cryptography>=50.0.0",
 ]
 
 [tool.black]


### PR DESCRIPTION
Bumps FalconPy to 1.6.4, cryptography to 50.0.0, and mcp to 1.28.1.

FalconPy 1.6.4 now ships type information, so mypy started type-checking the `APIHarnessV2(**api_params)` call in the client and flagged the mixed-value dict. Annotating `api_params` as `dict[str, Any]` keeps that unpack valid. No behavior change.