### PR TITLE
fix(modules/policies): reject settings for firewall policies

### DIFF
--- a/docs/modules/policies.md
+++ b/docs/modules/policies.md
@@ -139,8 +139,10 @@ Update an existing host-based policy of the given type.
 
 Provide the policy `id` plus any fields to change (name, description,
 settings). platform_name is not updatable after creation. Uses HTTP PATCH
-semantics — unspecified fields are left unchanged. Returns the updated
-policy record.
+semantics — unspecified fields are left unchanged. Firewall policies accept
+only name and description here; they have no settings field, and rule-group
+attachment is a whole-container operation this tool does not expose. Returns
+the updated policy record.
 
 **Example prompts:**
 

--- a/falcon_mcp/modules/policies.py
+++ b/falcon_mcp/modules/policies.py
@@ -229,6 +229,22 @@ class PoliciesModule(BaseModule):
         },
     }
 
+    # Whether a create/update body may carry a `settings` object. The firewall
+    # create and update endpoints have no `settings` field (their schema is
+    # id/name/description[/clone_id/platform_name] only), so the API silently
+    # discards a `settings` value and returns 200 — a no-op that looks like a
+    # success. Reject it up front instead. Firewall rule-group attachment is a
+    # whole-container PUT (/policy/entities/policy-container) that this module
+    # does not wrap; it cannot be done through create/update settings.
+    _SUPPORTS_SETTINGS: dict[str, bool] = {
+        "prevention": True,
+        "sensor_update": True,
+        "firewall": False,
+        "device_control": True,
+        "response": True,
+        "content_update": True,
+    }
+
     # Sort field bases that the API accepts (each with a .asc/.desc direction).
     # platform_name is deliberately excluded — it returns HTTP 500 on every type.
     _SAFE_SORT_FIELDS = {
@@ -598,6 +614,19 @@ class PoliciesModule(BaseModule):
                     operation=self._OPERATIONS[policy_type]["create"],
                 )
 
+        # The firewall endpoints have no `settings` field — passing one returns
+        # 200 while changing nothing. Reject it loudly instead of silently no-op.
+        if settings is not None and not self._SUPPORTS_SETTINGS[policy_type]:
+            op_key = "update" if is_update else "create"
+            return _format_error_response(
+                f"'{policy_type}' policies do not accept a 'settings' object — the "
+                "endpoint has no such field and would silently ignore it. Firewall "
+                "policy configuration (including rule-group attachment) is a "
+                "whole-container operation not exposed by this tool; use the Falcon "
+                "console for it. This tool can still update 'name' and 'description'.",
+                operation=self._OPERATIONS[policy_type][op_key],
+            )
+
         resource: dict[str, Any] = {}
         # id is only placed in the body on update (create never carries an id).
         if is_update and policy_id is not None:
@@ -646,7 +675,7 @@ class PoliciesModule(BaseModule):
         ),
         settings: Any | None = Field(
             default=None,
-            description="Opaque per-type settings object (dict or list), passed through unchanged. Building detailed settings is out of scope for v1 — prefer cloning an existing policy via clone_id then tweaking with falcon_update_policy.",
+            description="Opaque per-type settings object (dict or list), passed through unchanged. Not accepted for firewall policies (the endpoint has no settings field and would ignore it — rejected with an error). Building detailed settings is out of scope for v1 — prefer cloning an existing policy via clone_id then tweaking with falcon_update_policy.",
         ),
         clone_id: str | None = Field(
             default=None,
@@ -713,15 +742,17 @@ class PoliciesModule(BaseModule):
         ),
         settings: Any | None = Field(
             default=None,
-            description="Opaque per-type settings object (dict or list), passed through unchanged. Unspecified fields are left unchanged.",
+            description="Opaque per-type settings object (dict or list), passed through unchanged. Unspecified fields are left unchanged. Not accepted for firewall policies (the endpoint has no settings field and would ignore it — rejected with an error).",
         ),
     ) -> list[dict[str, Any]]:
         """Update an existing host-based policy of the given type.
 
         Provide the policy `id` plus any fields to change (name, description,
         settings). platform_name is not updatable after creation. Uses HTTP PATCH
-        semantics — unspecified fields are left unchanged. Returns the updated
-        policy record.
+        semantics — unspecified fields are left unchanged. Firewall policies accept
+        only name and description here; they have no settings field, and rule-group
+        attachment is a whole-container operation this tool does not expose. Returns
+        the updated policy record.
         """
         type_error = self._validate_policy_type(policy_type)
         if type_error is not None:

--- a/tests/modules/test_policies.py
+++ b/tests/modules/test_policies.py
@@ -496,6 +496,77 @@ class TestPoliciesModule(TestModules):
         self.assertIn("error", result[0])
         self.assertEqual(self.mock_client.command.call_count, 0)
 
+    def test_update_firewall_rejects_settings(self):
+        """Firewall update with settings is rejected — the endpoint has no
+        settings field and would silently 200 without changing anything (#526)."""
+        result = self.module.update_policy(
+            policy_type="firewall",
+            id="fw-1",
+            name=None,
+            description=None,
+            settings={"rule_group_ids": ["rg-1"]},
+        )
+        self.assertIn("error", result[0])
+        self.assertIn("settings", result[0]["error"])
+        self.assertEqual(self.mock_client.command.call_count, 0)
+
+    def test_create_firewall_rejects_settings(self):
+        """Firewall create with settings is rejected for the same reason (#526)."""
+        result = self.module.create_policy(
+            policy_type="firewall",
+            **self._create_kwargs(
+                name="fw",
+                platform_name="Windows",
+                settings={"foo": "bar"},
+            ),
+        )
+        self.assertIn("error", result[0])
+        self.assertIn("settings", result[0]["error"])
+        self.assertEqual(self.mock_client.command.call_count, 0)
+
+    def test_update_firewall_name_and_description_still_work(self):
+        """Firewall update without settings still works — only settings is barred."""
+        self.mock_client.command.return_value = self._create_response(
+            {"id": "fw-1", "name": "renamed"}
+        )
+        self.module.update_policy(
+            policy_type="firewall",
+            id="fw-1",
+            name="renamed",
+            description="desc",
+            settings=None,
+        )
+        call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(call[0][0], "updateFirewallPolicies")
+        resource = call[1]["body"]["resources"][0]
+        self.assertEqual(resource["id"], "fw-1")
+        self.assertEqual(resource["name"], "renamed")
+        self.assertEqual(resource["description"], "desc")
+        self.assertNotIn("settings", resource)
+
+    def test_update_non_firewall_types_accept_settings(self):
+        """Every non-firewall type still forwards settings into the body."""
+        for policy_type in EXPECTED_OPS:
+            if policy_type == "firewall":
+                continue
+            with self.subTest(policy_type=policy_type):
+                self.mock_client.command.reset_mock()
+                self.mock_client.command.side_effect = None
+                self.mock_client.command.return_value = self._create_response(
+                    {"id": "p-1"}
+                )
+                self.module.update_policy(
+                    policy_type=policy_type,
+                    id="p-1",
+                    name=None,
+                    description=None,
+                    settings=[{"id": "x", "value": True}],
+                )
+                call = self.mock_client.command.call_args_list[0]
+                wrapper = self.module._BODY_WRAPPER[policy_type]
+                resource = call[1]["body"][wrapper][0]
+                self.assertEqual(resource["settings"], [{"id": "x", "value": True}])
+
     def test_update_places_id_inside_resource(self):
         """Update body places id inside the resource object."""
         self.mock_client.command.return_value = self._create_response(


### PR DESCRIPTION
Passing a `settings` object to `falcon_update_policy` for a firewall policy returned HTTP 200 with an unchanged record. The firewall create and update endpoints have no `settings` field, so the API just drops it — a no-op that reads as success, with nothing to tell the caller it was ignored.

This rejects it up front with an error that names what actually works, reusing the same per-type validation `perform_policy_action` already does for actions. The message also steers away from the wrong conclusion that rule-group attachment has to be done in the console: it's a whole-container operation this module doesn't wrap yet, not something the API can't do. Verified live.

Fixes #526