### PR TITLE
feat(modules/recon): add aggregation and rule-preview tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Full docs are available at **[developer.crowdstrike.com/falcon-mcp](https://deve
 | [Policies](https://developer.crowdstrike.com/falcon-mcp/modules/policies/) | Search, create, update, and delete prevention, sensor update, firewall, device control, response, and content update policies; manage host-group assignment, enable/disable, and precedence |
 | [Quarantine](https://developer.crowdstrike.com/falcon-mcp/modules/quarantine/) | Search quarantine records, preview action counts, and release, unrelease, or delete quarantined files |
 | [Real Time Response](https://developer.crowdstrike.com/falcon-mcp/modules/rtr/) | Audit, summarize, and run read-only RTR triage workflows |
-| [Recon](https://developer.crowdstrike.com/falcon-mcp/modules/recon/) | Search Falcon Intelligence Recon notifications (recon alerts), monitoring rules, and exposed-data records for dark web, leaked credentials, and typosquatting |
+| [Recon](https://developer.crowdstrike.com/falcon-mcp/modules/recon/) | Search and aggregate Falcon Intelligence Recon notifications (recon alerts), monitoring rules, and exposed-data records for dark web, leaked credentials, and typosquatting, and preview prospective rule noise |
 | [Scheduled Reports](https://developer.crowdstrike.com/falcon-mcp/modules/scheduled-reports/) | Manage scheduled reports and download report files |
 | [Sensor Usage](https://developer.crowdstrike.com/falcon-mcp/modules/sensor-usage/) | Access and analyze sensor usage data |
 | [Serverless](https://developer.crowdstrike.com/falcon-mcp/modules/serverless/) | Search for vulnerabilities in serverless functions |

--- a/docs/modules/recon.md
+++ b/docs/modules/recon.md
@@ -12,6 +12,66 @@ Searching Falcon Intelligence Recon notifications, monitoring rules, and exposed
 
 ## Tools
 
+### `falcon_aggregate_recon_exposed_data_records`
+
+**Required scopes:** `Monitoring rules (Falcon Intelligence Recon):read`
+
+Count and group Falcon Intelligence Recon exposed-data records into summary buckets.
+
+Use this to answer how many, top, most common, per day, or over time questions about
+leaked credentials and PII — which sites leak the most, the newly-versus-previously
+reported mix, or exposure volume over time — without retrieving individual rows.
+Consult `falcon://recon/exposed-data-records/aggregate-guide` for the restricted field
+list and `falcon://recon/exposed-data-records/search/fql-guide` before writing a filter.
+Returns one entry per aggregation, each with a `name` and `buckets` keyed on `label`
+and `count`.
+
+**Example prompts:**
+
+- "Which sites leak the most of our credentials?"
+- "How many exposed credentials are newly reported vs previously reported?"
+- "Show exposed data record volume per day"
+
+### `falcon_aggregate_recon_notifications`
+
+**Required scopes:** `Monitoring rules (Falcon Intelligence Recon):read`
+
+Count and group Falcon Intelligence Recon notifications into summary buckets.
+
+Use this to answer how many, top, most common, per day, or over time questions about
+recon notifications — the mix of statuses, the noisiest monitoring rules, or the
+typosquatting trend — without retrieving individual records. Consult
+`falcon://recon/notifications/aggregate-guide` for aggregatable fields and
+`falcon://recon/notifications/search/fql-guide` before writing a filter. Returns one
+entry per aggregation, each with a `name` and `buckets` keyed on `label` and `count`.
+
+**Example prompts:**
+
+- "How many recon notifications are there by status?"
+- "What are the top 10 noisiest recon monitoring rules this month?"
+- "Show recon notification volume per day for the past 30 days"
+- "Break down typosquatting notifications by priority"
+
+### `falcon_preview_recon_rule`
+
+**Required scopes:** `Monitoring rules (Falcon Intelligence Recon):read`
+
+Estimate how many notifications a prospective Recon monitoring rule would generate.
+
+Use this before creating a monitoring rule to judge how noisy it would be, or to
+compare candidate filters — a high total means the rule needs tightening. Consult
+`falcon://recon/rules/preview-guide` for the rule-filter dialect, since `filter` is a
+rule definition rather than a notification search filter; to summarize notifications
+that already exist, use `falcon_aggregate_recon_notifications` instead. Returns a
+fixed breakdown of `channel`, `count`, and `site` aggregations with `label`/`count`
+buckets.
+
+**Example prompts:**
+
+- "How noisy would a rule monitoring example.com be?"
+- "Preview how many notifications a brand rule for Acme would generate in the past 30 days"
+- "Estimate the notification volume before I create this monitoring rule"
+
 ### `falcon_search_recon_exposed_data_records`
 
 **Required scopes:** `Monitoring rules (Falcon Intelligence Recon):read`
@@ -82,3 +142,6 @@ Responses include `pagination.total` (the total number of records matching the f
 - **`falcon://recon/notifications/search/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_recon_notifications` tool.
 - **`falcon://recon/rules/search/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_recon_rules` tool.
 - **`falcon://recon/exposed-data-records/search/fql-guide`**: Contains the guide for the `filter` param of the `falcon_search_recon_exposed_data_records` tool.
+- **`falcon://recon/notifications/aggregate-guide`**: Contains the aggregatable fields and usage guide for the `falcon_aggregate_recon_notifications` tool.
+- **`falcon://recon/exposed-data-records/aggregate-guide`**: Contains the aggregatable fields and usage guide for the `falcon_aggregate_recon_exposed_data_records` tool.
+- **`falcon://recon/rules/preview-guide`**: Contains the rule-filter dialect, valid topics, and lookback values for the `falcon_preview_recon_rule` tool.

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -252,6 +252,11 @@ API_SCOPE_REQUIREMENTS = {
     "GetRulesV1": ["Monitoring rules (Falcon Intelligence Recon):read"],
     "QueryNotificationsExposedDataRecordsV1": ["Monitoring rules (Falcon Intelligence Recon):read"],
     "GetNotificationsExposedDataRecordsV1": ["Monitoring rules (Falcon Intelligence Recon):read"],
+    "AggregateNotificationsV1": ["Monitoring rules (Falcon Intelligence Recon):read"],
+    "AggregateNotificationsExposedDataRecordsV1": [
+        "Monitoring rules (Falcon Intelligence Recon):read"
+    ],
+    "PreviewRuleV1": ["Monitoring rules (Falcon Intelligence Recon):read"],
     # Policies operations - Content Update
     "queryCombinedContentUpdatePolicies": ["Content Update Policies:read"],
     "queryContentUpdatePolicies": ["Content Update Policies:read"],

--- a/falcon_mcp/filter_hints.py
+++ b/falcon_mcp/filter_hints.py
@@ -282,6 +282,24 @@ FILTER_HINTS: dict[str, str] = {
         "created_date:>'now-7d' (relative date). "
         "Ex: domain:'example.com'+credential_status:'newly_reported'"
     ),
+    "falcon_aggregate_recon_notifications": (
+        "Filters which notifications are counted. Common fields: "
+        "status (new|in-progress|pending-review|closed-true-positive|closed-false-positive), "
+        "rule_priority (low|medium|high|critical), "
+        "rule_topic (SA_TYPOSQUATTING|SA_THIRD_PARTY|SA_CUSTOM|SA_DOMAIN|SA_IP|SA_BRAND_PRODUCT), "
+        "rule_id, item_type, item_site, source_category, "
+        "created_date:>'now-30d' (relative date). "
+        "Ex: rule_topic:'SA_TYPOSQUATTING'+created_date:>'now-30d'"
+    ),
+    "falcon_aggregate_recon_exposed_data_records": (
+        "Filters which records are counted. Common fields: domain, email, "
+        "credential_status (newly_reported|confirmed_active|previously_reported), "
+        "site (telegram.org|stealer_logs|malware_logs), source_category, notification_id, "
+        "rule.topic (SA_DOMAIN|SA_EMAIL), "
+        "created_date:>'now-7d' (relative date). "
+        "NOTE: the aggregatable `field` list is narrower than what this filter accepts. "
+        "Ex: credential_status:'newly_reported'+created_date:>'now-30d'"
+    ),
     # === Scheduled Reports ===
     "falcon_search_scheduled_reports": (
         "Common fields: name, type, status (Active|Inactive|Expired), "

--- a/falcon_mcp/modules/recon.py
+++ b/falcon_mcp/modules/recon.py
@@ -6,21 +6,38 @@ monitoring rules, and exposed-data records.
 """
 
 from textwrap import dedent
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server import FastMCP
 from mcp.server.fastmcp.resources import TextResource
 from pydantic import AnyUrl, Field
 
+from falcon_mcp.common.errors import handle_api_response
 from falcon_mcp.common.logging import get_logger
+from falcon_mcp.common.utils import prepare_api_parameters
 from falcon_mcp.modules.base import BaseModule
 from falcon_mcp.resources.recon import (
+    AGGREGATE_RECON_EXPOSED_DATA_RECORDS_GUIDE,
+    AGGREGATE_RECON_NOTIFICATIONS_GUIDE,
+    PREVIEW_RECON_RULE_GUIDE,
     SEARCH_RECON_EXPOSED_DATA_RECORDS_FQL_DOCUMENTATION,
     SEARCH_RECON_NOTIFICATIONS_FQL_DOCUMENTATION,
     SEARCH_RECON_RULES_FQL_DOCUMENTATION,
 )
 
 logger = get_logger(__name__)
+
+# Aggregation types both recon aggregate endpoints accept. `sum`, `avg`, and
+# `percentiles` are rejected with a 400, so they are deliberately absent.
+ReconAggregateType = Literal[
+    "terms",
+    "date_histogram",
+    "date_range",
+    "range",
+    "cardinality",
+    "max",
+    "min",
+]
 
 
 class ReconModule(BaseModule):
@@ -48,6 +65,24 @@ class ReconModule(BaseModule):
             server=server,
             method=self.search_recon_exposed_data_records,
             name="search_recon_exposed_data_records",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.aggregate_recon_notifications,
+            name="aggregate_recon_notifications",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.aggregate_recon_exposed_data_records,
+            name="aggregate_recon_exposed_data_records",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.preview_recon_rule,
+            name="preview_recon_rule",
         )
 
     def register_resources(self, server: FastMCP) -> None:
@@ -92,6 +127,45 @@ class ReconModule(BaseModule):
                     "`falcon_search_recon_exposed_data_records` tool."
                 ),
                 text=SEARCH_RECON_EXPOSED_DATA_RECORDS_FQL_DOCUMENTATION,
+            ),
+        )
+
+        self._add_resource(
+            server,
+            TextResource(
+                uri=AnyUrl("falcon://recon/notifications/aggregate-guide"),
+                name="falcon_aggregate_recon_notifications_guide",
+                description=(
+                    "Contains the aggregatable fields and usage guide for the "
+                    "`falcon_aggregate_recon_notifications` tool."
+                ),
+                text=AGGREGATE_RECON_NOTIFICATIONS_GUIDE,
+            ),
+        )
+
+        self._add_resource(
+            server,
+            TextResource(
+                uri=AnyUrl("falcon://recon/exposed-data-records/aggregate-guide"),
+                name="falcon_aggregate_recon_exposed_data_records_guide",
+                description=(
+                    "Contains the aggregatable fields and usage guide for the "
+                    "`falcon_aggregate_recon_exposed_data_records` tool."
+                ),
+                text=AGGREGATE_RECON_EXPOSED_DATA_RECORDS_GUIDE,
+            ),
+        )
+
+        self._add_resource(
+            server,
+            TextResource(
+                uri=AnyUrl("falcon://recon/rules/preview-guide"),
+                name="falcon_preview_recon_rule_guide",
+                description=(
+                    "Contains the rule-filter dialect, valid topics, and lookback values "
+                    "for the `falcon_preview_recon_rule` tool."
+                ),
+                text=PREVIEW_RECON_RULE_GUIDE,
             ),
         )
 
@@ -375,3 +449,291 @@ class ReconModule(BaseModule):
         # Restore the query-step sort order; the exposed-data details endpoint may reorder.
         details = self._reorder_by_ids(record_ids, details, id_field="id")
         return self._build_pagination_envelope(details, pagination, filter)
+
+    def aggregate_recon_notifications(
+        self,
+        field: str = Field(
+            description=(
+                "Notification field to group by, such as `status`, `rule_topic`, "
+                "`rule_priority`, `rule_id`, `item_type`, `item_site`, or `created_date`. "
+                "See `falcon://recon/notifications/aggregate-guide` for the full list."
+            ),
+            examples=["status", "rule_topic", "rule_priority", "created_date"],
+        ),
+        aggregate_type: ReconAggregateType = Field(
+            default="terms",
+            description=(
+                "Aggregation to run. Use `terms` for top values, `date_histogram` or "
+                "`date_range` for time buckets, `cardinality` for a distinct count, and "
+                "`max` or `min` for numeric extremes. `date_histogram` requires `interval`, "
+                "`date_range` requires `date_ranges`, and `range` requires `ranges`."
+            ),
+        ),
+        filter: str | None = Field(
+            default=None,
+            description=(
+                "FQL filter narrowing which notifications are counted. See "
+                "`falcon://recon/notifications/search/fql-guide` for syntax."
+            ),
+            examples=["rule_topic:'SA_TYPOSQUATTING'", "created_date:>'now-30d'"],
+        ),
+        q: str | None = Field(
+            default=None,
+            description="Free text search across all notification metadata.",
+        ),
+        name: str = Field(
+            default="recon_notification_aggregation",
+            description="Label echoed back on the result, identifying this aggregation.",
+        ),
+        size: int | None = Field(
+            default=10,
+            ge=1,
+            le=1000,
+            description="Maximum number of buckets to return for terms aggregations.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Bucket sort order, such as `_count|desc` or `_count|asc`.",
+            examples=["_count|desc", "_count|asc"],
+        ),
+        interval: str | None = Field(
+            default=None,
+            description=(
+                "Bucket width for `date_histogram`: hour, day, week, month, quarter, or year."
+            ),
+            examples=["day", "week"],
+        ),
+        date_ranges: list[dict[str, str]] | None = Field(
+            default=None,
+            description=(
+                "Time windows for `date_range` aggregations, for example "
+                "`[{'from': 'now-30d', 'to': 'now'}]`."
+            ),
+            examples=[[{"from": "now-30d", "to": "now"}]],
+        ),
+        ranges: list[dict[str, Any]] | None = Field(
+            default=None,
+            description=(
+                "Numeric windows for `range` aggregations, for example "
+                "`[{'From': 0, 'To': 100}]`. Required when aggregate_type is `range`."
+            ),
+            examples=[[{"From": 0, "To": 100}]],
+        ),
+        sub_aggregates: list[dict[str, Any]] | None = Field(
+            default=None,
+            description=(
+                "Nested aggregations run inside each bucket, for a breakdown within a "
+                "breakdown. Each entry uses the same shape as the top-level aggregation."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Count and group Falcon Intelligence Recon notifications into summary buckets.
+
+        Use this to answer how many, top, most common, per day, or over time questions about
+        recon notifications — the mix of statuses, the noisiest monitoring rules, or the
+        typosquatting trend — without retrieving individual records. Consult
+        `falcon://recon/notifications/aggregate-guide` for aggregatable fields and
+        `falcon://recon/notifications/search/fql-guide` before writing a filter. Returns one
+        entry per aggregation, each with a `name` and `buckets` keyed on `label` and `count`.
+        """
+        return self._base_aggregate(
+            operation="AggregateNotificationsV1",
+            agg_type=aggregate_type,
+            field=field,
+            filter=filter,
+            q=q,
+            name=name,
+            size=size,
+            sort=sort,
+            interval=interval,
+            date_ranges=date_ranges,
+            ranges=ranges,
+            sub_aggregates=sub_aggregates,
+            error_message="Failed to aggregate recon notifications",
+        )
+
+    def aggregate_recon_exposed_data_records(
+        self,
+        field: str = Field(
+            description=(
+                "Exposed-data-record field to group by. This endpoint accepts only: cid, "
+                "notification_id, notification_group_id, created_date, rule.id, rule.name, "
+                "rule.topic, source_category, site, author, file.name, credential_status, "
+                "bot.operating_system.hardware_id, bot.bot_id. Other fields are rejected — "
+                "see `falcon://recon/exposed-data-records/aggregate-guide`."
+            ),
+            examples=["credential_status", "site", "rule.topic", "created_date"],
+        ),
+        aggregate_type: ReconAggregateType = Field(
+            default="terms",
+            description=(
+                "Aggregation to run. Use `terms` for top values, `date_histogram` or "
+                "`date_range` for time buckets, `cardinality` for a distinct count, and "
+                "`max` or `min` for numeric extremes. `date_histogram` requires `interval`, "
+                "`date_range` requires `date_ranges`, and `range` requires `ranges`."
+            ),
+        ),
+        filter: str | None = Field(
+            default=None,
+            description=(
+                "FQL filter narrowing which records are counted. See "
+                "`falcon://recon/exposed-data-records/search/fql-guide` for syntax."
+            ),
+            examples=["credential_status:'newly_reported'", "domain:'example.com'"],
+        ),
+        q: str | None = Field(
+            default=None,
+            description="Free text search across all exposed-data record fields.",
+        ),
+        name: str = Field(
+            default="recon_exposed_data_aggregation",
+            description="Label echoed back on the result, identifying this aggregation.",
+        ),
+        size: int | None = Field(
+            default=10,
+            ge=1,
+            le=1000,
+            description="Maximum number of buckets to return for terms aggregations.",
+        ),
+        sort: str | None = Field(
+            default=None,
+            description="Bucket sort order, such as `_count|desc` or `_count|asc`.",
+            examples=["_count|desc", "_count|asc"],
+        ),
+        interval: str | None = Field(
+            default=None,
+            description=(
+                "Bucket width for `date_histogram`: hour, day, week, month, quarter, or year."
+            ),
+            examples=["day", "week"],
+        ),
+        date_ranges: list[dict[str, str]] | None = Field(
+            default=None,
+            description=(
+                "Time windows for `date_range` aggregations, for example "
+                "`[{'from': 'now-30d', 'to': 'now'}]`."
+            ),
+            examples=[[{"from": "now-30d", "to": "now"}]],
+        ),
+        ranges: list[dict[str, Any]] | None = Field(
+            default=None,
+            description=(
+                "Numeric windows for `range` aggregations, for example "
+                "`[{'From': 0, 'To': 100}]`. Required when aggregate_type is `range`."
+            ),
+            examples=[[{"From": 0, "To": 100}]],
+        ),
+        sub_aggregates: list[dict[str, Any]] | None = Field(
+            default=None,
+            description=(
+                "Nested aggregations run inside each bucket, for a breakdown within a "
+                "breakdown. Each entry uses the same shape as the top-level aggregation."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Count and group Falcon Intelligence Recon exposed-data records into summary buckets.
+
+        Use this to answer how many, top, most common, per day, or over time questions about
+        leaked credentials and PII — which sites leak the most, the newly-versus-previously
+        reported mix, or exposure volume over time — without retrieving individual rows.
+        Consult `falcon://recon/exposed-data-records/aggregate-guide` for the restricted field
+        list and `falcon://recon/exposed-data-records/search/fql-guide` before writing a filter.
+        Returns one entry per aggregation, each with a `name` and `buckets` keyed on `label`
+        and `count`.
+        """
+        return self._base_aggregate(
+            operation="AggregateNotificationsExposedDataRecordsV1",
+            agg_type=aggregate_type,
+            field=field,
+            filter=filter,
+            q=q,
+            name=name,
+            size=size,
+            sort=sort,
+            interval=interval,
+            date_ranges=date_ranges,
+            ranges=ranges,
+            sub_aggregates=sub_aggregates,
+            error_message="Failed to aggregate recon exposed-data records",
+        )
+
+    def preview_recon_rule(
+        self,
+        topic: Literal[
+            "SA_DOMAIN",
+            "SA_EMAIL",
+            "SA_IP",
+            "SA_AUTHOR",
+            "SA_BRAND_PRODUCT",
+            "SA_THIRD_PARTY",
+            "SA_CUSTOM",
+            "SA_VIP",
+            "SA_CVE",
+            "SA_ALIAS",
+        ] = Field(
+            description=(
+                "Topic of the prospective monitoring rule. SA_TYPOSQUATTING cannot be "
+                "previewed. Each topic supports different filter conditions — see "
+                "`falcon://recon/rules/preview-guide`."
+            ),
+            examples=["SA_DOMAIN", "SA_BRAND_PRODUCT"],
+        ),
+        filter: str = Field(
+            description=(
+                "The prospective rule's own match expression in monitoring-rule FQL, with "
+                "each condition parenthesized, e.g. `(domain:'example.com')`. This is not "
+                "notification search FQL. See `falcon://recon/rules/preview-guide` for the "
+                "condition words each topic supports."
+            ),
+            examples=[
+                "(domain:'example.com')",
+                "(phrase:'Acme')+(keyword:'Acme')",
+                "(email:'ceo@example.com')",
+            ],
+        ),
+        lookback_days: Literal[7, 30, 180, 365] | None = Field(
+            default=None,
+            description=(
+                "How far back to estimate over. Only 7, 30, 180, and 365 are accepted. "
+                "Omit to preview against the full retained window."
+            ),
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Estimate how many notifications a prospective Recon monitoring rule would generate.
+
+        Use this before creating a monitoring rule to judge how noisy it would be, or to
+        compare candidate filters — a high total means the rule needs tightening. Consult
+        `falcon://recon/rules/preview-guide` for the rule-filter dialect, since `filter` is a
+        rule definition rather than a notification search filter; to summarize notifications
+        that already exist, use `falcon_aggregate_recon_notifications` instead. Returns a
+        fixed breakdown of `channel`, `count`, and `site` aggregations with `label`/`count`
+        buckets.
+        """
+        operation = "PreviewRuleV1"
+        body = prepare_api_parameters(
+            {
+                "topic": topic,
+                "filter": filter,
+                "lookback_days": lookback_days,
+            }
+        )
+
+        logger.debug("Executing %s with body: %s", operation, body)
+
+        # A bare object, unlike the list-wrapped body the recon aggregate endpoints take.
+        response = self.client.command(operation, body=body)
+
+        result = handle_api_response(
+            response,
+            operation=operation,
+            error_message="Failed to preview recon rule",
+            default_result=[],
+        )
+
+        # The rule-filter dialect is the usual thing to get wrong here, and the API's
+        # rejection names the offending field but not the fix. Hand back the guide.
+        if self._is_error(result):
+            return self._format_fql_error_response([result], filter, PREVIEW_RECON_RULE_GUIDE)
+
+        return result
+

--- a/falcon_mcp/resources/recon.py
+++ b/falcon_mcp/resources/recon.py
@@ -977,3 +977,227 @@ rule.topic:'SA_DOMAIN'+created_date:>'now-7d'
 credential_status:'newly_reported',credential_status:'confirmed_active'
 """
 )
+
+# ---------------------------------------------------------------------------
+# Aggregation guides
+# ---------------------------------------------------------------------------
+
+_SHARED_AGGREGATION_SYNTAX = """
+=== AGGREGATION TYPES ===
+• terms: Top values of a field, ranked by document count. The default.
+• date_histogram: Evenly spaced time buckets. Set `interval` to hour, day, week,
+  month, quarter, or year.
+• date_range: Explicit time windows. Set `date_ranges`, e.g.
+  [{"from": "now-30d", "to": "now"}]
+• range: Explicit numeric windows. Set `ranges`, e.g. [{"From": 0, "To": 100}]
+• cardinality: Distinct-value count for a field.
+• max / min: Largest and smallest value of a numeric field.
+
+`date_histogram`, `date_range`, and `range` each fail without their companion
+argument — `interval`, `date_ranges`, and `ranges` respectively. Always supply it
+when choosing those types.
+
+Not supported on either recon aggregate endpoint: sum, avg, and percentiles all
+return a 400, including on numeric date fields.
+
+=== READING THE RESPONSE ===
+Each aggregation returns `{"name": ..., "buckets": [...]}`, where `name` echoes the
+`name` you passed — use it to tell results apart. Bucket entries key on `label` and
+`count`, not `key`.
+
+For cardinality, max, and min the single bucket looks like `{"count": 0, "value": N}`.
+The answer is `value`; the `count: 0` is an artifact of the shape and does NOT mean
+"no data".
+
+Date fields bucket as epoch-millisecond integers. `date_histogram` also returns
+`key_as_string` with a readable ISO timestamp.
+
+=== NARROWING AND NESTING ===
+• `filter` accepts the same FQL as the matching search tool, applied before aggregating.
+• `q` does a free-text search across the record.
+• `size` caps the number of terms buckets returned.
+• `sort` orders buckets, e.g. `_count|asc`.
+• `sub_aggregates` nests a second aggregation inside every bucket of the first, which
+  is how you get a breakdown-within-a-breakdown.
+
+A filter that references an unknown field returns an empty `resources` list with HTTP
+200 — indistinguishable from a filter that legitimately matched nothing. Malformed FQL
+syntax returns a 400. Stick to the fields in the matching search FQL guide.
+"""
+
+AGGREGATE_RECON_NOTIFICATIONS_GUIDE = (
+    """Recon Notification Aggregation Guide
+
+Use `falcon_aggregate_recon_notifications` to answer "how many" and "which are the top"
+questions about recon notifications without pulling individual records. For the records
+themselves, use `falcon_search_recon_notifications`.
+
+=== VERIFIED AGGREGATION FIELDS ===
+Notification attributes:
+• status — new, in-progress, pending-review, closed-true-positive,
+  closed-false-positive, closed-no-action-true-positive
+• rule_topic — SA_TYPOSQUATTING, SA_THIRD_PARTY, SA_CUSTOM, SA_DOMAIN, SA_IP,
+  SA_BRAND_PRODUCT, SA_ALIAS, SA_VIP, SA_EMAIL, SA_CVE, SA_AUTHOR, SA_BIN
+• rule_priority — low, medium, high, critical
+• rule_id, item_type, item_site, source_category, cid, user_uuid, id
+• assigned_to_uuid — unassigned, or a user UUID
+• created_date, updated_date — epoch millis; use with date_histogram or date_range
+
+Breach and typosquatting detail:
+• breach_summary.credential_statuses, breach_summary.is_retroactively_deduped
+• typosquatting.id, typosquatting.unicode_format, typosquatting.punycode_format
+• typosquatting.parent_domain.{id,unicode_format,punycode_format}
+• typosquatting.base_domain.{id,unicode_format,punycode_format,is_registered}
+• typosquatting.base_domain.whois.registrar.{name,status}
+• typosquatting.base_domain.whois.registrant.{email,name,org}
+• typosquatting.base_domain.whois.name_servers
+
+Do not aggregate on `rule_name` — it returns a server error on this endpoint. Aggregate
+on `rule_id` instead, then resolve names with `falcon_search_recon_rules`. The fields
+`notification_id`, `site`, and `author` belong to the exposed-data-record schema and
+return no buckets here.
+"""
+    + _SHARED_AGGREGATION_SYNTAX
+    + """
+=== EXAMPLES ===
+
+# Notification volume by status
+field: status, aggregate_type: terms
+
+# Busiest monitoring rules in the past 30 days
+field: rule_id, aggregate_type: terms, size: 10, filter: created_date:>'now-30d'
+
+# Daily notification trend
+field: created_date, aggregate_type: date_histogram, interval: day
+
+# Priority mix for typosquatting only
+field: rule_priority, aggregate_type: terms, filter: rule_topic:'SA_TYPOSQUATTING'
+
+# How many distinct rules have fired
+field: rule_id, aggregate_type: cardinality
+
+# Which registrars host the most typosquatting domains
+field: typosquatting.base_domain.whois.registrar.name, aggregate_type: terms, size: 10
+"""
+)
+
+AGGREGATE_RECON_EXPOSED_DATA_RECORDS_GUIDE = (
+    """Recon Exposed-Data Record Aggregation Guide
+
+Use `falcon_aggregate_recon_exposed_data_records` to summarize leaked credential and PII
+records — top breach sites, credential-status mix, volume over time — without pulling
+individual rows. For the rows themselves, use `falcon_search_recon_exposed_data_records`.
+
+=== AGGREGATION FIELDS: A STRICT LIST ===
+This endpoint accepts only the fourteen fields below and rejects anything else with a
+400. That is a much narrower set than the tool's `filter` parameter accepts, so a field
+you can filter on is not necessarily a field you can aggregate on.
+
+• cid
+• notification_id
+• notification_group_id
+• created_date — epoch millis; use with date_histogram or date_range
+• rule.id
+• rule.name
+• rule.topic — SA_DOMAIN, SA_EMAIL
+• source_category — chat_medium, other, and similar
+• site — telegram.org, stealer_logs, malware_logs, and similar
+• author
+• file.name
+• credential_status — newly_reported, previously_reported, confirmed_active
+• bot.operating_system.hardware_id
+• bot.bot_id
+
+Note the dotted spellings: this endpoint uses `rule.topic` and `rule.name`, whereas
+`falcon_aggregate_recon_notifications` uses `rule_topic`. They are not interchangeable.
+Commonly attempted but rejected here: id, email, domain, login_id, exposure_date,
+hash_type, user_uuid, site_id, author_id, status, rule_topic, and any location.*,
+financial.*, or social.* field.
+"""
+    + _SHARED_AGGREGATION_SYNTAX
+    + """
+=== EXAMPLES ===
+
+# Credential-status mix across all exposed data
+field: credential_status, aggregate_type: terms
+
+# Top sites leaking your credentials
+field: site, aggregate_type: terms, size: 10
+
+# Newly reported exposures by site
+field: site, aggregate_type: terms, size: 10, filter: credential_status:'newly_reported'
+
+# Exposure volume per day
+field: created_date, aggregate_type: date_histogram, interval: day
+
+# Which monitoring rules surface the most exposed records
+field: rule.name, aggregate_type: terms, size: 10
+
+# Credential-status breakdown within each rule topic
+field: rule.topic, aggregate_type: terms, sub_aggregates:
+  [{"type": "terms", "field": "credential_status", "name": "by_status"}]
+"""
+)
+
+PREVIEW_RECON_RULE_GUIDE = """Recon Rule Preview Guide
+
+Use `falcon_preview_recon_rule` to estimate how noisy a prospective monitoring rule would
+be before creating it. You supply a candidate rule definition and Falcon reports how many
+notifications it would have produced, broken down by channel and site.
+
+This tool takes a rule definition, not a notification search filter. To aggregate
+notifications that already exist, use `falcon_aggregate_recon_notifications`.
+
+=== THE FILTER IS RULE FQL, NOT SEARCH FQL ===
+`filter` is the prospective rule's own match expression, written in the monitoring-rule
+dialect and parenthesized per condition. It is a different language from the FQL used by
+`falcon_search_recon_notifications` — fields like `status` or `created_date` are invalid
+here. A bare value such as `example.com` is rejected as invalid FQL.
+
+Verified expressions by topic:
+| Topic            | Example filter                                    |
+|------------------|---------------------------------------------------|
+| SA_DOMAIN        | (domain:'example.com')                            |
+| SA_EMAIL         | (email:'user@example.com')                        |
+| SA_IP            | (ip:'1.2.3.4')                                    |
+| SA_AUTHOR        | (author:'handle')                                 |
+| SA_BRAND_PRODUCT | (phrase:'BrandName')+(keyword:'BrandName')        |
+| SA_THIRD_PARTY   | (phrase:'VendorName')                             |
+| SA_CUSTOM        | (keyword:'term')                                  |
+| SA_VIP           | (keyword:'term')                                  |
+| SA_CVE           | (keyword:'term')                                  |
+| SA_ALIAS         | (keyword:'term')                                  |
+
+Combine conditions with `+`. Using a condition word the topic does not support returns a
+400 naming `filter.expressions[0]`.
+
+=== TOPIC AND LOOKBACK CONSTRAINTS ===
+`topic` must be one of the topics above. SA_TYPOSQUATTING is rejected — typosquatting
+rules cannot be previewed. SA_BIN is accepted as a topic but has no supported condition
+word, so it cannot be previewed in practice either.
+
+`lookback_days` accepts only 7, 30, 180, and 365. Any other value, including 1, 14, or 90,
+returns a 400. Omitting it previews against the full retained window and returns a single
+`Total` count; supplying it adds a separate `Total - EDR` count for exposed-data matches.
+
+=== READING THE RESPONSE ===
+The breakdown is fixed — you cannot choose the aggregation fields. Three aggregations come
+back, each with `label`/`count` buckets:
+• channel — the kinds of sources that matched, e.g. public_repo, chat_medium, forum
+• count — total matches; `Total`, plus `Total - EDR` when lookback_days is set
+• site — the specific sites that matched, e.g. github.com, telegram.org
+
+`sum_other_doc_count` on channel and site reports matches beyond the returned buckets.
+A high total means the rule would be noisy; tighten the filter and preview again.
+
+=== EXAMPLES ===
+
+# How noisy would monitoring this domain be over the past 30 days?
+topic: SA_DOMAIN, filter: (domain:'example.com'), lookback_days: 30
+
+# Brand mention volume for the past week
+topic: SA_BRAND_PRODUCT, filter: (phrase:'Acme')+(keyword:'Acme'), lookback_days: 7
+
+# Full-window estimate for watching an executive's email
+topic: SA_EMAIL, filter: (email:'ceo@example.com')
+"""

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -408,6 +408,22 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
         "Show leaked credentials from the past 7 days",
         "Find exposed data records for a specific notification",
     ],
+    "falcon_aggregate_recon_notifications": [
+        "How many recon notifications are there by status?",
+        "What are the top 10 noisiest recon monitoring rules this month?",
+        "Show recon notification volume per day for the past 30 days",
+        "Break down typosquatting notifications by priority",
+    ],
+    "falcon_aggregate_recon_exposed_data_records": [
+        "Which sites leak the most of our credentials?",
+        "How many exposed credentials are newly reported vs previously reported?",
+        "Show exposed data record volume per day",
+    ],
+    "falcon_preview_recon_rule": [
+        "How noisy would a rule monitoring example.com be?",
+        "Preview how many notifications a brand rule for Acme would generate in the past 30 days",
+        "Estimate the notification volume before I create this monitoring rule",
+    ],
     # Scheduled Reports
     "falcon_search_scheduled_reports": [
         "Show me all active scheduled reports",

--- a/tests/integration/test_recon.py
+++ b/tests/integration/test_recon.py
@@ -39,8 +39,9 @@ class TestReconIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_recon_notifications, limit=5)
 
         self.assert_no_error(result, context="search_recon_notifications")
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_recon_notifications")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_recon_notifications"
+        )
 
     def test_search_recon_notifications_returns_full_details(self):
         """Test that results contain full notification detail, not just IDs."""
@@ -48,7 +49,8 @@ class TestReconIntegration(BaseIntegrationTest):
 
         self.assert_no_error(result, context="search_recon_notifications details")
 
-        if not isinstance(result, list) or len(result) == 0:
+        records = result["results"] if isinstance(result, dict) else result
+        if not records:
             self.skip_with_warning(
                 "No recon notifications available — skipping details field validation",
                 context="search_recon_notifications full details",
@@ -56,7 +58,7 @@ class TestReconIntegration(BaseIntegrationTest):
             return
 
         # Full details should have more than just an id field
-        first = result[0]
+        first = records[0]
         assert isinstance(first, dict), "Expected dict entity"
         assert "id" in first, f"Missing 'id' field; got keys: {list(first.keys())}"
         # A detailed notification has status and rule metadata at minimum
@@ -105,8 +107,7 @@ class TestReconIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_recon_rules, limit=5)
 
         self.assert_no_error(result, context="search_recon_rules")
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_recon_rules")
+        self.assert_valid_list_response(result, min_length=0, context="search_recon_rules")
 
     def test_search_recon_rules_returns_full_details(self):
         """Test that rule results contain full rule definition, not just IDs."""
@@ -114,14 +115,15 @@ class TestReconIntegration(BaseIntegrationTest):
 
         self.assert_no_error(result, context="search_recon_rules details")
 
-        if not isinstance(result, list) or len(result) == 0:
+        records = result["results"] if isinstance(result, dict) else result
+        if not records:
             self.skip_with_warning(
                 "No recon rules available — skipping details field validation",
                 context="search_recon_rules full details",
             )
             return
 
-        first = result[0]
+        first = records[0]
         assert isinstance(first, dict), "Expected dict entity"
         assert "id" in first, f"Missing 'id' field; got keys: {list(first.keys())}"
         assert len(first.keys()) > 1, (
@@ -154,10 +156,9 @@ class TestReconIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_recon_exposed_data_records, limit=5)
 
         self.assert_no_error(result, context="search_recon_exposed_data_records")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="search_recon_exposed_data_records"
-            )
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_recon_exposed_data_records"
+        )
 
     def test_search_recon_exposed_data_records_returns_full_details(self):
         """Test that exposed-data results contain full record detail, not just IDs."""
@@ -165,14 +166,15 @@ class TestReconIntegration(BaseIntegrationTest):
 
         self.assert_no_error(result, context="search_recon_exposed_data_records details")
 
-        if not isinstance(result, list) or len(result) == 0:
+        records = result["results"] if isinstance(result, dict) else result
+        if not records:
             self.skip_with_warning(
                 "No exposed-data records available — skipping details field validation",
                 context="search_recon_exposed_data_records full details",
             )
             return
 
-        first = result[0]
+        first = records[0]
         assert isinstance(first, dict), "Expected dict entity"
         assert "id" in first, f"Missing 'id' field; got keys: {list(first.keys())}"
         assert len(first.keys()) > 1, (
@@ -189,3 +191,281 @@ class TestReconIntegration(BaseIntegrationTest):
         self.assert_no_error(
             result, context="search_recon_exposed_data_records sort=created_date|desc"
         )
+
+    # ------------------------------------------------------------------
+    # Aggregations
+    # ------------------------------------------------------------------
+
+    def test_aggregate_recon_notifications_operation_name(self):
+        """Validate the AggregateNotificationsV1 operation name and terms buckets."""
+        result = self.call_method(
+            self.module.aggregate_recon_notifications,
+            field="status",
+            aggregate_type="terms",
+            name="by_status",
+            size=5,
+        )
+
+        self.assert_no_error(result, context="AggregateNotificationsV1 validation")
+        assert isinstance(result, list), f"Expected list of aggregations; got {type(result)}"
+
+        if not result:
+            self.skip_with_warning(
+                "No notification aggregations returned",
+                context="aggregate_recon_notifications",
+            )
+            return
+
+        agg = result[0]
+        assert agg.get("name") == "by_status", f"Aggregation name not echoed back: {agg}"
+        for bucket in agg.get("buckets") or []:
+            # Buckets key on `label`, not the Elasticsearch-style `key`.
+            assert "label" in bucket, f"Bucket missing 'label': {bucket}"
+            assert "count" in bucket, f"Bucket missing 'count': {bucket}"
+
+    def test_aggregate_recon_notifications_supported_types(self):
+        """Every aggregate_type the tool exposes must be accepted by the live API."""
+        cases = {
+            "terms": {"field": "rule_topic", "size": 3},
+            "date_histogram": {"field": "created_date", "interval": "day"},
+            "cardinality": {"field": "rule_id"},
+            "max": {"field": "created_date"},
+            "min": {"field": "created_date"},
+            "date_range": {
+                "field": "created_date",
+                "date_ranges": [{"from": "now-30d", "to": "now"}],
+            },
+            "range": {
+                "field": "created_date",
+                "ranges": [{"From": 0, "To": 9999999999999}],
+            },
+        }
+        for agg_type, kwargs in cases.items():
+            result = self.call_method(
+                self.module.aggregate_recon_notifications,
+                aggregate_type=agg_type,
+                name=f"probe_{agg_type}",
+                **kwargs,
+            )
+            self.assert_no_error(result, context=f"notifications aggregate_type={agg_type}")
+
+    def test_aggregate_recon_notifications_filter_narrows_results(self):
+        """A documented FQL filter must be honored, not silently ignored."""
+        unfiltered = self.call_method(
+            self.module.aggregate_recon_notifications,
+            field="rule_topic",
+            aggregate_type="terms",
+            name="all",
+            size=50,
+        )
+        filtered = self.call_method(
+            self.module.aggregate_recon_notifications,
+            field="rule_topic",
+            aggregate_type="terms",
+            filter="rule_topic:'SA_TYPOSQUATTING'",
+            name="filtered",
+            size=50,
+        )
+
+        self.assert_no_error(unfiltered, context="aggregate notifications unfiltered")
+        self.assert_no_error(filtered, context="aggregate notifications filtered")
+
+        all_buckets = (unfiltered[0].get("buckets") or []) if unfiltered else []
+        filtered_buckets = (filtered[0].get("buckets") or []) if filtered else []
+
+        if len(all_buckets) < 2 or not filtered_buckets:
+            self.skip_with_warning(
+                "Not enough topic diversity to prove the filter narrowed results",
+                context="aggregate_recon_notifications filter",
+            )
+            return
+
+        labels = {bucket["label"] for bucket in filtered_buckets}
+        assert labels == {"SA_TYPOSQUATTING"}, (
+            f"Filter did not narrow to the requested topic; got labels {labels}"
+        )
+
+    def test_aggregate_recon_exposed_data_records_operation_name(self):
+        """Validate the AggregateNotificationsExposedDataRecordsV1 operation name."""
+        result = self.call_method(
+            self.module.aggregate_recon_exposed_data_records,
+            field="credential_status",
+            aggregate_type="terms",
+            name="by_credential_status",
+            size=5,
+        )
+
+        self.assert_no_error(
+            result, context="AggregateNotificationsExposedDataRecordsV1 validation"
+        )
+        assert isinstance(result, list), f"Expected list of aggregations; got {type(result)}"
+
+    def test_aggregate_recon_exposed_data_records_supported_types(self):
+        """Every aggregate_type the tool exposes must be accepted by this endpoint too.
+
+        Both aggregate tools share one `ReconAggregateType`, so the exposed-data
+        endpoint needs the same live coverage as the notifications one.
+        """
+        cases = {
+            "terms": {"field": "rule.topic", "size": 3},
+            "date_histogram": {"field": "created_date", "interval": "day"},
+            "cardinality": {"field": "rule.id"},
+            "max": {"field": "created_date"},
+            "min": {"field": "created_date"},
+            "date_range": {
+                "field": "created_date",
+                "date_ranges": [{"from": "now-30d", "to": "now"}],
+            },
+            "range": {
+                "field": "created_date",
+                "ranges": [{"From": 0, "To": 9999999999999}],
+            },
+        }
+        for agg_type, kwargs in cases.items():
+            result = self.call_method(
+                self.module.aggregate_recon_exposed_data_records,
+                aggregate_type=agg_type,
+                name=f"probe_{agg_type}",
+                **kwargs,
+            )
+            self.assert_no_error(result, context=f"exposed-data aggregate_type={agg_type}")
+
+    def test_aggregate_recon_exposed_data_records_documented_fields(self):
+        """Every field the aggregate guide documents must be accepted by the live API.
+
+        This endpoint rejects unlisted fields with a 400, so the guide's list is a
+        hard contract rather than a suggestion.
+        """
+        documented = [
+            "cid",
+            "notification_id",
+            "notification_group_id",
+            "created_date",
+            "rule.id",
+            "rule.name",
+            "rule.topic",
+            "source_category",
+            "site",
+            "author",
+            "file.name",
+            "credential_status",
+            "bot.operating_system.hardware_id",
+            "bot.bot_id",
+        ]
+        for field in documented:
+            result = self.call_method(
+                self.module.aggregate_recon_exposed_data_records,
+                field=field,
+                aggregate_type="terms",
+                name="probe",
+                size=1,
+            )
+            self.assert_no_error(result, context=f"exposed-data aggregate field={field}")
+
+    def test_aggregate_recon_exposed_data_records_sub_aggregates(self):
+        """Nested sub-aggregations must come back inside the parent buckets."""
+        result = self.call_method(
+            self.module.aggregate_recon_exposed_data_records,
+            field="rule.topic",
+            aggregate_type="terms",
+            name="by_topic",
+            size=2,
+            sub_aggregates=[
+                {
+                    "type": "terms",
+                    "field": "credential_status",
+                    "name": "by_status",
+                    "size": 2,
+                }
+            ],
+        )
+
+        self.assert_no_error(result, context="exposed-data sub_aggregates")
+
+        buckets = (result[0].get("buckets") or []) if result else []
+        if not buckets:
+            self.skip_with_warning(
+                "No exposed-data records to nest aggregations over",
+                context="aggregate_recon_exposed_data_records sub_aggregates",
+            )
+            return
+
+        assert "sub_aggregates" in buckets[0], (
+            f"Sub-aggregation missing from bucket: {buckets[0]}"
+        )
+
+    # ------------------------------------------------------------------
+    # Rule preview
+    # ------------------------------------------------------------------
+
+    def test_preview_recon_rule_operation_name(self):
+        """Validate PreviewRuleV1 and its fixed channel/count/site breakdown."""
+        result = self.call_method(
+            self.module.preview_recon_rule,
+            topic="SA_DOMAIN",
+            filter="(domain:'example.com')",
+            lookback_days=30,
+        )
+
+        self.assert_no_error(result, context="PreviewRuleV1 validation")
+        assert isinstance(result, list), f"Expected list of aggregations; got {type(result)}"
+
+        names = {agg.get("name") for agg in result}
+        assert "count" in names, f"Preview response missing the 'count' aggregation: {names}"
+        assert names <= {"channel", "count", "site"}, (
+            f"Preview returned unexpected aggregations: {names}"
+        )
+
+    def test_preview_recon_rule_accepts_documented_lookback_values(self):
+        """lookback_days is an enum; every value the tool exposes must be accepted."""
+        for lookback in (7, 30, 180, 365):
+            result = self.call_method(
+                self.module.preview_recon_rule,
+                topic="SA_DOMAIN",
+                filter="(domain:'example.com')",
+                lookback_days=lookback,
+            )
+            self.assert_no_error(result, context=f"PreviewRuleV1 lookback_days={lookback}")
+
+    def test_preview_recon_rule_omitted_lookback(self):
+        """Omitting lookback_days must still be a valid request."""
+        result = self.call_method(
+            self.module.preview_recon_rule,
+            topic="SA_EMAIL",
+            filter="(email:'user@example.com')",
+        )
+        self.assert_no_error(result, context="PreviewRuleV1 without lookback_days")
+
+    def test_preview_recon_rule_documented_topic_filters(self):
+        """Each topic/condition-word pair shown in the preview guide must parse."""
+        cases = [
+            ("SA_DOMAIN", "(domain:'example.com')"),
+            ("SA_EMAIL", "(email:'user@example.com')"),
+            ("SA_IP", "(ip:'1.2.3.4')"),
+            ("SA_AUTHOR", "(author:'handle')"),
+            ("SA_BRAND_PRODUCT", "(phrase:'Acme')+(keyword:'Acme')"),
+            ("SA_THIRD_PARTY", "(phrase:'Acme')"),
+            ("SA_CUSTOM", "(keyword:'term')"),
+            ("SA_VIP", "(keyword:'term')"),
+            ("SA_CVE", "(keyword:'term')"),
+            ("SA_ALIAS", "(keyword:'term')"),
+        ]
+        for topic, rule_filter in cases:
+            result = self.call_method(
+                self.module.preview_recon_rule,
+                topic=topic,
+                filter=rule_filter,
+                lookback_days=30,
+            )
+            self.assert_no_error(result, context=f"PreviewRuleV1 topic={topic}")
+
+    def test_preview_recon_rule_invalid_filter_returns_guide(self):
+        """A bare (non-FQL) filter is rejected and the guide is returned for self-correction."""
+        result = self.call_method(
+            self.module.preview_recon_rule,
+            topic="SA_DOMAIN",
+            filter="example.com",
+        )
+
+        assert isinstance(result, dict), f"Expected the FQL-error dict; got {type(result)}"
+        assert "fql_guide" in result, f"Rejected filter did not return a guide: {result}"

--- a/tests/modules/test_recon.py
+++ b/tests/modules/test_recon.py
@@ -3,6 +3,7 @@ Tests for the Recon module.
 """
 
 import unittest
+from typing import Any
 
 from falcon_mcp.modules.recon import ReconModule
 from tests.modules.utils.test_modules import TestModules
@@ -25,6 +26,9 @@ class TestReconModule(TestModules):
             "falcon_search_recon_notifications",
             "falcon_search_recon_rules",
             "falcon_search_recon_exposed_data_records",
+            "falcon_aggregate_recon_notifications",
+            "falcon_aggregate_recon_exposed_data_records",
+            "falcon_preview_recon_rule",
         ]
         self.assert_tools_registered(expected_tools)
 
@@ -34,6 +38,9 @@ class TestReconModule(TestModules):
             "falcon_search_recon_notifications_fql_guide",
             "falcon_search_recon_rules_fql_guide",
             "falcon_search_recon_exposed_data_records_fql_guide",
+            "falcon_aggregate_recon_notifications_guide",
+            "falcon_aggregate_recon_exposed_data_records_guide",
+            "falcon_preview_recon_rule_guide",
         ]
         self.assert_resources_registered(expected_resources)
 
@@ -380,6 +387,355 @@ class TestReconModule(TestModules):
 
         # 3 calls total (one query per tool), no details calls
         self.assertEqual(self.mock_client.command.call_count, 3)
+
+    # ------------------------------------------------------------------
+    # Aggregate notifications
+    # ------------------------------------------------------------------
+
+    def _aggregate_notifications(self, **overrides):
+        """Call aggregate_recon_notifications with every Field param supplied.
+
+        Pydantic defaults are not resolved when calling the method directly, so
+        each parameter has to be passed explicitly.
+        """
+        params = {
+            "field": "status",
+            "aggregate_type": "terms",
+            "filter": None,
+            "q": None,
+            "name": "by_status",
+            "size": 10,
+            "sort": None,
+            "interval": None,
+            "date_ranges": None,
+            "ranges": None,
+            "sub_aggregates": None,
+        }
+        params.update(overrides)
+        return self.module.aggregate_recon_notifications(**params)
+
+    def test_aggregate_recon_notifications_success(self):
+        """Verify a terms aggregation returns the API's buckets."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "name": "by_status",
+                        "buckets": [
+                            {"label": "new", "count": 8500073},
+                            {"label": "in-progress", "count": 4},
+                        ],
+                    }
+                ],
+                "errors": [],
+            },
+        }
+
+        result = self._aggregate_notifications()
+
+        self.mock_client.command.assert_called_once()
+        args, kwargs = self.mock_client.command.call_args
+        self.assertEqual(args[0], "AggregateNotificationsV1")
+        # The endpoint 400s on a bare object; the spec must be list-wrapped.
+        self.assertEqual(
+            kwargs["body"],
+            [{"type": "terms", "field": "status", "name": "by_status", "size": 10}],
+        )
+        self.assertEqual(result[0]["buckets"][0]["label"], "new")
+
+    def test_aggregate_recon_notifications_omits_unset_spec_keys(self):
+        """Verify unset optional params are absent from the body, not sent as null."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [], "errors": []},
+        }
+
+        self._aggregate_notifications(size=None)
+
+        spec = self.mock_client.command.call_args[1]["body"][0]
+        for absent in ("filter", "q", "sort", "interval", "date_ranges", "sub_aggregates", "size"):
+            self.assertNotIn(absent, spec)
+
+    def test_aggregate_recon_notifications_forwards_all_spec_params(self):
+        """Verify filter, q, sort, interval, date_ranges, and sub_aggregates reach the body."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [], "errors": []},
+        }
+
+        sub = [{"type": "terms", "field": "status", "name": "inner"}]
+        self._aggregate_notifications(
+            field="created_date",
+            aggregate_type="date_range",
+            filter="rule_topic:'SA_TYPOSQUATTING'",
+            q="crowdstrike",
+            sort="_count|asc",
+            interval="day",
+            date_ranges=[{"from": "now-30d", "to": "now"}],
+            sub_aggregates=sub,
+        )
+
+        spec = self.mock_client.command.call_args[1]["body"][0]
+        self.assertEqual(spec["type"], "date_range")
+        self.assertEqual(spec["field"], "created_date")
+        self.assertEqual(spec["filter"], "rule_topic:'SA_TYPOSQUATTING'")
+        self.assertEqual(spec["q"], "crowdstrike")
+        self.assertEqual(spec["sort"], "_count|asc")
+        self.assertEqual(spec["interval"], "day")
+        self.assertEqual(spec["date_ranges"], [{"from": "now-30d", "to": "now"}])
+        self.assertEqual(spec["sub_aggregates"], sub)
+
+    def test_aggregate_every_declared_type_sends_required_companion_args(self):
+        """Every aggregate_type the Literal allows must be able to build a usable spec.
+
+        `date_histogram` needs `interval`, `date_range` needs `date_ranges`, and `range`
+        needs `ranges`; without them the API 500s, so the tool has to expose a way to
+        supply each.
+        """
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [], "errors": []},
+        }
+
+        # aggregate_type -> the companion key its spec cannot work without.
+        required_companion = {
+            "terms": None,
+            "cardinality": None,
+            "max": None,
+            "min": None,
+            "date_histogram": "interval",
+            "date_range": "date_ranges",
+            "range": "ranges",
+        }
+        companion_values: dict[str, Any] = {
+            "interval": "day",
+            "date_ranges": [{"from": "now-30d", "to": "now"}],
+            "ranges": [{"From": 0, "To": 100}],
+        }
+
+        for aggregate_type, companion in required_companion.items():
+            extra = {companion: companion_values[companion]} if companion else {}
+            for call in (self._aggregate_notifications, self._aggregate_records):
+                self.mock_client.command.reset_mock()
+                call(aggregate_type=aggregate_type, **extra)
+                spec = self.mock_client.command.call_args[1]["body"][0]
+                self.assertEqual(spec["type"], aggregate_type)
+                if companion:
+                    self.assertIn(
+                        companion,
+                        spec,
+                        f"{aggregate_type} must forward {companion} into the spec",
+                    )
+
+    def test_aggregate_recon_notifications_server_error(self):
+        """A 500 (as `rule_name` returns live) surfaces as an error, not empty buckets."""
+        self.mock_client.command.return_value = {
+            "status_code": 500,
+            "body": {"errors": [{"message": "Internal Server Error"}]},
+        }
+
+        result = self._aggregate_notifications(field="rule_name")
+
+        self.assertIn("error", result)
+
+    def test_aggregate_recon_notifications_body_level_error_on_200(self):
+        """A 2xx carrying body-level errors must not be reported as success."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [], "errors": [{"message": "Invalid aggregates request"}]},
+        }
+
+        result = self._aggregate_notifications()
+
+        self.assertIn("error", result)
+        self.assertIn("Invalid aggregates request", result["error"])
+
+    # ------------------------------------------------------------------
+    # Aggregate exposed-data records
+    # ------------------------------------------------------------------
+
+    def _aggregate_records(self, **overrides):
+        """Call aggregate_recon_exposed_data_records with every Field param supplied."""
+        params = {
+            "field": "credential_status",
+            "aggregate_type": "terms",
+            "filter": None,
+            "q": None,
+            "name": "by_cs",
+            "size": 10,
+            "sort": None,
+            "interval": None,
+            "date_ranges": None,
+            "ranges": None,
+            "sub_aggregates": None,
+        }
+        params.update(overrides)
+        return self.module.aggregate_recon_exposed_data_records(**params)
+
+    def test_aggregate_recon_exposed_data_records_success(self):
+        """Verify the exposed-data aggregate hits its own operation and returns buckets."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "name": "by_cs",
+                        "buckets": [
+                            {"label": "previously_reported", "count": 49577530},
+                            {"label": "newly_reported", "count": 38150176},
+                        ],
+                    }
+                ],
+                "errors": [],
+            },
+        }
+
+        result = self._aggregate_records()
+
+        args, kwargs = self.mock_client.command.call_args
+        self.assertEqual(args[0], "AggregateNotificationsExposedDataRecordsV1")
+        self.assertEqual(
+            kwargs["body"],
+            [
+                {
+                    "type": "terms",
+                    "field": "credential_status",
+                    "name": "by_cs",
+                    "size": 10,
+                }
+            ],
+        )
+        self.assertEqual(result[0]["buckets"][1]["label"], "newly_reported")
+
+    def test_aggregate_recon_exposed_data_records_rejected_field(self):
+        """This endpoint 400s on fields outside its whitelist (e.g. `email`)."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Invalid aggregates request"}]},
+        }
+
+        result = self._aggregate_records(field="email")
+
+        self.assertIn("error", result)
+
+    def test_aggregate_recon_exposed_data_records_sub_aggregates(self):
+        """Verify nested sub-aggregates are forwarded and returned intact."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "name": "topic",
+                        "buckets": [
+                            {
+                                "label": "SA_DOMAIN",
+                                "count": 86295590,
+                                "sub_aggregates": [
+                                    {
+                                        "name": "cs",
+                                        "buckets": [{"label": "newly_reported", "count": 37788056}],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+                "errors": [],
+            },
+        }
+
+        sub = [{"type": "terms", "field": "credential_status", "name": "cs", "size": 2}]
+        result = self._aggregate_records(field="rule.topic", name="topic", sub_aggregates=sub)
+
+        spec = self.mock_client.command.call_args[1]["body"][0]
+        self.assertEqual(spec["sub_aggregates"], sub)
+        self.assertEqual(result[0]["buckets"][0]["sub_aggregates"][0]["name"], "cs")
+
+    # ------------------------------------------------------------------
+    # Preview rule
+    # ------------------------------------------------------------------
+
+    def test_preview_recon_rule_success(self):
+        """Verify the preview body is a bare object and the fixed trio comes back."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {"name": "channel", "buckets": [{"label": "public_repo", "count": 64}]},
+                    {"name": "count", "buckets": [{"label": "Total", "count": 99}]},
+                    {"name": "site", "buckets": [{"label": "github.com", "count": 57}]},
+                ],
+                "errors": [],
+            },
+        }
+
+        result = self.module.preview_recon_rule(
+            topic="SA_BRAND_PRODUCT",
+            filter="(phrase:'Acme')+(keyword:'Acme')",
+            lookback_days=30,
+        )
+
+        args, kwargs = self.mock_client.command.call_args
+        self.assertEqual(args[0], "PreviewRuleV1")
+        # Unlike the aggregate endpoints, this one takes a bare object, not a list.
+        self.assertEqual(
+            kwargs["body"],
+            {
+                "topic": "SA_BRAND_PRODUCT",
+                "filter": "(phrase:'Acme')+(keyword:'Acme')",
+                "lookback_days": 30,
+            },
+        )
+        self.assertEqual([agg["name"] for agg in result], ["channel", "count", "site"])
+
+    def test_preview_recon_rule_omits_unset_lookback(self):
+        """lookback_days=None must be absent from the body rather than sent as null."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [], "errors": []},
+        }
+
+        self.module.preview_recon_rule(
+            topic="SA_DOMAIN",
+            filter="(domain:'example.com')",
+            lookback_days=None,
+        )
+
+        body = self.mock_client.command.call_args[1]["body"]
+        self.assertNotIn("lookback_days", body)
+        self.assertEqual(body["topic"], "SA_DOMAIN")
+
+    def test_preview_recon_rule_invalid_filter_returns_guide(self):
+        """A rejected rule filter returns the preview guide so the agent can self-correct."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {
+                "errors": [
+                    {
+                        "message": "Invalid request",
+                        "details": [
+                            {
+                                "field": "filter",
+                                "message_key": "RULE_FILTER_INVALID_FQL",
+                            }
+                        ],
+                    }
+                ]
+            },
+        }
+
+        result = self.module.preview_recon_rule(
+            topic="SA_DOMAIN",
+            filter="example.com",
+            lookback_days=None,
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("fql_guide", result)
+        self.assertEqual(result["filter_used"], "example.com")
+        # The guide must actually explain the rule-FQL dialect, not the search dialect.
+        self.assertIn("(domain:'example.com')", result["fql_guide"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds three tools to the recon module. Two are aggregations — `falcon_aggregate_recon_notifications` and `falcon_aggregate_recon_exposed_data_records` — for counting and grouping notifications and exposed-data records into buckets rather than pulling back individual records. The third, `falcon_preview_recon_rule`, estimates how many notifications a monitoring rule would generate before you actually create it.

The two aggregates run through the shared `_base_aggregate` foundation. The preview tool doesn't: it lives under `/recon/aggregates/` but takes a rule definition instead of an aggregate spec, its breakdown is fixed at channel/count/site, and its filter is written in the monitoring-rule dialect — so it gets a plain name and its own guide.

Live validation shaped a lot of the details. The two aggregate endpoints don't share a field set: exposed-data records whitelists fourteen fields and 400s on anything else, while notifications is permissive but returns a 500 on `rule_name`, and the two even spell the topic field differently (`rule.topic` vs `rule_topic`). Preview only accepts four `lookback_days` values and can't preview typosquatting rules at all. `date_histogram`, `date_range`, and `range` each need a companion argument or the API 500s, so all three are wired up and covered by a test that walks every declared aggregation type. Along the way I found three older integration tests that had been silently skipping ever since search tools moved to the pagination envelope — they were guarding on a bare list — so those now unwrap the envelope and actually assert against live data.