### PR TITLE
fix(modules/ngsiem): return job metadata so a zero-row result is provably one

### DIFF
--- a/docs/modules/ngsiem.md
+++ b/docs/modules/ngsiem.md
@@ -25,13 +25,14 @@ filter (e.g. `#event_simpleName=ProcessRollup2`, `UserName=*`) and pipe into
 commands like `groupBy([...], function=count())` and `sort()`; keep the time
 range tight. Consult `falcon://ngsiem/search/cql-guide` to construct the query —
 it has the pipe model, core commands, and working examples (distinct count, time
-bucketing, regex match, filtering on an aggregate). Returns matching event
-records, or an error/empty dict carrying the CQL guide when the job fails,
-times out, or returns no rows. Note: the API does not return detailed CQL parser
-diagnostics — a malformed query may error or silently return unexpected/empty
-results rather than a helpful message, so a result is not proof the query parsed
-as intended. Search times out after FALCON_MCP_NGSIEM_TIMEOUT seconds
-(default: 300).
+bucketing, regex match, filtering on an aggregate). Returns
+`{results, query_used, job}`, where `job` carries the row count, events scanned,
+the window searched, and `job.parsed_query` — the API's own normalization of the
+query it ran. Check `job.parsed_query` against your intent: unrecognized words
+become free-text stages instead of an error, so `| limit 5` runs as `| limit | 5`
+and returns the wrong rows silently. On zero rows a hint says whether the job
+scanned events (a real negative) or scanned none (unresolved). Search times out
+after FALCON_MCP_NGSIEM_TIMEOUT seconds (default: 300).
 
 **Example prompts:**
 

--- a/falcon_mcp/filter_hints.py
+++ b/falcon_mcp/filter_hints.py
@@ -281,8 +281,7 @@ FILTER_HINTS: dict[str, str] = {
         "is_default (true|false), precedence, created_at (UTC datetime), modified_by."
     ),
     "falcon_search_data_protection_content_patterns": (
-        "Common fields: name, category, type, region, "
-        "example, deleted (true|false)."
+        "Common fields: name, category, type, region, example, deleted (true|false)."
     ),
     # === Recon ===
     "falcon_search_recon_notifications": (
@@ -369,8 +368,10 @@ QUERY_STRING_HINTS: dict[str, str] = {
         "(no SELECT/WHERE/stats/`| limit`). Start from a tag filter "
         "`#event_simpleName=ProcessRollup2`, then pipe into `groupBy([field], "
         "function=count())`, `sort(_count, order=desc)`, and `head(n)` to cap raw "
-        "events. For distinct count, time bucketing, regex/contains match, or "
+        "events. Unrecognized words become free-text stages instead of an error, so "
+        "check `job.parsed_query` against your intent; on zero rows, "
+        "`job.processed_events` above zero means a real negative. "
+        "For distinct count, time bucketing, regex/contains match, or "
         "filtering on an aggregate, see `falcon://ngsiem/search/cql-guide`."
     ),
 }
-

--- a/falcon_mcp/modules/ngsiem.py
+++ b/falcon_mcp/modules/ngsiem.py
@@ -7,7 +7,7 @@ Next-Gen SIEM via the asynchronous job-based search API.
 
 import asyncio
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from mcp.server import FastMCP
@@ -27,11 +27,20 @@ _CQL_ERROR_HINT = (
     "language (filter | command | command) — not SQL or Splunk SPL. Consult "
     "`falcon://ngsiem/search/cql-guide` for the syntax and working examples."
 )
-_CQL_EMPTY_HINT = (
-    "0 events returned. This can mean no data matched, but it is also how the API "
-    "reports an invalid query (it free-text-matches malformed CQL rather than "
-    "erroring). If this is unexpected, review the CQL guide above and verify your "
-    "query syntax and field names. Consult `falcon://ngsiem/search/cql-guide`."
+# The API demotes unrecognized CQL words to free-text stages instead of erroring, so
+# `job.parsed_query` (its own normalization of what ran) is the only misparse signal.
+_CQL_CONFIRMED_ZERO_HINT = (
+    "No rows matched, and the job scanned {processed_events:,} events — a real "
+    "negative. Report it as such rather than retrying. If you expected rows, check "
+    "`job.parsed_query` against the query you sent."
+)
+
+# A correct filter over an empty partition and a misparsed query both scan nothing.
+_CQL_UNSCANNED_ZERO_HINT = (
+    "No rows, and `job.processed_events` does not show a completed scan, so this alone "
+    "is not a confirmed negative. Compare `job.parsed_query` to the query you sent: "
+    "unrecognized words become free-text stages instead of an error. If it matches your "
+    "intent the negative is real; if not, correct the syntax using the guide above."
 )
 
 # Configurable polling settings
@@ -50,6 +59,27 @@ def _iso_to_epoch_ms(iso_timestamp: str) -> int:
     """
     dt = datetime.fromisoformat(iso_timestamp.replace("Z", "+00:00"))
     return int(dt.timestamp() * 1000)
+
+
+def _epoch_ms_to_iso(epoch_ms: Any) -> str | None:
+    """Convert Unix epoch milliseconds to an ISO 8601 UTC timestamp.
+
+    Args:
+        epoch_ms: Unix epoch time in milliseconds
+
+    Returns:
+        ISO 8601 timestamp string, or None if the value is not a usable number
+    """
+    if isinstance(epoch_ms, bool) or not isinstance(epoch_ms, (int, float)):
+        return None
+    try:
+        return (
+            datetime.fromtimestamp(epoch_ms / 1000, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+    except (OSError, OverflowError, ValueError):
+        return None
 
 
 class NGSIEMModule(BaseModule):
@@ -109,6 +139,84 @@ class NGSIEMModule(BaseModule):
         error_response["hint"] = _CQL_ERROR_HINT
         return error_response
 
+    @staticmethod
+    def _extract_job_metadata(
+        body: dict[str, Any],
+        repository: str,
+        job_id: str,
+    ) -> dict[str, Any]:
+        """Map a search-status body onto the `job` block of the response envelope.
+
+        Fields the response omits are reported as None, never defaulted to 0.
+
+        Args:
+            body: The `body` of a 200 GetSearchStatusV1 response
+            repository: The repository the job ran against
+            job_id: The search job ID
+
+        Returns:
+            Dict of job metadata suitable for the `job` key of the response envelope
+        """
+        meta = body.get("metaData") or {}
+        filter_query = meta.get("filterQuery") or {}
+        # Job-level and query-level warnings are scoped separately; callers want both.
+        warnings = [*(body.get("warnings") or []), *(meta.get("warnings") or [])]
+
+        return {
+            "job_id": job_id,
+            "repository": repository,
+            "event_count": meta.get("eventCount"),
+            "processed_events": meta.get("processedEvents"),
+            "processed_bytes": meta.get("processedBytes"),
+            "parsed_query": filter_query.get("queryString"),
+            "search_start": _epoch_ms_to_iso(meta.get("queryStart")),
+            "search_end": _epoch_ms_to_iso(meta.get("queryEnd")),
+            "duration_ms": meta.get("timeMillis"),
+            "is_aggregate": meta.get("isAggregate"),
+            "cancelled": body.get("cancelled"),
+            "warnings": warnings,
+        }
+
+    def _build_job_envelope(
+        self,
+        events: list[dict[str, Any]],
+        job: dict[str, Any],
+        query_string: str,
+    ) -> dict[str, Any]:
+        """Assemble the response envelope, identical in shape for any row count.
+
+        NG-SIEM jobs carry no `meta.pagination`, so this keeps the house `results` key
+        and swaps the pagination block for a `job` block. Zero rows also get the CQL
+        guide and a hint chosen from `job.processed_events`.
+
+        Args:
+            events: The event records returned by the job
+            job: Job metadata from `_extract_job_metadata`
+            query_string: The CQL query as submitted
+
+        Returns:
+            Dict with `results`, `query_used`, `job`, and on zero rows also
+            `cql_guide` and `hint`
+        """
+        envelope: dict[str, Any] = {
+            "results": events,
+            "query_used": query_string,
+            "job": job,
+        }
+
+        if events:
+            return envelope
+
+        processed = job.get("processed_events")
+        if isinstance(processed, int) and not isinstance(processed, bool) and processed > 0:
+            hint = _CQL_CONFIRMED_ZERO_HINT.format(processed_events=processed)
+        else:
+            hint = _CQL_UNSCANNED_ZERO_HINT
+
+        envelope["cql_guide"] = SEARCH_NGSIEM_CQL_DOCUMENTATION
+        envelope["hint"] = hint
+        return envelope
+
     async def search_ngsiem(
         self,
         query_string: str = Field(
@@ -160,7 +268,7 @@ class NGSIEMModule(BaseModule):
             ),
             examples={"2025-01-01T00:00:00Z"},
         ),
-    ) -> list[dict[str, Any]] | dict[str, Any]:
+    ) -> dict[str, Any]:
         """Execute a CQL (CrowdStrike Query Language) query against CrowdStrike Next-Gen SIEM.
 
         Use this to search security events, logs, and telemetry with CQL. CQL is a
@@ -169,13 +277,14 @@ class NGSIEMModule(BaseModule):
         commands like `groupBy([...], function=count())` and `sort()`; keep the time
         range tight. Consult `falcon://ngsiem/search/cql-guide` to construct the query —
         it has the pipe model, core commands, and working examples (distinct count, time
-        bucketing, regex match, filtering on an aggregate). Returns matching event
-        records, or an error/empty dict carrying the CQL guide when the job fails,
-        times out, or returns no rows. Note: the API does not return detailed CQL parser
-        diagnostics — a malformed query may error or silently return unexpected/empty
-        results rather than a helpful message, so a result is not proof the query parsed
-        as intended. Search times out after FALCON_MCP_NGSIEM_TIMEOUT seconds
-        (default: 300).
+        bucketing, regex match, filtering on an aggregate). Returns
+        `{results, query_used, job}`, where `job` carries the row count, events scanned,
+        the window searched, and `job.parsed_query` — the API's own normalization of the
+        query it ran. Check `job.parsed_query` against your intent: unrecognized words
+        become free-text stages instead of an error, so `| limit 5` runs as `| limit | 5`
+        and returns the wrong rows silently. On zero rows a hint says whether the job
+        scanned events (a real negative) or scanned none (unresolved). Search times out
+        after FALCON_MCP_NGSIEM_TIMEOUT seconds (default: 300).
         """
         # Step 1: Start the search job
         # Note: FalconPy uber class passes body unchanged; API expects camelCase keys
@@ -217,6 +326,7 @@ class NGSIEMModule(BaseModule):
 
         # Step 2: Poll for completion
         elapsed = 0.0
+        last_job_meta: dict[str, Any] | None = None
         while elapsed < TIMEOUT_SECONDS:
             await asyncio.sleep(POLL_INTERVAL_SECONDS)
             elapsed += POLL_INTERVAL_SECONDS
@@ -238,33 +348,36 @@ class NGSIEMModule(BaseModule):
                 return self._format_cql_error_response(error_response, query_string)
 
             body = poll_response.get("body", {})
+            last_job_meta = self._extract_job_metadata(body, repository, job_id)
             if body.get("done"):
                 logger.debug("NGSIEM search job completed: %s", job_id)
-                events = body.get("events", [])
-                if not events:
-                    # The API free-text-matches invalid CQL and returns 200 with an
-                    # empty list, so an empty result is the most common silent-failure
-                    # signal. Return the guide + hint so the model can self-correct.
-                    return {
-                        "results": [],
-                        "query_used": query_string,
-                        "cql_guide": SEARCH_NGSIEM_CQL_DOCUMENTATION,
-                        "hint": _CQL_EMPTY_HINT,
-                    }
-                return events
+                return self._build_job_envelope(
+                    body.get("events") or [],
+                    last_job_meta,
+                    query_string,
+                )
 
         # Step 3: Timeout — attempt cleanup
         logger.warning("NGSIEM search job timed out: %s", job_id)
-        await self.client.command_async(
+        stop_response = await self.client.command_async(
             operation="StopSearchV1",
             repository=repository,
             id=job_id,
         )
 
+        # How far the job got, and whether cleanup actually stopped it.
+        details: dict[str, Any] = {
+            "job_id": job_id,
+            "timeout_seconds": TIMEOUT_SECONDS,
+            "stop_status_code": stop_response.get("status_code"),
+        }
+        if last_job_meta is not None:
+            details["last_job_status"] = last_job_meta
+
         error_response = _format_error_response(
             message=f"NGSIEM search timed out after {TIMEOUT_SECONDS} seconds. "
             "Try narrowing your query or reducing the time range.",
-            details={"job_id": job_id, "timeout_seconds": TIMEOUT_SECONDS},
+            details=details,
             operation="GetSearchStatusV1",
         )
         return self._format_cql_error_response(error_response, query_string)

--- a/falcon_mcp/resources/ngsiem.py
+++ b/falcon_mcp/resources/ngsiem.py
@@ -95,19 +95,27 @@ containing `powershell` case-insensitively, then show 10 events:
 `i` after the closing slash for case-insensitive matching. (The `=~` operator is
 something else — it pipes a field into a function like `wildcard()`, not a bare regex.)
 
-## Important caveat: no useful parser error on failure
+## Important: check what the API actually ran
 
-The API does NOT return a detailed CQL parser diagnostic. A malformed query may come
-back with a generic error, or — worse — the API free-text-matches the raw query text
-and returns HTTP 200 with unrelated rows or an empty result. **A result is not proof
-your query parsed as intended.** Because of this:
+The API returns no CQL parser diagnostic. Anything it cannot recognize as a command is
+demoted to a free-text filter stage and run anyway, so a malformed query returns HTTP
+200 with unrelated rows or none at all. **A result is not proof your query parsed as
+intended.** Two fields in the response's `job` block settle it:
 
-- Do NOT rely on a "run it, read the parser error, repair" loop — the error signal is
-  not reliable here.
-- Construct the query correctly up front using the shapes above.
-- If a query returns unexpected rows or zero rows, re-check the syntax against this
-  guide (SPL/SQL-isms and a missing/incorrect `#tag` filter are the usual causes)
-  rather than assuming the data simply isn't there.
+- **`job.parsed_query`** — the API's normalization of the stages it ran. Compare it
+  against your intent. `| limit 5` comes back as `| limit | 5`, each stray word now its
+  own free-text match. Normalization also turns an implicit-AND space into a `|`, so
+  expect that one difference even on a correct query.
+- **`job.processed_events`** — how many events the engine read through your filter.
+
+On zero rows: above zero means the job scanned that many events and none matched, which
+is a real negative — report it as the answer. Zero means nothing reached the filter, so
+check `job.parsed_query`; if it matches your intent the negative is real (a tag or field
+value with no data behaves this way), otherwise fix the syntax.
+
+Because the error signal is unreliable, build the query correctly up front rather than
+running it to read a parser error. SPL/SQL-isms and a misspelled `#tag` filter are the
+usual causes of a surprising result.
 
 ## Authoritative external references
 

--- a/tests/integration/test_ngsiem.py
+++ b/tests/integration/test_ngsiem.py
@@ -41,8 +41,8 @@ class TestNGSIEMIntegration(BaseIntegrationTest):
 
         self.assert_no_error(result, context="search_ngsiem")
 
-        # Result should be a list (events)
-        assert isinstance(result, list), f"Expected list of events, got {type(result)}"
+        events = self._unwrap_results(result)
+        assert isinstance(events, list), f"Expected list of events, got {type(events)}"
 
     def test_operation_names_are_correct(self):
         """Validate that FalconPy operation names work against real API.
@@ -93,7 +93,7 @@ class TestNGSIEMIntegration(BaseIntegrationTest):
         )
 
         self.assert_no_error(result, context="search with no matches")
-        assert isinstance(result, list), f"Expected list, got {type(result)}"
+        assert self._unwrap_results(result) == [], "Expected no events for an absent aid"
 
     def test_search_ngsiem_with_repository_parameter(self):
         """Test search with explicit repository parameter."""
@@ -110,7 +110,7 @@ class TestNGSIEMIntegration(BaseIntegrationTest):
 
         # May return events or empty list depending on environment
         self.assert_no_error(result, context="search with investigate_view repository")
-        assert isinstance(result, list), f"Expected list, got {type(result)}"
+        assert isinstance(self._unwrap_results(result), list)
 
     def test_search_ngsiem_invalid_repository_returns_error(self):
         """Test that an invalid repository value returns an error."""
@@ -141,11 +141,12 @@ class TestNGSIEMIntegration(BaseIntegrationTest):
         )
 
         self.assert_no_error(result, context="search_ngsiem event structure")
-        assert isinstance(result, list), f"Expected list, got {type(result)}"
+        events = self._unwrap_results(result)
+        assert isinstance(events, list), f"Expected list, got {type(events)}"
 
         # Only validate structure if events exist
-        if len(result) > 0:
-            first_event = result[0]
+        if len(events) > 0:
+            first_event = events[0]
             assert isinstance(first_event, dict), f"Expected event dict, got {type(first_event)}"
             # Events should have at least a timestamp field
             assert "@timestamp" in first_event or "timestamp" in first_event, (
@@ -166,7 +167,7 @@ class TestNGSIEMIntegration(BaseIntegrationTest):
         )
 
         self.assert_no_error(result, context="search with special characters")
-        assert isinstance(result, list), f"Expected list, got {type(result)}"
+        assert isinstance(self._unwrap_results(result), list)
 
     def test_search_ngsiem_timeout_returns_error(self):
         """Test that a search exceeding the timeout returns a timeout error.
@@ -194,4 +195,79 @@ class TestNGSIEMIntegration(BaseIntegrationTest):
         assert "error" in result, "Expected 'error' key for timeout"
         assert "timed out" in result["error"].lower(), (
             f"Expected timeout message, got: {result['error']}"
+        )
+
+    def test_job_metadata_is_returned_live(self):
+        """Job metadata reaches the caller from a real search.
+
+        Guards against an upstream rename, which would silently return None for all
+        of them and strip the zero-row reasoning of its evidence.
+        """
+        end_time = datetime.now(timezone.utc)
+        start_time = end_time - timedelta(hours=1)
+
+        result = self.call_method(
+            self.module.search_ngsiem,
+            query_string="#event_simpleName=ProcessRollup2 | head(3)",
+            start=start_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            end=end_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+
+        self.assert_no_error(result, context="search_ngsiem job metadata")
+        job = result["job"]
+        assert job["processed_events"] is not None, f"processed_events missing: {job}"
+        assert job["processed_bytes"] is not None, f"processed_bytes missing: {job}"
+        assert job["event_count"] is not None, f"event_count missing: {job}"
+        assert job["search_start"] is not None, f"search_start missing: {job}"
+        assert job["search_end"] is not None, f"search_end missing: {job}"
+        assert job["parsed_query"] == "#event_simpleName=ProcessRollup2", (
+            f"unexpected parse echo: {job['parsed_query']!r}"
+        )
+
+    def test_zero_row_result_is_provably_a_zero_row_result_live(self):
+        """A valid filter matching nothing comes back as a confirmed negative.
+
+        The reported scenario: a well-formed query over a value that does not exist.
+        """
+        end_time = datetime.now(timezone.utc)
+        start_time = end_time - timedelta(hours=1)
+
+        result = self.call_method(
+            self.module.search_ngsiem,
+            query_string=(
+                '#event_simpleName=NetworkConnectIP4 aid="00000000000000000000000000000000" '
+                "| head(5)"
+            ),
+            start=start_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            end=end_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+
+        self.assert_no_error(result, context="zero-row search")
+        assert result["results"] == [], f"Expected no rows, got {len(result['results'])}"
+        assert result["job"]["processed_events"] > 0, (
+            f"a valid filter must scan events even when it matches none; got "
+            f"{result['job']['processed_events']}"
+        )
+        assert "a real negative" in result["hint"], (
+            f"a scanned zero-row result must be stated as real: {result['hint']!r}"
+        )
+
+    def test_misparsed_query_is_visible_live(self):
+        """An SPL-ism returns rows under a parse the caller did not ask for.
+
+        `| limit 5` is not CQL, and the API runs it without an error.
+        """
+        end_time = datetime.now(timezone.utc)
+        start_time = end_time - timedelta(hours=1)
+
+        result = self.call_method(
+            self.module.search_ngsiem,
+            query_string="#event_simpleName=ProcessRollup2 | limit 5",
+            start=start_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            end=end_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+
+        self.assert_no_error(result, context="misparsed query")
+        assert result["job"]["parsed_query"] == "#event_simpleName=ProcessRollup2 | limit | 5", (
+            f"expected the demoted free-text stages; got {result['job']['parsed_query']!r}"
         )

--- a/tests/modules/test_ngsiem.py
+++ b/tests/modules/test_ngsiem.py
@@ -117,11 +117,13 @@ class TestNGSIEMModule(TestModules):
         self.assertEqual(second_call[1]["search_id"], "job-123")
         self.assertEqual(second_call[1]["repository"], "search-all")
 
-        # Verify result is the events list
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["aid"], "agent-1")
-        self.assertEqual(result[1]["event"], "DnsRequest")
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["aid"], "agent-1")
+        self.assertEqual(result["results"][1]["event"], "DnsRequest")
+        # A populated result carries no guide/hint
+        self.assertNotIn("cql_guide", result)
+        self.assertNotIn("hint", result)
 
     @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
     def test_search_ngsiem_multiple_polls(self, mock_sleep):
@@ -159,9 +161,9 @@ class TestNGSIEMModule(TestModules):
         self.assertEqual(self.mock_client.command.call_count, 4)
 
         # Verify result
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["aid"], "agent-1")
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["results"][0]["aid"], "agent-1")
 
     @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
     def test_search_ngsiem_start_error(self, mock_sleep):
@@ -232,7 +234,7 @@ class TestNGSIEMModule(TestModules):
         }
         poll_not_done = {
             "status_code": 200,
-            "body": {"done": False},
+            "body": {"done": False, "metaData": {"processedEvents": 4200, "timeMillis": 9000}},
         }
         stop_response = {
             "status_code": 200,
@@ -267,6 +269,10 @@ class TestNGSIEMModule(TestModules):
         self.assertIn("details", result)
         self.assertEqual(result["details"]["job_id"], "job-timeout")
         self.assertEqual(result["details"]["timeout_seconds"], 10)
+        # Cleanup outcome and how far the job got before the deadline
+        self.assertEqual(result["details"]["stop_status_code"], 200)
+        self.assertEqual(result["details"]["last_job_status"]["processed_events"], 4200)
+        self.assertEqual(result["details"]["last_job_status"]["duration_ms"], 9000)
         # Verify the CQL guide + repair hint reach the model on timeout
         self.assertIn("cql_guide", result)
         self.assertIn("hint", result)
@@ -405,6 +411,242 @@ class TestNGSIEMModule(TestModules):
         self.assertIn("cql_guide", result)
         self.assertIn("hint", result)
         self.assertEqual(result["query_used"], "aid=abc123")
+
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_search_ngsiem_surfaces_job_metadata_on_success(self, mock_sleep):
+        """A populated result carries the job metadata, mapped from the real body shape."""
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"id": "job-meta"}},
+            {
+                "status_code": 200,
+                "body": {
+                    "done": True,
+                    "cancelled": False,
+                    "events": [{"aid": "agent-1"}],
+                    "warnings": [],
+                    "metaData": {
+                        "eventCount": 1,
+                        "processedEvents": 189064,
+                        "processedBytes": 498887584,
+                        "timeMillis": 5799,
+                        "isAggregate": False,
+                        "queryStart": 1735689600000,  # 2025-01-01T00:00:00Z
+                        "queryEnd": 1735693200000,  # 2025-01-01T01:00:00Z
+                        "warnings": [],
+                        "filterQuery": {"queryString": "#event_simpleName=ProcessRollup2"},
+                    },
+                },
+            },
+        ]
+
+        result = asyncio.run(
+            self.module.search_ngsiem(
+                query_string="#event_simpleName=ProcessRollup2 | head(1)",
+                start="2025-01-01T00:00:00Z",
+                repository="search-all",
+            )
+        )
+
+        job = result["job"]
+        self.assertEqual(job["job_id"], "job-meta")
+        self.assertEqual(job["repository"], "search-all")
+        self.assertEqual(job["event_count"], 1)
+        self.assertEqual(job["processed_events"], 189064)
+        self.assertEqual(job["processed_bytes"], 498887584)
+        self.assertEqual(job["duration_ms"], 5799)
+        self.assertIs(job["is_aggregate"], False)
+        self.assertIs(job["cancelled"], False)
+        self.assertEqual(job["warnings"], [])
+        self.assertEqual(job["search_start"], "2025-01-01T00:00:00Z")
+        self.assertEqual(job["search_end"], "2025-01-01T01:00:00Z")
+        self.assertEqual(result["query_used"], "#event_simpleName=ProcessRollup2 | head(1)")
+        self.assertEqual(job["parsed_query"], "#event_simpleName=ProcessRollup2")
+
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_search_ngsiem_exposes_misparse_on_populated_result(self, mock_sleep):
+        """A misparsed query still returns rows, so parsed_query must survive success.
+
+        Live, `| limit 5` returns 147 rows for a query the caller believes caps at 5.
+        """
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"id": "job-misparse"}},
+            {
+                "status_code": 200,
+                "body": {
+                    "done": True,
+                    "events": [{"aid": f"agent-{i}"} for i in range(147)],
+                    "metaData": {
+                        "eventCount": 147,
+                        "processedEvents": 66067,
+                        "filterQuery": {
+                            "queryString": "#event_simpleName=ProcessRollup2 | limit | 5"
+                        },
+                    },
+                },
+            },
+        ]
+
+        result = asyncio.run(
+            self.module.search_ngsiem(
+                query_string="#event_simpleName=ProcessRollup2 | limit 5",
+                start="2025-01-01T00:00:00Z",
+            )
+        )
+
+        self.assertEqual(len(result["results"]), 147)
+        self.assertEqual(
+            result["job"]["parsed_query"], "#event_simpleName=ProcessRollup2 | limit | 5"
+        )
+
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_zero_rows_with_events_scanned_is_reported_as_a_real_negative(self, mock_sleep):
+        """A job that scanned events and matched none is stated as a true negative.
+
+        Live, a valid filter on an absent aid scans thousands of events; a misparsed
+        query scans zero. So a nonzero scan count settles it.
+        """
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"id": "job-zero"}},
+            {
+                "status_code": 200,
+                "body": {
+                    "done": True,
+                    "events": [],
+                    "metaData": {
+                        "eventCount": 0,
+                        "processedEvents": 90102,
+                        "processedBytes": 23734288,
+                        "filterQuery": {"queryString": "#event_simpleName=DnsRequest"},
+                    },
+                },
+            },
+        ]
+
+        result = asyncio.run(
+            self.module.search_ngsiem(
+                query_string="#event_simpleName=DnsRequest DomainName=*example*",
+                start="2025-01-01T00:00:00Z",
+            )
+        )
+
+        self.assertEqual(result["results"], [])
+        self.assertEqual(result["job"]["processed_events"], 90102)
+        # The scan count is quoted back, and the verdict is stated, not doubted
+        self.assertIn("90,102", result["hint"])
+        self.assertIn("a real negative", result["hint"])
+        self.assertNotIn("not a confirmed negative", result["hint"])
+        self.assertNotIn("it is also how the API reports an invalid query", result["hint"])
+
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_zero_rows_with_nothing_scanned_stays_unresolved(self, mock_sleep):
+        """Zero scanned events is ambiguous, so the hint points at parsed_query.
+
+        Live, both an empty tag partition and a misparse scan zero.
+        """
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"id": "job-unscanned"}},
+            {
+                "status_code": 200,
+                "body": {
+                    "done": True,
+                    "events": [],
+                    "metaData": {
+                        "eventCount": 0,
+                        "processedEvents": 0,
+                        "processedBytes": 0,
+                        "filterQuery": {"queryString": "#event_simpleName=ProcessRollupTwo"},
+                    },
+                },
+            },
+        ]
+
+        result = asyncio.run(
+            self.module.search_ngsiem(
+                query_string="#event_simpleName=ProcessRollupTwo | head(3)",
+                start="2025-01-01T00:00:00Z",
+            )
+        )
+
+        self.assertEqual(result["job"]["processed_events"], 0)
+        self.assertIn("not a confirmed negative", result["hint"])
+        self.assertIn("parsed_query", result["hint"])
+        self.assertIn("cql_guide", result)
+
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_absent_metadata_reports_none_rather_than_zero(self, mock_sleep):
+        """A response without metaData reports None, not a fabricated 0."""
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"id": "job-bare"}},
+            {"status_code": 200, "body": {"done": True, "events": []}},
+        ]
+
+        result = asyncio.run(
+            self.module.search_ngsiem(
+                query_string="aid=abc123",
+                start="2025-01-01T00:00:00Z",
+            )
+        )
+
+        job = result["job"]
+        self.assertIsNone(job["event_count"])
+        self.assertIsNone(job["processed_events"])
+        self.assertIsNone(job["parsed_query"])
+        self.assertIsNone(job["search_start"])
+        self.assertIsNone(job["search_end"])
+        self.assertIn("not a confirmed negative", result["hint"])
+
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_warnings_are_merged_from_both_scopes(self, mock_sleep):
+        """Warnings from both the job-level and metaData scopes reach the caller."""
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"id": "job-warn"}},
+            {
+                "status_code": 200,
+                "body": {
+                    "done": True,
+                    "events": [{"aid": "agent-1"}],
+                    "warnings": ["job-level warning"],
+                    "metaData": {"warnings": ["query-level warning"]},
+                },
+            },
+        ]
+
+        result = asyncio.run(
+            self.module.search_ngsiem(
+                query_string="aid=abc123",
+                start="2025-01-01T00:00:00Z",
+            )
+        )
+
+        self.assertEqual(result["job"]["warnings"], ["job-level warning", "query-level warning"])
+
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_empty_and_populated_results_share_one_shape(self, mock_sleep):
+        """Both outcomes must be the same shape, so a caller needs one parse path."""
+        common = ["results", "query_used", "job"]
+
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"id": "job-a"}},
+            {"status_code": 200, "body": {"done": True, "events": [{"aid": "agent-1"}]}},
+        ]
+        populated = asyncio.run(
+            self.module.search_ngsiem(query_string="aid=a", start="2025-01-01T00:00:00Z")
+        )
+
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"id": "job-b"}},
+            {"status_code": 200, "body": {"done": True, "events": []}},
+        ]
+        empty = asyncio.run(
+            self.module.search_ngsiem(query_string="aid=b", start="2025-01-01T00:00:00Z")
+        )
+
+        for key in common:
+            self.assertIn(key, populated)
+            self.assertIn(key, empty)
+        self.assertIsInstance(populated["results"], list)
+        self.assertIsInstance(empty["results"], list)
+        self.assertEqual(sorted(populated["job"]), sorted(empty["job"]))
 
 
 class TestNGSIEMModuleConfig(unittest.TestCase):


### PR DESCRIPTION
NG-SIEM searches threw away everything the job response told us except the events themselves, so an agent had no way to tell a real zero-row answer from a query that quietly returned nothing. Worse, the empty-result hint told the model that an empty result is how the API reports a bad query, so a valid "nothing in the fleet resolved this domain" came back sounding unreliable.

Both the empty and populated paths now return the same shape, with a job block carrying the row count, how many events were scanned, the window actually searched, any warnings, and the API's own normalization of the query it ran. That last field is the useful one. The API silently demotes unrecognized words to free-text matches instead of erroring, so `| limit 5` runs as `| limit | 5` and hands back unrelated rows. Comparing it against intent is the only way to catch that, which is why it is on the success path too and not just the empty one.

The empty-result hint now follows what the metadata shows: a scan that read events and matched none is reported as a real negative, and a scan that read nothing stays open and points at the parse echo. The CQL guide and the dynamic-mode hint got the same correction. The timeout path picked up the last poll's progress and whether cleanup actually stopped the job.

MCP isError compliance is left alone here since it spans every module and is tracked separately.