### PR TITLE
fix(modules/firewall): drop ignored q param and fix name-glob filter docs

### DIFF
--- a/falcon_mcp/filter_hints.py
+++ b/falcon_mcp/filter_hints.py
@@ -143,15 +143,21 @@ FILTER_HINTS: dict[str, str] = {
     # === Firewall Rules ===
     "falcon_search_firewall_rules": (
         "Common fields: platform (windows|mac|linux), name, "
-        "enabled (true|false), created_on (UTC datetime)."
+        "enabled (true|false), created_on (UTC datetime). "
+        "name: use the contains operator name:~'value' (whole-word substring); a "
+        "name:'value*' glob is treated literally and returns nothing."
     ),
     "falcon_search_firewall_rule_groups": (
         "Common fields: platform (windows|mac|linux), name, "
-        "enabled (true|false), created_on (UTC datetime)."
+        "enabled (true|false), created_on (UTC datetime). "
+        "name: use the contains operator name:~'value' (whole-word substring); a "
+        "name:'value*' glob is treated literally and returns nothing."
     ),
     "falcon_search_firewall_policy_rules": (
         "Common fields: platform (windows|mac|linux), name, "
-        "enabled (true|false), created_on (UTC datetime)."
+        "enabled (true|false), created_on (UTC datetime). "
+        "name: use the contains operator name:~'value' (whole-word substring); a "
+        "name:'value*' glob is treated literally and returns nothing."
     ),
     # === Intel: Actors ===
     "falcon_search_actors": (

--- a/falcon_mcp/modules/firewall.py
+++ b/falcon_mcp/modules/firewall.py
@@ -88,7 +88,7 @@ class FirewallModule(BaseModule):
         filter: str | None = Field(
             default=None,
             description="FQL filter expression. See `falcon://firewall/rules/fql-guide` for syntax.",
-            examples=["enabled:true", "platform:'windows'+name:'Block*'"],
+            examples=["enabled:true", "platform:'windows'+name:~'Block'"],
         ),
         limit: int = Field(
             default=10,
@@ -106,10 +106,6 @@ class FirewallModule(BaseModule):
                 sort endpoint; the pipe form ('platform|asc') also works here.
             """).strip(),
             examples=["modified_on.desc", "name.asc"],
-        ),
-        q: str | None = Field(
-            default=None,
-            description="Free-text query string across rule fields.",
         ),
         after: str | None = Field(
             default=None,
@@ -129,7 +125,6 @@ class FirewallModule(BaseModule):
                 "filter": filter,
                 "limit": limit,
                 "sort": sort,
-                "q": q,
                 "after": after,
             },
             error_message="Failed to search firewall rules",
@@ -163,7 +158,7 @@ class FirewallModule(BaseModule):
         filter: str | None = Field(
             default=None,
             description="FQL filter expression. See `falcon://firewall/rules/fql-guide` for syntax.",
-            examples=["enabled:true", "platform:'windows'+name:'Default*'"],
+            examples=["enabled:true", "platform:'windows'+name:~'Default'"],
         ),
         limit: int = Field(
             default=10,
@@ -174,10 +169,6 @@ class FirewallModule(BaseModule):
         sort: str | None = Field(
             default=None,
             description="Sort expression in FQL syntax (e.g., modified_on.desc).",
-        ),
-        q: str | None = Field(
-            default=None,
-            description="Free-text query string across rule group fields.",
         ),
         after: str | None = Field(
             default=None,
@@ -197,7 +188,6 @@ class FirewallModule(BaseModule):
                 "filter": filter,
                 "limit": limit,
                 "sort": sort,
-                "q": q,
                 "after": after,
             },
             error_message="Failed to search firewall rule groups",
@@ -249,10 +239,6 @@ class FirewallModule(BaseModule):
             default=None,
             description="Sort expression in FQL syntax (e.g., modified_on.desc).",
         ),
-        q: str | None = Field(
-            default=None,
-            description="Free-text query string across policy rule fields.",
-        ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search firewall rules within a specific policy container.
 
@@ -269,7 +255,6 @@ class FirewallModule(BaseModule):
                 "limit": limit,
                 "offset": offset,
                 "sort": sort,
-                "q": q,
             },
             error_message="Failed to search firewall policy rules",
         )

--- a/falcon_mcp/resources/firewall.py
+++ b/falcon_mcp/resources/firewall.py
@@ -23,7 +23,8 @@ SEARCH_FIREWALL_RULES_FQL_FILTERS = [
     (
         "name",
         "String",
-        "Rule or rule group name. Example: name:'Block*'",
+        "Rule or rule group name. For substring matching use the contains operator, "
+        "name:~'value'. Example: name:~'Block'",
     ),
     (
         "description",
@@ -78,11 +79,18 @@ Use either `field.asc` / `field.desc` or `field|asc` / `field|desc`.
   - `filter="enabled:true"`
 - Windows rule groups:
   - `filter="platform:'windows'"`
+- Rules whose name contains a word:
+  - `filter="name:~'Block'"`
 - Recently modified entities:
   - `sort="modified_on.desc"`
 
 ## Notes
 
+- For name matching, use the contains operator `name:~'value'` (case-insensitive,
+  matches whole words). A `name:'value*'` glob is treated literally — the `*` is a
+  literal character, so the query silently returns nothing. For an arbitrary
+  substring (not a whole word), use the wildcard form `name:*'*value*'`. A plain
+  `name:'value'` exact match also works when you know the full name.
 - For policy-specific searches, use `falcon_search_firewall_policy_rules` with `policy_id`.
 - Start broad, then refine your filter if results are empty.
 """

--- a/tests/integration/test_firewall.py
+++ b/tests/integration/test_firewall.py
@@ -28,7 +28,6 @@ class TestFirewallIntegration(BaseIntegrationTest):
             filter=None,
             limit=1,
             sort=None,
-            q=None,
             after=None,
         )
         self.assert_no_error(result, context="operation name validation")
@@ -40,7 +39,6 @@ class TestFirewallIntegration(BaseIntegrationTest):
             filter=None,
             limit=5,
             sort=None,
-            q=None,
             after=None,
         )
 
@@ -61,7 +59,6 @@ class TestFirewallIntegration(BaseIntegrationTest):
             filter="enabled:true",
             limit=3,
             sort="modified_on.desc",
-            q=None,
             after=None,
         )
 
@@ -78,7 +75,6 @@ class TestFirewallIntegration(BaseIntegrationTest):
             filter=None,
             limit=5,
             sort=None,
-            q=None,
             after=None,
         )
 
@@ -101,7 +97,6 @@ class TestFirewallIntegration(BaseIntegrationTest):
             filter="enabled:true",
             limit=3,
             sort="modified_on.desc",
-            q=None,
             after=None,
         )
 

--- a/tests/modules/test_firewall.py
+++ b/tests/modules/test_firewall.py
@@ -84,7 +84,6 @@ class TestFirewallModule(TestModules):
             filter="enabled:true",
             limit=20,
             sort="modified_on.desc",
-            q=None,
             after=None,
         )
 
@@ -96,6 +95,9 @@ class TestFirewallModule(TestModules):
         self.assertEqual(first_call[1]["parameters"]["filter"], "enabled:true")
         self.assertEqual(first_call[1]["parameters"]["limit"], 20)
         self.assertNotIn("offset", first_call[1]["parameters"])
+        # `q` is not a supported parameter — the API ignores it, so it must not
+        # be forwarded (see issue #525).
+        self.assertNotIn("q", first_call[1]["parameters"])
         self.assertEqual(first_call[1]["parameters"]["sort"], "modified_on.desc")
 
         self.assertEqual(second_call[0][0], "get_rules")
@@ -127,7 +129,6 @@ class TestFirewallModule(TestModules):
             filter=None,
             limit=20,
             sort="modified_on.desc",
-            q=None,
             after=None,
         )
 
@@ -146,7 +147,6 @@ class TestFirewallModule(TestModules):
             filter="name:'DoesNotExist*'",
             limit=10,
             sort=None,
-            q=None,
             after=None,
         )
 
@@ -179,7 +179,6 @@ class TestFirewallModule(TestModules):
             filter="enabled:true",
             limit=10,
             sort="modified_on.desc",
-            q=None,
             after=None,
         )
 
@@ -213,7 +212,6 @@ class TestFirewallModule(TestModules):
             filter=None,
             limit=10,
             sort="modified_on.desc",
-            q=None,
             after=None,
         )
 
@@ -246,7 +244,6 @@ class TestFirewallModule(TestModules):
             limit=10,
             offset=0,
             sort="modified_on.desc",
-            q=None,
         )
 
         self.assertEqual(self.mock_client.command.call_count, 2)
@@ -281,7 +278,6 @@ class TestFirewallModule(TestModules):
             limit=10,
             offset=0,
             sort="modified_on.desc",
-            q=None,
         )
 
         self.assertEqual(len(result["results"]), 2)
@@ -398,7 +394,6 @@ class TestFirewallModule(TestModules):
             filter="bad_field:'value'",
             limit=10,
             sort=None,
-            q=None,
             after=None,
         )
 
@@ -418,7 +413,6 @@ class TestFirewallModule(TestModules):
             filter=None,
             limit=10,
             sort=None,
-            q=None,
             after=None,
         )
 
@@ -442,7 +436,6 @@ class TestFirewallModule(TestModules):
             filter="enabled:true",
             limit=10,
             sort=None,
-            q=None,
             after=None,
         )
 
@@ -461,7 +454,6 @@ class TestFirewallModule(TestModules):
             filter="bad_field:'value'",
             limit=10,
             sort=None,
-            q=None,
             after=None,
         )
 
@@ -469,6 +461,20 @@ class TestFirewallModule(TestModules):
         self.assertIn("results", result)
         self.assertIn("fql_guide", result)
         self.assertIn("hint", result)
+
+
+    def test_search_tools_do_not_expose_q_param(self):
+        """The `q` free-text param was removed — the API silently ignores it, so
+        offering it returned unfiltered results that looked filtered (issue #525)."""
+        import inspect
+
+        for method in (
+            self.module.search_firewall_rules,
+            self.module.search_firewall_rule_groups,
+            self.module.search_firewall_policy_rules,
+        ):
+            params = inspect.signature(method).parameters
+            self.assertNotIn("q", params, f"{method.__name__} must not expose `q`")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `q` parameter on the three firewall search tools looked like a free-text search but did nothing. It got passed to the query API, which ignores it, so every value returned the full result set — there was no way for a caller to tell a real no-match from a query that was quietly dropped. This removes it.

While I was in here, the FQL guide, the filter examples on both search tools, and the dynamic-mode hints all suggested a `name:'value*'` glob that the API treats as a literal asterisk and never matches. I pointed them at the contains operator `name:~'value'` instead, with a note on `name:*'*value*'` for an arbitrary substring. Both forms verified against a live tenant.

Fixes #525