### PR TITLE
feat(modules/cases): add description_format to create/update case

### DIFF
--- a/docs/modules/cases.md
+++ b/docs/modules/cases.md
@@ -155,6 +155,7 @@ created case record.
 
 - "Create a critical case called 'Suspicious lateral movement from WORKSTATION-42'"
 - "Open a high-severity case for the credential theft alerts and attach them as evidence"
+- "Create a case with a markdown-formatted description"
 
 ### `falcon_get_cases`
 
@@ -238,6 +239,7 @@ updated case record with incremented version.
 
 - "Set that case to in_progress and assign it to the analyst"
 - "Close the case — investigation is complete"
+- "Rewrite the case description as markdown"
 
 ## Resources
 

--- a/falcon_mcp/modules/cases.py
+++ b/falcon_mcp/modules/cases.py
@@ -286,6 +286,10 @@ class CasesModule(BaseModule):
             default=None,
             description="Case description (max 2048 characters).",
         ),
+        description_format: str | None = Field(
+            default=None,
+            description="Rendering format for the description. Values: plaintext, markdown. Defaults to CrowdStrike's server-side default (plaintext) when omitted.",
+        ),
         status: str | None = Field(
             default=None,
             description="Initial status. Values: new, in_progress. Defaults to 'new' if omitted.",
@@ -324,6 +328,8 @@ class CasesModule(BaseModule):
 
         if description is not None:
             body["description"] = description
+        if description_format is not None:
+            body["description_format"] = description_format
         if status is not None:
             body["status"] = status
         if assigned_to_user_uuid is not None:
@@ -366,6 +372,10 @@ class CasesModule(BaseModule):
             default=None,
             description="New case description.",
         ),
+        description_format: str | None = Field(
+            default=None,
+            description="Rendering format for the description. Values: plaintext, markdown. Left unchanged when omitted.",
+        ),
         status: str | None = Field(
             default=None,
             description="New status. Values: new, in_progress, closed, reopened.",
@@ -404,6 +414,8 @@ class CasesModule(BaseModule):
             fields["name"] = name
         if description is not None:
             fields["description"] = description
+        if description_format is not None:
+            fields["description_format"] = description_format
         if status is not None:
             fields["status"] = status
         if severity is not None:

--- a/falcon_mcp/modules/cases.py
+++ b/falcon_mcp/modules/cases.py
@@ -286,9 +286,9 @@ class CasesModule(BaseModule):
             default=None,
             description="Case description (max 2048 characters).",
         ),
-        description_format: str | None = Field(
+        description_format: Literal["markdown", "plaintext"] | None = Field(
             default=None,
-            description="Rendering format for the description. Values: plaintext, markdown. Defaults to CrowdStrike's server-side default (plaintext) when omitted.",
+            description="Rendering format for the description. Omit to leave it unset.",
         ),
         status: str | None = Field(
             default=None,
@@ -372,9 +372,9 @@ class CasesModule(BaseModule):
             default=None,
             description="New case description.",
         ),
-        description_format: str | None = Field(
+        description_format: Literal["markdown", "plaintext"] | None = Field(
             default=None,
-            description="Rendering format for the description. Values: plaintext, markdown. Left unchanged when omitted.",
+            description="Rendering format for the description. Left unchanged when omitted.",
         ),
         status: str | None = Field(
             default=None,

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -107,10 +107,12 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     "falcon_create_case": [
         "Create a critical case called 'Suspicious lateral movement from WORKSTATION-42'",
         "Open a high-severity case for the credential theft alerts and attach them as evidence",
+        "Create a case with a markdown-formatted description",
     ],
     "falcon_update_case": [
         "Set that case to in_progress and assign it to the analyst",
         "Close the case — investigation is complete",
+        "Rewrite the case description as markdown",
     ],
     "falcon_add_case_alert_evidence": [
         "Attach these detection alerts to the case",

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -232,6 +232,89 @@ class TestCasesIntegration(BaseIntegrationTest):
         )
         self.assert_no_error(close_result, context="close case cleanup")
 
+    def test_description_format_roundtrip(self):
+        """Create with a description_format, then change it, and verify each step.
+
+        The PATCH body nests description_format inside 'fields'. Sending it at the
+        body top level returns 200 and silently ignores it, so step 3 is the only
+        assertion that catches that mistake. The case is left closed as cleanup.
+        """
+        unique_name = f"falcon-mcp-test-fmt-{int(time.time())}"
+
+        # Step 1: Create with markdown format
+        create_result = self.call_method(
+            self.module.create_case,
+            name=unique_name,
+            severity=25,
+            description="# Integration test case\n\nSafe to delete.",
+            description_format="markdown",
+            status="new",
+        )
+
+        self.assert_no_error(create_result, context="create_case with markdown")
+        self.assert_valid_list_response(
+            create_result, min_length=1, context="create_case with markdown"
+        )
+
+        case = create_result[0]
+        case_id = case["id"]
+        assert case.get("description_format") == "markdown", (
+            "Created case did not report description_format 'markdown'. "
+            f"Got '{case.get('description_format')}'. Fields: {list(case.keys())}"
+        )
+
+        # Step 2: Patch the description alone - the format must survive
+        desc_result = self.call_method(
+            self.module.update_case,
+            id=case_id,
+            description="## Updated body\n\nStill markdown.",
+            expected_version=case.get("version", 1),
+        )
+
+        self.assert_no_error(desc_result, context="update description only")
+        self.assert_valid_list_response(
+            desc_result, min_length=1, context="update description only"
+        )
+
+        desc_case = desc_result[0]
+        assert desc_case.get("description_format") == "markdown", (
+            "Updating the description alone changed description_format. "
+            f"Expected 'markdown', got '{desc_case.get('description_format')}'"
+        )
+
+        # Step 3: Flip the format to plaintext - the regression guard.
+        # Pair it with a second field so 'fields' stays non-empty even if
+        # description_format is misplaced, forcing the API to be the judge.
+        fmt_result = self.call_method(
+            self.module.update_case,
+            id=case_id,
+            description_format="plaintext",
+            severity=50,
+            expected_version=desc_case.get("version", 2),
+        )
+
+        self.assert_no_error(fmt_result, context="update description_format")
+        self.assert_valid_list_response(
+            fmt_result, min_length=1, context="update description_format"
+        )
+
+        fmt_case = fmt_result[0]
+        assert fmt_case.get("description_format") == "plaintext", (
+            "description_format did not change to 'plaintext'. Got "
+            f"'{fmt_case.get('description_format')}'. The PATCH body most likely "
+            "sent the field at the top level instead of inside 'fields', which "
+            "the API accepts with 200 and ignores."
+        )
+
+        # Step 4: Close the case (cleanup)
+        close_result = self.call_method(
+            self.module.update_case,
+            id=case_id,
+            status="closed",
+            expected_version=fmt_case.get("version", 3),
+        )
+        self.assert_no_error(close_result, context="close case cleanup")
+
     # -------------------------------------------------------------------------
     # Template Tests
     # -------------------------------------------------------------------------

--- a/tests/modules/test_cases.py
+++ b/tests/modules/test_cases.py
@@ -327,6 +327,31 @@ class TestCasesModule(TestModules):
         body = call_args[1]["body"]
         self.assertEqual(body["template"], {"id": "tmpl-abc-123"})
 
+    def test_create_case_with_description_format(self):
+        """Test that description_format is passed through to the request body."""
+        self.mock_client.command.return_value = {
+            "status_code": 201,
+            "body": {"resources": [{"id": "new-case-id", "name": "Markdown Case"}]},
+        }
+
+        self.module.create_case(
+            name="Markdown Case",
+            severity=50,
+            description="**Bold** summary",
+            description_format="markdown",
+            status=None,
+            assigned_to_user_uuid=None,
+            tags=None,
+            template_id=None,
+            alert_ids=None,
+            event_ids=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        body = call_args[1]["body"]
+        self.assertEqual(body["description"], "**Bold** summary")
+        self.assertEqual(body["description_format"], "markdown")
+
     def test_create_case_error(self):
         """Test that create case API error is returned wrapped in a list."""
         self.mock_client.command.return_value = {
@@ -406,6 +431,7 @@ class TestCasesModule(TestModules):
             id="case-id-1",
             name=None,
             description=None,
+            description_format=None,
             status=None,
             severity=None,
             assigned_to_user_uuid=None,
@@ -431,6 +457,31 @@ class TestCasesModule(TestModules):
         call_args = self.mock_client.command.call_args
         body = call_args[1]["body"]
         self.assertEqual(body["fields"]["template"], {"id": "tmpl-xyz-789"})
+
+    def test_update_case_with_description_format(self):
+        """Test that description_format is included in the updated fields."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "case-id-1"}]},
+        }
+
+        self.module.update_case(
+            id="case-id-1",
+            name=None,
+            description="## Updated",
+            description_format="markdown",
+            status=None,
+            severity=None,
+            assigned_to_user_uuid=None,
+            remove_user_assignment=None,
+            template_id=None,
+            expected_version=None,
+        )
+
+        call_args = self.mock_client.command.call_args
+        body = call_args[1]["body"]
+        self.assertEqual(body["fields"]["description"], "## Updated")
+        self.assertEqual(body["fields"]["description_format"], "markdown")
 
     # -------------------------------------------------------------------------
     # Evidence Tests

--- a/tests/modules/test_cases.py
+++ b/tests/modules/test_cases.py
@@ -261,6 +261,7 @@ class TestCasesModule(TestModules):
             name="My Case",
             severity=75,
             description=None,
+            description_format=None,
             status=None,
             assigned_to_user_uuid=None,
             tags=None,
@@ -274,6 +275,7 @@ class TestCasesModule(TestModules):
         body = call_args[1]["body"]
         self.assertEqual(body["name"], "My Case")
         self.assertEqual(body["severity"], 75)
+        self.assertNotIn("description_format", body)
 
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
@@ -290,6 +292,7 @@ class TestCasesModule(TestModules):
             name="Evidence Case",
             severity=50,
             description=None,
+            description_format=None,
             status=None,
             assigned_to_user_uuid=None,
             tags=None,
@@ -315,6 +318,7 @@ class TestCasesModule(TestModules):
             name="Template Case",
             severity=25,
             description=None,
+            description_format=None,
             status=None,
             assigned_to_user_uuid=None,
             tags=None,
@@ -363,6 +367,7 @@ class TestCasesModule(TestModules):
             name="Bad Case",
             severity=50,
             description=None,
+            description_format=None,
             status=None,
             assigned_to_user_uuid=None,
             tags=None,
@@ -393,7 +398,14 @@ class TestCasesModule(TestModules):
         result = self.module.update_case(
             id="case-id-1",
             name="Updated Name",
+            description=None,
+            description_format=None,
             status="in_progress",
+            severity=None,
+            assigned_to_user_uuid=None,
+            remove_user_assignment=None,
+            template_id=None,
+            expected_version=None,
         )
 
         call_args = self.mock_client.command.call_args
@@ -403,6 +415,7 @@ class TestCasesModule(TestModules):
         self.assertIn("fields", body)
         self.assertEqual(body["fields"]["name"], "Updated Name")
         self.assertEqual(body["fields"]["status"], "in_progress")
+        self.assertNotIn("description_format", body["fields"])
 
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
@@ -416,7 +429,14 @@ class TestCasesModule(TestModules):
 
         self.module.update_case(
             id="case-id-1",
+            name=None,
+            description=None,
+            description_format=None,
+            status=None,
             severity=90,
+            assigned_to_user_uuid=None,
+            remove_user_assignment=None,
+            template_id=None,
             expected_version=2,
         )
 
@@ -452,7 +472,18 @@ class TestCasesModule(TestModules):
             "body": {"resources": [{"id": "case-id-1"}]},
         }
 
-        self.module.update_case(id="case-id-1", template_id="tmpl-xyz-789")
+        self.module.update_case(
+            id="case-id-1",
+            name=None,
+            description=None,
+            description_format=None,
+            status=None,
+            severity=None,
+            assigned_to_user_uuid=None,
+            remove_user_assignment=None,
+            template_id="tmpl-xyz-789",
+            expected_version=None,
+        )
 
         call_args = self.mock_client.command.call_args
         body = call_args[1]["body"]
@@ -691,6 +722,7 @@ class TestCasesModule(TestModules):
             name="Unauthorized Case",
             severity=50,
             description=None,
+            description_format=None,
             status=None,
             assigned_to_user_uuid=None,
             tags=None,
@@ -713,6 +745,13 @@ class TestCasesModule(TestModules):
         result = self.module.update_case(
             id="case-id-1",
             name="Conflicting Update",
+            description=None,
+            description_format=None,
+            status=None,
+            severity=None,
+            assigned_to_user_uuid=None,
+            remove_user_assignment=None,
+            template_id=None,
             expected_version=1,
         )
 


### PR DESCRIPTION
## What

Add an optional `description_format` parameter to `falcon_create_case` and `falcon_update_case`.

## Why

The cases module currently sends only a plain `description` in the request body, so CrowdStrike renders every case description with its server-side default (`plaintext`). Descriptions written with markdown syntax (headings, bold, code spans, blockquotes) therefore show their raw markup instead of being rendered, and there was no way to opt into markdown through the tools.

The CrowdStrike Case Management API already supports this: `OperationsCreateCaseRequest` (create) and `OperationsCaseFieldChanges` (update) both carry an optional `description_format` field, and returned case records include `"description_format": "markdown" | "plaintext"`.

## Change

- `create_case`: new optional `description_format`; when set, added to the `entities_cases_put_v2` body.
- `update_case`: new optional `description_format`; when set, added to the `fields` of the `entities_cases_patch_v2` body.
- Both default to `None` (parameter omitted), so existing behavior is unchanged and this is fully backwards compatible.

## Testing

- `uv run ruff check .` — passes.
- `uv run pytest` — full unit suite passes; added `test_create_case_with_description_format` and `test_update_case_with_description_format`.
