### PR TITLE
fix(modules/policies): send rule_group_id for rule-group actions

### DIFF
--- a/docs/modules/policies.md
+++ b/docs/modules/policies.md
@@ -65,11 +65,12 @@ the API response for the deletion.
 
 Perform an action on one or more policies of the given type.
 
-Use this to enable/disable policies or attach/detach host groups and rule
-groups (and, for content_update, content overrides). action_name is
-validated against the actions valid for that policy_type. The
-add/remove-host-group and add/remove-rule-group actions require a group_id.
-Returns the updated policy records.
+Use this to enable/disable policies or attach/detach host groups (and, for
+prevention, Custom IOA rule groups; for content_update, content overrides).
+action_name is validated against the actions valid for that policy_type —
+rule-group actions are prevention-only. The add/remove-host-group and
+add/remove-rule-group actions require a group_id. Returns the updated policy
+records.
 
 **Example prompts:**
 

--- a/falcon_mcp/modules/policies.py
+++ b/falcon_mcp/modules/policies.py
@@ -174,7 +174,11 @@ class PoliciesModule(BaseModule):
 
     # Valid action_name values per type for perform_policy_action. The SDK rejects
     # rule-group actions for firewall/device_control; content_update has unique
-    # pin/override actions.
+    # pin/override actions. Rule-group actions are prevention-only: the
+    # sensor_update and response endpoints advertise them but have no rule-group
+    # support behind them — they return 200 with zero affected resources, attach
+    # nothing, and their policy schema has no rule-group field to hold an
+    # attachment. Reject them up front rather than report a silent no-op as success.
     _VALID_ACTIONS: dict[str, set[str]] = {
         "prevention": {
             "enable",
@@ -189,16 +193,12 @@ class PoliciesModule(BaseModule):
             "disable",
             "add-host-group",
             "remove-host-group",
-            "add-rule-group",
-            "remove-rule-group",
         },
         "response": {
             "enable",
             "disable",
             "add-host-group",
             "remove-host-group",
-            "add-rule-group",
-            "remove-rule-group",
         },
         "firewall": {
             "enable",
@@ -227,6 +227,18 @@ class PoliciesModule(BaseModule):
             # Pinning a specific content version is out of scope until a dedicated
             # parameter is wired in.
         },
+    }
+
+    # The action_parameters name each group action requires. Host-group actions take
+    # 'group_id'; rule-group actions take 'rule_group_id'. The two are not
+    # interchangeable — sending the wrong name returns HTTP 400 "Group action
+    # parameters must be provided" and changes nothing, the same response as sending
+    # no action_parameters at all.
+    _GROUP_ACTION_PARAM: dict[str, str] = {
+        "add-host-group": "group_id",
+        "remove-host-group": "group_id",
+        "add-rule-group": "rule_group_id",
+        "remove-rule-group": "rule_group_id",
     }
 
     # Whether a create/update body may carry a `settings` object. The firewall
@@ -843,23 +855,24 @@ class PoliciesModule(BaseModule):
             ),
         ),
         action_name: str = Field(
-            description="The action to perform. Common to all types: 'enable', 'disable', 'add-host-group', 'remove-host-group'. prevention/sensor_update/response also allow 'add-rule-group'/'remove-rule-group'; content_update also allows 'override-allow'/'override-pause'/'override-revert'. The valid set is validated per type.",
+            description="The action to perform. Common to all types: 'enable', 'disable', 'add-host-group', 'remove-host-group'. prevention also allows 'add-rule-group'/'remove-rule-group' (attach/detach a Custom IOA rule group); content_update also allows 'override-allow'/'override-pause'/'override-revert'. The valid set is validated per type.",
         ),
         ids: list[str] = Field(
             description="IDs of the policies to act on.",
         ),
         group_id: str | None = Field(
             default=None,
-            description="Group ID for group actions. Required for 'add-host-group'/'remove-host-group' (a host group ID) and 'add-rule-group'/'remove-rule-group' (a rule group ID); omit for other actions.",
+            description="Group ID for group actions. Required for 'add-host-group'/'remove-host-group' (a host group ID) and, on prevention policies, 'add-rule-group'/'remove-rule-group' (a Custom IOA rule group ID); omit for other actions.",
         ),
     ) -> list[dict[str, Any]]:
         """Perform an action on one or more policies of the given type.
 
-        Use this to enable/disable policies or attach/detach host groups and rule
-        groups (and, for content_update, content overrides). action_name is
-        validated against the actions valid for that policy_type. The
-        add/remove-host-group and add/remove-rule-group actions require a group_id.
-        Returns the updated policy records.
+        Use this to enable/disable policies or attach/detach host groups (and, for
+        prevention, Custom IOA rule groups; for content_update, content overrides).
+        action_name is validated against the actions valid for that policy_type —
+        rule-group actions are prevention-only. The add/remove-host-group and
+        add/remove-rule-group actions require a group_id. Returns the updated policy
+        records.
         """
         type_error = self._validate_policy_type(policy_type)
         if type_error is not None:
@@ -884,12 +897,7 @@ class PoliciesModule(BaseModule):
             ]
 
         body: dict[str, Any] = {"ids": ids}
-        if action_name in (
-            "add-host-group",
-            "remove-host-group",
-            "add-rule-group",
-            "remove-rule-group",
-        ):
+        if action_name in self._GROUP_ACTION_PARAM:
             if not group_id:
                 return [
                     _format_error_response(
@@ -899,7 +907,9 @@ class PoliciesModule(BaseModule):
                         operation=self._OPERATIONS[policy_type]["action"],
                     )
                 ]
-            body["action_parameters"] = [{"name": "group_id", "value": group_id}]
+            body["action_parameters"] = [
+                {"name": self._GROUP_ACTION_PARAM[action_name], "value": group_id}
+            ]
 
         result = self._base_query_api_call(
             operation=self._OPERATIONS[policy_type]["action"],

--- a/tests/modules/test_policies.py
+++ b/tests/modules/test_policies.py
@@ -684,36 +684,34 @@ class TestPoliciesModule(TestModules):
     # ---- Perform action --------------------------------------------------------
 
     def test_perform_action_rule_group_validity_per_type(self):
-        """add-rule-group is valid for prevention/sensor_update/response, rejected for firewall/dc."""
-        # prevention/sensor_update/response accept add-rule-group (with a group_id).
-        for policy_type, action_op in (
-            ("prevention", "performPreventionPoliciesAction"),
-            ("sensor_update", "performSensorUpdatePoliciesAction"),
-            ("response", "performRTResponsePoliciesAction"),
-        ):
-            with self.subTest(policy_type=policy_type, expect="accepted"):
+        """Rule-group actions are valid for prevention only, rejected for every other type."""
+        for action_name in ("add-rule-group", "remove-rule-group"):
+            with self.subTest(policy_type="prevention", action_name=action_name):
                 self.mock_client.command.reset_mock()
                 self.mock_client.command.return_value = {
                     "status_code": 200,
                     "body": {"resources": [{"id": "p-1"}]},
                 }
                 result = self.module.perform_policy_action(
-                    policy_type=policy_type,
-                    action_name="add-rule-group",
+                    policy_type="prevention",
+                    action_name=action_name,
                     ids=["p-1"],
                     group_id="rg-1",
                 )
                 self.assertNotIn("error", result[0])
                 self.assertEqual(self.mock_client.command.call_count, 1)
                 call = self.mock_client.command.call_args_list[0]
-                self.assertEqual(call[0][0], action_op)
+                self.assertEqual(call[0][0], "performPreventionPoliciesAction")
                 self.assertEqual(
                     call[1]["body"]["action_parameters"],
-                    [{"name": "group_id", "value": "rg-1"}],
+                    [{"name": "rule_group_id", "value": "rg-1"}],
                 )
 
-        # firewall and device_control reject rule-group actions before any API call.
-        for policy_type in ("firewall", "device_control"):
+        # Every other type rejects rule-group actions before any API call. firewall
+        # and device_control are rejected by the SDK; sensor_update and response
+        # accept the action_name but have no rule-group support behind it — the API
+        # returns 200 with zero affected resources and attaches nothing.
+        for policy_type in ("sensor_update", "response", "firewall", "device_control"):
             with self.subTest(policy_type=policy_type, expect="rejected"):
                 self.mock_client.command.reset_mock()
                 result = self.module.perform_policy_action(
@@ -724,6 +722,37 @@ class TestPoliciesModule(TestModules):
                 )
                 self.assertIn("error", result[0])
                 self.assertEqual(self.mock_client.command.call_count, 0)
+
+    def test_perform_action_group_param_name_is_per_action(self):
+        """Group actions use the action_parameters name their endpoint requires.
+
+        Host-group actions take 'group_id'; rule-group actions take 'rule_group_id'.
+        The names are not interchangeable — the wrong one returns HTTP 400 "Group
+        action parameters must be provided" and changes nothing.
+        """
+        for action_name, expected_name in (
+            ("add-host-group", "group_id"),
+            ("remove-host-group", "group_id"),
+            ("add-rule-group", "rule_group_id"),
+            ("remove-rule-group", "rule_group_id"),
+        ):
+            with self.subTest(action_name=action_name):
+                self.mock_client.command.reset_mock()
+                self.mock_client.command.return_value = {
+                    "status_code": 200,
+                    "body": {"resources": [{"id": "p-1"}]},
+                }
+                self.module.perform_policy_action(
+                    policy_type="prevention",
+                    action_name=action_name,
+                    ids=["p-1"],
+                    group_id="g-1",
+                )
+                call = self.mock_client.command.call_args_list[0]
+                self.assertEqual(
+                    call[1]["body"]["action_parameters"],
+                    [{"name": expected_name, "value": "g-1"}],
+                )
 
     def test_perform_action_rule_group_requires_group_id(self):
         """add-rule-group without group_id returns a guiding error, no API call.

--- a/tests/modules/test_policies.py
+++ b/tests/modules/test_policies.py
@@ -757,8 +757,9 @@ class TestPoliciesModule(TestModules):
     def test_perform_action_rule_group_requires_group_id(self):
         """add-rule-group without group_id returns a guiding error, no API call.
 
-        Rule-group actions need the same action_parameters group_id payload as
-        host-group actions; omitting it must be caught before the API call.
+        Rule-group actions carry the group through action_parameters as host-group
+        actions do, but under their own parameter name; either way an omitted
+        group_id must be caught before the API call.
         """
         result = self.module.perform_policy_action(
             policy_type="prevention",


### PR DESCRIPTION
`falcon_perform_policy_action` built the group-action body with a hardcoded parameter name, so `add-rule-group` and `remove-rule-group` on prevention policies always came back with a 400 and never attached the rule group. Host-group actions really do take `group_id`, but rule-group actions need `rule_group_id`, and neither name works in the other's place, so the hardcoded name becomes a per-action map.

This also drops rule-group actions from `sensor_update` and `response`. Those endpoints list the actions but have nothing behind them: they return 200 with no affected resources whatever you pass, and their policy schema has no field to hold an attachment. Rejecting the action outright seemed better than letting a no-op look like success, which is how firewall `settings` already work.

Fixes #530