### PR TITLE
feat(modules/zero-trust-assessment): add Zero Trust Assessment module

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Full docs are available at **[developer.crowdstrike.com/falcon-mcp](https://deve
 | [Serverless](https://developer.crowdstrike.com/falcon-mcp/modules/serverless/) | Search for vulnerabilities in serverless functions |
 | [Shield](https://developer.crowdstrike.com/falcon-mcp/modules/shield/) | SaaS security posture, checks, alerts, and app inventory |
 | [Spotlight](https://developer.crowdstrike.com/falcon-mcp/modules/spotlight/) | Manage and analyze vulnerability data and security assessments |
+| [Zero Trust Assessment](https://developer.crowdstrike.com/falcon-mcp/modules/zero-trust-assessment/) | Retrieve Zero Trust Assessment posture scores and sensor and OS hardening signals for hosts |
 
 See the [Module Overview](https://developer.crowdstrike.com/falcon-mcp/modules/overview/) for required API scopes, available tools, and FQL resources.
 

--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -33,3 +33,4 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 | [Serverless](/falcon-mcp/modules/serverless/) | `Falcon Container Image:read` | Accessing and managing CrowdStrike Falcon Serverless Vulnerabilities |
 | [Shield](/falcon-mcp/modules/shield/) | `SaaS Security:read`, `SaaS Security:write` | Shield module for CrowdStrike Falcon. |
 | [Spotlight](/falcon-mcp/modules/spotlight/) | `Vulnerabilities:read` | Accessing and managing CrowdStrike Falcon Spotlight vulnerabilities |
+| [Zero Trust Assessment](/falcon-mcp/modules/zero-trust-assessment/) | `Zero Trust Assessment:read` | Retrieving Zero Trust Assessment posture scores and sensor and OS hardening signals for hosts |

--- a/docs/modules/zero-trust-assessment.md
+++ b/docs/modules/zero-trust-assessment.md
@@ -1,0 +1,72 @@
+<!-- meta:title Zero Trust Assessment -->
+<!-- meta:description Retrieving Zero Trust Assessment posture scores and sensor and OS hardening signals for hosts -->
+<!-- meta:section modules -->
+<!-- meta:link-base /falcon-mcp/ -->
+<!-- frontmatter:sidebar order:10 -->
+
+Retrieving Zero Trust Assessment posture scores and sensor and OS hardening signals for hosts
+
+## API Scopes
+
+- `Zero Trust Assessment:read`
+
+## Tools
+
+### `falcon_get_zta_assessments`
+
+**Required scopes:** `Zero Trust Assessment:read`
+
+Get Zero Trust Assessment details for specific hosts by agent ID (AID).
+
+Use this when you already hold an AID: a detection reports one as its `device_id`, and
+`falcon_search_hosts` resolves a hostname to one. No Zero Trust tool accepts a
+hostname, so resolve the name with `falcon_search_hosts` first.
+Returns `results` holding one record per assessed host — the Zero Trust score plus the
+full sensor and OS hardening signals — and `not_found` listing the AIDs with no
+assessment.
+
+`not_found` is always present, even when empty, because the API reports an unknown or
+never-assessed AID by omitting its record from an otherwise successful response.
+
+**Example prompts:**
+
+- "What is the security posture of host WEB-01?"
+- "Show the Zero Trust hardening signals for this agent ID"
+
+### `falcon_get_zta_audit`
+
+**Required scopes:** `Zero Trust Assessment:read`
+
+Get the tenant-wide Zero Trust Assessment summary.
+
+Use this to answer how the whole tenant scores, rather than which hosts score badly —
+it is a single CID-level rollup and carries no per-host data, so reach for
+`falcon_search_zta_assessments` when you need individual hosts.
+Returns one record with the assessed host count and average Zero Trust score for the
+tenant, broken down by platform.
+
+**Example prompts:**
+
+- "What is our overall Zero Trust score?"
+- "Break down our Zero Trust posture by platform"
+
+### `falcon_search_zta_assessments`
+
+**Required scopes:** `Zero Trust Assessment:read`
+
+Search Zero Trust Assessment scores and return full assessment details.
+
+Use this to rank hosts by security posture: pass `max_score` to list the weakest
+hosts, `min_score` to list the strongest. Score is the only attribute this tool can
+select on, so start from `falcon_get_zta_assessments` when you already have an agent
+ID (AID) and from `falcon_search_hosts` when you have a hostname.
+Returns each host's Zero Trust score with its full sensor and OS hardening signals,
+in the standard pagination envelope; feed `pagination.next` back as `after`.
+
+Results name hosts only by AID, so pair this with `falcon_search_hosts` to report
+hostnames. Each record carries a long signal list, so raise `limit` deliberately.
+
+**Example prompts:**
+
+- "Which hosts have the weakest Zero Trust posture?"
+- "Show me hosts scoring below 40 on Zero Trust Assessment"

--- a/falcon_mcp/common/api_scopes.py
+++ b/falcon_mcp/common/api_scopes.py
@@ -277,6 +277,10 @@ API_SCOPE_REQUIREMENTS = {
     "deleteContentUpdatePolicies": ["Content Update Policies:write"],
     "performContentUpdatePoliciesAction": ["Content Update Policies:write"],
     "setContentUpdatePoliciesPrecedence": ["Content Update Policies:write"],
+    # Zero Trust Assessment operations
+    "getAssessmentsByScoreV1": ["Zero Trust Assessment:read"],
+    "getAssessmentV1": ["Zero Trust Assessment:read"],
+    "getAuditV1": ["Zero Trust Assessment:read"],
 }
 
 

--- a/falcon_mcp/modules/zero_trust_assessment.py
+++ b/falcon_mcp/modules/zero_trust_assessment.py
@@ -1,0 +1,219 @@
+"""
+Zero Trust Assessment module for Falcon MCP Server
+
+This module provides tools for retrieving Zero Trust Assessment posture scores and sensor and OS
+hardening signals for hosts.
+"""
+
+from typing import Any
+
+from mcp.server import FastMCP
+from pydantic import Field
+
+from falcon_mcp.common.errors import _format_error_response
+from falcon_mcp.common.utils import unwrap_field_default
+from falcon_mcp.modules.base import BaseModule
+
+SORT_ORDERS = ("asc", "desc")
+
+
+def _build_score_filter(min_score: int | None, max_score: int | None) -> str:
+    """Build the FQL the query endpoint requires from typed score bounds."""
+    parts = []
+    if min_score is not None:
+        parts.append(f"score:>={min_score}")
+    if max_score is not None:
+        parts.append(f"score:<={max_score}")
+    # The endpoint rejects a missing filter, and score:>=0 matches every assessed host.
+    return "+".join(parts) if parts else "score:>=0"
+
+
+def _missing_aids(requested: list[str], records: list[dict[str, Any]]) -> list[str]:
+    """AIDs that came back with no assessment, preserving request order."""
+    found = {r.get("aid") for r in records}
+    return [aid for aid in requested if aid not in found]
+
+
+class ZeroTrustAssessmentModule(BaseModule):
+    """Module for Zero Trust Assessment operations."""
+
+    def register_tools(self, server: FastMCP) -> None:
+        """Register tools with the MCP server.
+
+        Args:
+            server: MCP server instance
+        """
+        self._add_tool(
+            server=server,
+            method=self.search_zta_assessments,
+            name="search_zta_assessments",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.get_zta_assessments,
+            name="get_zta_assessments",
+        )
+
+        self._add_tool(
+            server=server,
+            method=self.get_zta_audit,
+            name="get_zta_audit",
+        )
+
+    def search_zta_assessments(
+        self,
+        min_score: int | None = Field(
+            default=None,
+            ge=0,
+            le=100,
+            description="Lowest Zero Trust score to include (0-100). Omit for no lower bound.",
+        ),
+        max_score: int | None = Field(
+            default=None,
+            ge=0,
+            le=100,
+            description=(
+                "Highest Zero Trust score to include (0-100). Combine with `min_score` "
+                "to select a range."
+            ),
+        ),
+        limit: int = Field(
+            default=100,
+            ge=1,
+            le=1000,
+            description="Maximum number of hosts to return. (Max: 1000)",
+        ),
+        after: str | None = Field(
+            default=None,
+            description="Pagination token from a previous response's `pagination.next`.",
+        ),
+        sort_order: str = Field(
+            default="asc",
+            description="'asc' for weakest first, 'desc' for strongest first.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Search Zero Trust Assessment scores and return full assessment details.
+
+        Use this to rank hosts by security posture: pass `max_score` to list the weakest
+        hosts, `min_score` to list the strongest. Score is the only attribute this tool can
+        select on, so start from `falcon_get_zta_assessments` when you already have an agent
+        ID (AID) and from `falcon_search_hosts` when you have a hostname.
+        Returns each host's Zero Trust score with its full sensor and OS hardening signals,
+        in the standard pagination envelope; feed `pagination.next` back as `after`.
+
+        Results name hosts only by AID, so pair this with `falcon_search_hosts` to report
+        hostnames. Each record carries a long signal list, so raise `limit` deliberately.
+        """
+        # Resolve unset Pydantic Field defaults to avoid leaking FieldInfo objects (issue #384)
+        min_score = unwrap_field_default(min_score)
+        max_score = unwrap_field_default(max_score)
+        limit = unwrap_field_default(limit)
+        after = unwrap_field_default(after)
+        sort_order = unwrap_field_default(sort_order)
+
+        if sort_order not in SORT_ORDERS:
+            return _format_error_response(
+                f"Invalid sort_order '{sort_order}'. Valid values are: {', '.join(SORT_ORDERS)}."
+            )
+
+        if min_score is not None and max_score is not None and min_score > max_score:
+            return _format_error_response(
+                f"min_score ({min_score}) is greater than max_score ({max_score}), "
+                "so no host can match."
+            )
+
+        fql = _build_score_filter(min_score, max_score)
+
+        assessments, pagination = self._base_search_with_meta(
+            operation="getAssessmentsByScoreV1",
+            search_params={
+                "filter": fql,
+                "limit": limit,
+                "after": after,
+                "sort": f"score|{sort_order}",
+            },
+            error_message="Failed to search Zero Trust Assessment scores",
+        )
+
+        if self._is_error(assessments):
+            return [assessments]
+
+        # The query returns {aid, score} pairs rather than bare IDs.
+        aids = [aid for record in assessments if (aid := record.get("aid"))]
+
+        if not aids:
+            return self._build_pagination_envelope([], pagination, fql)
+
+        details = self._base_get_by_ids(
+            operation="getAssessmentV1",
+            ids=aids,
+            use_params=True,
+        )
+
+        if self._is_error(details):
+            return [details]
+
+        details = self._reorder_by_ids(aids, details, id_field="aid")
+        envelope = self._build_pagination_envelope(details, pagination, fql)
+
+        # A miss here means the host stopped being assessed between the two calls.
+        missing = _missing_aids(aids, details)
+        if missing:
+            envelope["not_found"] = missing
+
+        return envelope
+
+    def get_zta_assessments(
+        self,
+        ids: list[str] = Field(
+            min_length=1,
+            max_length=1000,
+            description="One or more agent IDs (AIDs), 1-1000. Lowercase hex, case-sensitive.",
+        ),
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Get Zero Trust Assessment details for specific hosts by agent ID (AID).
+
+        Use this when you already hold an AID: a detection reports one as its `device_id`, and
+        `falcon_search_hosts` resolves a hostname to one. No Zero Trust tool accepts a
+        hostname, so resolve the name with `falcon_search_hosts` first.
+        Returns `results` holding one record per assessed host — the Zero Trust score plus the
+        full sensor and OS hardening signals — and `not_found` listing the AIDs with no
+        assessment.
+
+        `not_found` is always present, even when empty, because the API reports an unknown or
+        never-assessed AID by omitting its record from an otherwise successful response.
+        """
+        # Resolve unset Pydantic Field defaults to avoid leaking FieldInfo objects (issue #384)
+        ids = unwrap_field_default(ids)
+
+        details = self._base_get_by_ids(
+            operation="getAssessmentV1",
+            ids=ids,
+            use_params=True,
+        )
+
+        if self._is_error(details):
+            return details
+
+        return {"results": details, "not_found": _missing_aids(ids, details)}
+
+    def get_zta_audit(self) -> list[dict[str, Any]] | dict[str, Any]:
+        """Get the tenant-wide Zero Trust Assessment summary.
+
+        Use this to answer how the whole tenant scores, rather than which hosts score badly —
+        it is a single CID-level rollup and carries no per-host data, so reach for
+        `falcon_search_zta_assessments` when you need individual hosts.
+        Returns one record with the assessed host count and average Zero Trust score for the
+        tenant, broken down by platform.
+        """
+        result = self._base_search_api_call(
+            operation="getAuditV1",
+            search_params={},
+            error_message="Failed to get the Zero Trust Assessment audit summary",
+        )
+
+        if self._is_error(result):
+            return [result]
+
+        return result

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -64,6 +64,10 @@ MODULE_METADATA: dict[str, dict[str, Any]] = {
     "shield": {
         "title": "Shield",
     },
+    "zerotrustassessment": {
+        "title": "Zero Trust Assessment",
+        "slug": "zero-trust-assessment",
+    },
 }
 
 # Natural language prompt examples for each tool, shown in generated docs
@@ -568,6 +572,19 @@ TOOL_EXAMPLES: dict[str, list[str]] = {
     ],
     "falcon_delete_rtr_session": [
         "End the RTR session abc123",
+    ],
+    # Zero Trust Assessment
+    "falcon_search_zta_assessments": [
+        "Which hosts have the weakest Zero Trust posture?",
+        "Show me hosts scoring below 40 on Zero Trust Assessment",
+    ],
+    "falcon_get_zta_assessments": [
+        "What is the security posture of host WEB-01?",
+        "Show the Zero Trust hardening signals for this agent ID",
+    ],
+    "falcon_get_zta_audit": [
+        "What is our overall Zero Trust score?",
+        "Break down our Zero Trust posture by platform",
     ],
 }
 

--- a/tests/integration/test_zero_trust_assessment.py
+++ b/tests/integration/test_zero_trust_assessment.py
@@ -1,0 +1,136 @@
+"""Integration tests for the Zero Trust Assessment module."""
+
+import pytest
+
+from falcon_mcp.modules.zero_trust_assessment import ZeroTrustAssessmentModule
+from tests.integration.utils.base_integration_test import BaseIntegrationTest
+
+# An AID is 32 lowercase hex characters; an all-zero one cannot belong to a real host.
+BOGUS_AID = "0" * 32
+
+
+@pytest.mark.integration
+class TestZeroTrustAssessmentIntegration(BaseIntegrationTest):
+    """Integration tests for Zero Trust Assessment with real API calls.
+
+    Validates:
+    - Correct FalconPy operation names (getAssessmentsByScoreV1, getAssessmentV1, getAuditV1)
+    - The score filter the search tool builds is accepted by the query endpoint
+    - The query's `score` matches `assessment.overall` in the hydrated record
+    - An unassessed AID is reported in `not_found` rather than silently dropped
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_module(self, falcon_client):
+        """Set up the Zero Trust Assessment module with a real client."""
+        self.module = ZeroTrustAssessmentModule(falcon_client)
+
+    def test_search_zta_assessments_returns_envelope(self):
+        """search_zta_assessments returns the pagination envelope with a real count.
+
+        Validates the getAssessmentsByScoreV1 and getAssessmentV1 operation names, and
+        that the locally built `score:<=50` filter is accepted.
+        """
+        result = self.call_method(self.module.search_zta_assessments, max_score=50)
+
+        self.assert_no_error(result, context="search_zta_assessments")
+        self.assert_valid_list_response(result, context="search_zta_assessments")
+
+        assert result["filter_used"] == "score:<=50"
+        assert result["pagination"]["total"] is not None, (
+            "Expected the query endpoint to report a total, got "
+            f"{result['pagination']}"
+        )
+
+    def test_search_zta_assessments_returns_full_details(self):
+        """The search tool hydrates the query's AIDs into full assessment records."""
+        result = self.call_method(self.module.search_zta_assessments, max_score=100, limit=5)
+
+        self.assert_no_error(result, context="search_zta_assessments details")
+
+        if not result["results"]:
+            self.skip_with_warning(
+                "No assessed hosts in this tenant", context="search_zta_assessments"
+            )
+
+        self.assert_search_returns_details(
+            result,
+            expected_fields=["aid", "cid", "assessment", "assessment_items"],
+            context="search_zta_assessments",
+        )
+
+    def test_query_score_matches_assessment_overall(self):
+        """The score the query reports equals `assessment.overall` in the detail record.
+
+        Chains the raw query into get_zta_assessments so both values are observable.
+        """
+        query = self.module.client.command(
+            "getAssessmentsByScoreV1",
+            parameters={"filter": "score:>=0", "limit": 5, "sort": "score|asc"},
+        )
+        scores_by_aid = {
+            record["aid"]: record["score"]
+            for record in query.get("body", {}).get("resources", [])
+        }
+
+        if not scores_by_aid:
+            self.skip_with_warning(
+                "No assessed hosts in this tenant", context="query_score_matches"
+            )
+
+        result = self.call_method(
+            self.module.get_zta_assessments, ids=list(scores_by_aid)
+        )
+
+        self.assert_no_error(result, context="get_zta_assessments")
+        assert result["not_found"] == [], (
+            f"AIDs the query just returned should still resolve: {result['not_found']}"
+        )
+
+        for record in result["results"]:
+            assert record["assessment"]["overall"] == scores_by_aid[record["aid"]], (
+                f"Score mismatch for {record['aid']}: query reported "
+                f"{scores_by_aid[record['aid']]}, detail reported "
+                f"{record['assessment']['overall']}"
+            )
+
+    def test_get_zta_assessments_reports_unassessed_aid(self):
+        """An AID with no assessment comes back in `not_found`, not as an error.
+
+        The API answers an unknown AID with a success status and simply omits the
+        record, so this proves the miss is surfaced.
+        """
+        result = self.call_method(self.module.get_zta_assessments, ids=[BOGUS_AID])
+
+        self.assert_no_error(result, context="get_zta_assessments bogus AID")
+        assert result["results"] == []
+        assert result["not_found"] == [BOGUS_AID]
+
+    def test_get_zta_audit_returns_tenant_summary(self):
+        """get_zta_audit returns one CID-level rollup.
+
+        Validates the getAuditV1 operation name.
+        """
+        result = self.call_method(self.module.get_zta_audit)
+
+        self.assert_no_error(result, context="get_zta_audit")
+        self.assert_valid_list_response(result, min_length=1, context="get_zta_audit")
+
+        summary = result[0]
+        for field in ("num_aids", "average_overall_score", "platforms"):
+            assert field in summary, (
+                f"Expected '{field}' in the audit summary. "
+                f"Available fields: {list(summary.keys())}"
+            )
+
+    def test_search_rejects_inverted_bounds_without_calling_the_api(self):
+        """Inverted score bounds are refused locally, so the API is never asked."""
+        result = self.call_method(
+            self.module.search_zta_assessments, min_score=80, max_score=20
+        )
+
+        assert "error" in result
+        assert "details" not in result, (
+            "An inverted-bounds rejection must be local, but the response carries "
+            "API details"
+        )

--- a/tests/modules/test_zero_trust_assessment.py
+++ b/tests/modules/test_zero_trust_assessment.py
@@ -1,0 +1,414 @@
+"""
+Tests for the Zero Trust Assessment module.
+"""
+
+import inspect
+import unittest
+from typing import Any
+
+from pydantic.fields import FieldInfo
+
+from falcon_mcp.modules.zero_trust_assessment import (
+    ZeroTrustAssessmentModule,
+    _build_score_filter,
+)
+from tests.modules.utils.test_modules import TestModules
+
+QUERY_OP = "getAssessmentsByScoreV1"
+ENTITY_OP = "getAssessmentV1"
+AUDIT_OP = "getAuditV1"
+
+
+def _query_response(aids_and_scores, pagination=None):
+    """Build a getAssessmentsByScoreV1 response with {aid, score} resources."""
+    body: dict[str, Any] = {
+        "resources": [{"aid": aid, "score": score} for aid, score in aids_and_scores]
+    }
+    if pagination is not None:
+        body["meta"] = {"pagination": pagination}
+    return {"status_code": 200, "body": body}
+
+
+def _entity_response(aids_and_scores):
+    """Build a getAssessmentV1 response with full assessment records."""
+    return {
+        "status_code": 200,
+        "body": {
+            "resources": [
+                {
+                    "aid": aid,
+                    "cid": "cid1",
+                    "event_platform": "Win",
+                    "assessment": {"overall": score, "os": score, "sensor_config": score},
+                    "assessment_items": {"os_signals": [], "sensor_signals": []},
+                }
+                for aid, score in aids_and_scores
+            ]
+        },
+    }
+
+
+class TestZeroTrustAssessmentModule(TestModules):
+    """Test cases for the Zero Trust Assessment module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.setup_module(ZeroTrustAssessmentModule)
+
+    def test_register_tools(self):
+        """Test registering tools with the server."""
+        expected_tools = [
+            "falcon_search_zta_assessments",
+            "falcon_get_zta_assessments",
+            "falcon_get_zta_audit",
+        ]
+        self.assert_tools_registered(expected_tools)
+
+    # ---- Filter construction ------------------------------------------------------
+
+    def test_build_score_filter_both_bounds(self):
+        """Both bounds are joined with the AND operator."""
+        self.assertEqual(_build_score_filter(20, 60), "score:>=20+score:<=60")
+
+    def test_build_score_filter_min_only(self):
+        """A min bound alone produces a single clause."""
+        self.assertEqual(_build_score_filter(20, None), "score:>=20")
+
+    def test_build_score_filter_max_only(self):
+        """A max bound alone produces a single clause."""
+        self.assertEqual(_build_score_filter(None, 60), "score:<=60")
+
+    def test_build_score_filter_no_bounds(self):
+        """No bounds falls back to the match-everything filter the API requires."""
+        self.assertEqual(_build_score_filter(None, None), "score:>=0")
+
+    def test_build_score_filter_equal_bounds(self):
+        """Equal bounds select an exact score without being rejected."""
+        self.assertEqual(_build_score_filter(50, 50), "score:>=50+score:<=50")
+
+    def test_search_sends_built_filter_and_reports_it(self):
+        """The built FQL reaches the API and comes back as filter_used."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 30)]),
+            _entity_response([("aid1", 30)]),
+        ]
+
+        result = self.module.search_zta_assessments(min_score=10, max_score=40)
+
+        query_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(query_call[0][0], QUERY_OP)
+        self.assertEqual(
+            query_call[1]["parameters"]["filter"], "score:>=10+score:<=40"
+        )
+        self.assertEqual(result["filter_used"], "score:>=10+score:<=40")
+
+    def test_search_without_bounds_sends_default_filter(self):
+        """Omitting both bounds still sends a filter, because the API demands one."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 30)]),
+            _entity_response([("aid1", 30)]),
+        ]
+
+        result = self.module.search_zta_assessments()
+
+        query_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(query_call[1]["parameters"]["filter"], "score:>=0")
+        self.assertEqual(result["filter_used"], "score:>=0")
+
+    # ---- Sort and bound validation ------------------------------------------------
+
+    def test_search_sort_order_asc(self):
+        """sort_order 'asc' maps to the pipe-separated sort the API accepts."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 30)]),
+            _entity_response([("aid1", 30)]),
+        ]
+
+        self.module.search_zta_assessments(sort_order="asc")
+
+        query_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(query_call[1]["parameters"]["sort"], "score|asc")
+
+    def test_search_sort_order_desc(self):
+        """sort_order 'desc' maps to the pipe-separated sort the API accepts."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 90)]),
+            _entity_response([("aid1", 90)]),
+        ]
+
+        self.module.search_zta_assessments(sort_order="desc")
+
+        query_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(query_call[1]["parameters"]["sort"], "score|desc")
+
+    def test_search_invalid_sort_order_is_rejected_locally(self):
+        """An unsupported sort_order is refused without spending an API call."""
+        result = self.module.search_zta_assessments(sort_order="score.asc")
+
+        self.assertIn("error", result)
+        self.assertIn("score.asc", result["error"])
+        self.mock_client.command.assert_not_called()
+
+    def test_search_inverted_bounds_are_rejected_locally(self):
+        """min_score above max_score is refused instead of returning zero rows."""
+        result = self.module.search_zta_assessments(min_score=80, max_score=20)
+
+        self.assertIn("error", result)
+        self.mock_client.command.assert_not_called()
+
+    def test_search_declares_asc_as_the_default_sort_order(self):
+        """The weakest-first default is declared on the signature."""
+        declared = inspect.signature(
+            self.module.search_zta_assessments
+        ).parameters["sort_order"].default
+
+        self.assertEqual(declared.default, "asc")
+
+    def test_search_zero_arg_call_resolves_field_defaults(self):
+        """A call with no arguments uses the real defaults and leaks no FieldInfo (issue #384)."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 30)]),
+            _entity_response([("aid1", 30)]),
+        ]
+
+        result = self.module.search_zta_assessments()
+
+        query_params = self.mock_client.command.call_args_list[0][1]["parameters"]
+        self.assertEqual(query_params["sort"], "score|asc")
+        self.assertEqual(query_params["limit"], 100)
+        # An unresolved `after` FieldInfo would survive prepare_api_parameters' None filter.
+        self.assertNotIn("after", query_params)
+
+        def assert_no_fieldinfo(obj):
+            if isinstance(obj, dict):
+                for value in obj.values():
+                    assert_no_fieldinfo(value)
+            elif isinstance(obj, list):
+                for value in obj:
+                    assert_no_fieldinfo(value)
+            else:
+                self.assertNotIsInstance(obj, FieldInfo)
+
+        assert_no_fieldinfo(result)
+        assert_no_fieldinfo(query_params)
+
+    # ---- Pagination and two-step wiring -------------------------------------------
+
+    def test_search_surfaces_pagination_cursor_as_next(self):
+        """The API's `after` cursor is surfaced as `pagination.next`."""
+        self.mock_client.command.side_effect = [
+            _query_response(
+                [("aid1", 30)],
+                pagination={"limit": 100, "total": 18958, "after": "cursor-abc"},
+            ),
+            _entity_response([("aid1", 30)]),
+        ]
+
+        result = self.module.search_zta_assessments()
+
+        self.assert_pagination(result, 18958, has_next=True)
+        self.assertEqual(result["pagination"]["next"], "cursor-abc")
+
+    def test_search_forwards_after_token(self):
+        """A supplied `after` token is passed through to the query endpoint."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 30)]),
+            _entity_response([("aid1", 30)]),
+        ]
+
+        self.module.search_zta_assessments(after="cursor-abc")
+
+        query_call = self.mock_client.command.call_args_list[0]
+        self.assertEqual(query_call[1]["parameters"]["after"], "cursor-abc")
+
+    def test_search_hydrates_query_aids(self):
+        """Both operations are called, and hydration receives the query's AIDs."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 10), ("aid2", 20)]),
+            _entity_response([("aid1", 10), ("aid2", 20)]),
+        ]
+
+        result = self.module.search_zta_assessments()
+
+        operations = [call[0][0] for call in self.mock_client.command.call_args_list]
+        self.assertEqual(operations, [QUERY_OP, ENTITY_OP])
+
+        entity_call = self.mock_client.command.call_args_list[1]
+        self.assertEqual(entity_call[1]["parameters"]["ids"], ["aid1", "aid2"])
+
+        # Full details, not the {aid, score} pairs from the query step.
+        self.assertEqual(len(result["results"]), 2)
+        self.assertIn("assessment_items", result["results"][0])
+
+    def test_search_restores_query_sort_order(self):
+        """Hydrated records are reordered to match the query's sort."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 10), ("aid2", 20), ("aid3", 30)]),
+            # The entity endpoint answers out of order.
+            _entity_response([("aid3", 30), ("aid1", 10), ("aid2", 20)]),
+        ]
+
+        result = self.module.search_zta_assessments()
+
+        self.assertEqual(
+            [record["aid"] for record in result["results"]], ["aid1", "aid2", "aid3"]
+        )
+
+    def test_search_empty_result_returns_envelope(self):
+        """An empty query returns the envelope and skips the entity endpoint."""
+        self.mock_client.command.return_value = _query_response(
+            [], pagination={"limit": 100, "total": 0}
+        )
+
+        result = self.module.search_zta_assessments(max_score=1)
+
+        self.assertEqual(result["results"], [])
+        self.assert_pagination(result, 0)
+        self.assertEqual(result["filter_used"], "score:<=1")
+        self.mock_client.command.assert_called_once()
+
+    def test_search_omits_not_found_when_all_aids_resolve(self):
+        """`not_found` stays absent from the search envelope when nothing is missing."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 30)]),
+            _entity_response([("aid1", 30)]),
+        ]
+
+        result = self.module.search_zta_assessments()
+
+        self.assertNotIn("not_found", result)
+
+    def test_search_reports_aid_that_vanished_between_calls(self):
+        """An AID the entity step drops is reported rather than silently lost."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 30), ("aid2", 40)]),
+            _entity_response([("aid1", 30)]),
+        ]
+
+        result = self.module.search_zta_assessments()
+
+        self.assertEqual(result["not_found"], ["aid2"])
+        self.assertEqual(len(result["results"]), 1)
+
+    def test_search_query_error_is_wrapped_in_a_list(self):
+        """A failed query is returned as a single-item list, not an envelope."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "missing filter expression"}]},
+        }
+
+        result = self.module.search_zta_assessments()
+
+        self.assertIn("error", result[0])
+        self.assertTrue(
+            result[0]["error"].startswith("Failed to search Zero Trust Assessment scores")
+        )
+
+    def test_search_hydration_error_is_wrapped_in_a_list(self):
+        """A failed hydration step is returned as a single-item list."""
+        self.mock_client.command.side_effect = [
+            _query_response([("aid1", 30)]),
+            {"status_code": 403, "body": {"errors": [{"message": "access denied"}]}},
+        ]
+
+        result = self.module.search_zta_assessments()
+
+        self.assertIn("error", result[0])
+
+    # ---- get_zta_assessments ------------------------------------------------------
+
+    def test_get_assessments_returns_results_and_empty_not_found(self):
+        """`not_found` is present even when every requested AID resolved."""
+        self.mock_client.command.return_value = _entity_response([("aid1", 30)])
+
+        result = self.module.get_zta_assessments(ids=["aid1"])
+
+        self.mock_client.command.assert_called_once_with(
+            ENTITY_OP, parameters={"ids": ["aid1"]}
+        )
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["not_found"], [])
+
+    def test_get_assessments_reports_unassessed_aids(self):
+        """An AID the API omits from a 200 response lands in `not_found`."""
+        self.mock_client.command.return_value = _entity_response([("aid1", 30)])
+
+        result = self.module.get_zta_assessments(ids=["aid1", "aid-unknown"])
+
+        self.assertEqual(result["not_found"], ["aid-unknown"])
+        self.assertEqual(len(result["results"]), 1)
+
+    def test_get_assessments_not_found_preserves_request_order(self):
+        """Missing AIDs are reported in the order they were requested."""
+        self.mock_client.command.return_value = _entity_response([("aid2", 30)])
+
+        result = self.module.get_zta_assessments(ids=["aid1", "aid2", "aid3"])
+
+        self.assertEqual(result["not_found"], ["aid1", "aid3"])
+
+    def test_get_assessments_error_is_returned_unchanged(self):
+        """A failed lookup returns the error dict, not an envelope."""
+        self.mock_client.command.return_value = {
+            "status_code": 400,
+            "body": {"errors": [{"message": "Max number of AIDs allowed is 1000"}]},
+        }
+
+        result = self.module.get_zta_assessments(ids=["aid1"])
+
+        self.assertIn("error", result)
+        self.assertNotIn("results", result)
+
+    def test_get_assessments_declares_the_api_id_bounds(self):
+        """The 1-1000 AID range the endpoint enforces is declared on the parameter."""
+        declared = inspect.signature(
+            self.module.get_zta_assessments
+        ).parameters["ids"].default
+
+        constraints = {type(m).__name__: m for m in declared.metadata}
+        self.assertEqual(constraints["MinLen"].min_length, 1)
+        self.assertEqual(constraints["MaxLen"].max_length, 1000)
+
+    # ---- get_zta_audit ------------------------------------------------------------
+
+    def test_get_audit_returns_one_record(self):
+        """The audit endpoint returns a single CID-level rollup."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {
+                "resources": [
+                    {
+                        "cid": "cid1",
+                        "num_aids": 18958,
+                        "average_overall_score": 61.5,
+                        "platforms": [{"name": "Windows", "num_aids": 900}],
+                    }
+                ]
+            },
+        }
+
+        result = self.module.get_zta_audit()
+
+        self.mock_client.command.assert_called_once_with(AUDIT_OP, parameters={})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["num_aids"], 18958)
+        self.assertIn("platforms", result[0])
+
+    def test_get_audit_error_is_wrapped_in_a_list(self):
+        """A failed audit call is returned as a single-item list."""
+        self.mock_client.command.return_value = {
+            "status_code": 403,
+            "body": {"errors": [{"message": "access denied"}]},
+        }
+
+        result = self.module.get_zta_audit()
+
+        self.assertIn("error", result[0])
+        self.assertTrue(
+            result[0]["error"].startswith(
+                "Failed to get the Zero Trust Assessment audit summary"
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #498 asked for host security posture data so an agent can weigh a detection against the hardening state of the host it fired on. Nothing we ship returned that, so this adds a Zero Trust Assessment module: `falcon_search_zta_assessments` ranks hosts by score, `falcon_get_zta_assessments` looks up specific agent IDs, and `falcon_get_zta_audit` gives the tenant-wide rollup. All read-only.

It's a separate module rather than tools inside hosts because the scope differs (`Zero Trust Assessment:read` vs `Hosts:read`), and the audit rollup has no AID in it anyway.

The query endpoint only filters on `score`, not `aid`, so the search tool takes `min_score`/`max_score` bounds and builds the FQL itself instead of exposing a `filter` param. The entity endpoint has a worse habit: give it an agent ID it doesn't know and you get a 200 back with the record simply missing. Both lookup tools report those as `not_found` rather than quietly returning fewer records than you asked for.

Worth knowing when you use these: the records carry no hostname, only agent IDs, so the descriptions point at `falcon_search_hosts` to put names on them.

Closes #498.
