### PR TITLE
docs(deployment): sync Bedrock env vars with marketplace config

### DIFF
--- a/docs/deployment/amazon-bedrock.md
+++ b/docs/deployment/amazon-bedrock.md
@@ -44,6 +44,14 @@ The MCP Server requires internet connectivity to communicate with CrowdStrike's 
 | `FALCON_MCP_USER_AGENT_COMMENT` | `AWS/Bedrock/AgentCore` | Request identifier |
 | `FALCON_MCP_STATELESS_HTTP` | `true` | **Required** for AgentCore |
 | `FALCON_MCP_API_KEY` | *(optional)* | API key to secure the MCP endpoint |
+| `FALCON_MCP_MODULES` | *(optional)* | Comma-separated list of modules to enable. Defaults to all modules when unset |
+| `FALCON_MEMBER_CID` | *(optional)* | Child CID for Flight Control (MSSP multi-tenancy). Targets a specific child CID when authenticating with parent credentials |
+| `FALCON_MCP_DEBUG` | `false` | Enable debug logging |
+| `FALCON_PROXY_URL` | *(optional)* | HTTP/HTTPS proxy URL for outbound Falcon API connections in restricted network environments |
+| `FALCON_MCP_READ_ONLY` | *(optional)* | When set to `true`, register only read-only (non-mutating) tools. Excludes any tool that modifies Falcon state |
+| `FALCON_MCP_TOOLS` | *(optional)* | Comma-separated allow-list of specific tool names to enable, additive to the modules selected via `FALCON_MCP_MODULES` |
+| `FALCON_MCP_EXCLUDE_TOOLS` | *(optional)* | Comma-separated deny-list of tool names to disable. Takes precedence over `FALCON_MCP_TOOLS` and `FALCON_MCP_READ_ONLY` |
+| `FALCON_MCP_DYNAMIC` | *(optional)* | Enable dynamic mode, which exposes a small set of meta-tools for on-demand tool discovery instead of registering the full tool surface |
 
 > [!CAUTION]
 > `FALCON_MCP_STATELESS_HTTP` must be set to `true` for proper operation in AgentCore's stateless container environment.


### PR DESCRIPTION
The Amazon Bedrock AgentCore deployment doc listed only 9 environment variables, but the AWS Marketplace listing now exposes several more optional ones. This adds them to the Environment Variables table so the doc stays a superset-accurate reflection of what a deployer can actually set.

The new rows — `FALCON_MCP_MODULES`, `FALCON_MEMBER_CID`, `FALCON_MCP_DEBUG`, `FALCON_PROXY_URL`, `FALCON_MCP_READ_ONLY`, `FALCON_MCP_TOOLS`, `FALCON_MCP_EXCLUDE_TOOLS`, and `FALCON_MCP_DYNAMIC` — are grouped after the required and DO-NOT-CHANGE operational variables, and their wording and defaults match the marketplace config. Existing table format and the CAUTION/NOTE callouts are unchanged.