### PR TITLE
fix(modules/ngsiem): reject repository values that break path construction

### DIFF
--- a/falcon_mcp/modules/ngsiem.py
+++ b/falcon_mcp/modules/ngsiem.py
@@ -47,6 +47,54 @@ _CQL_UNSCANNED_ZERO_HINT = (
 POLL_INTERVAL_SECONDS = int(os.environ.get("FALCON_MCP_NGSIEM_POLL_INTERVAL", "5"))
 TIMEOUT_SECONDS = int(os.environ.get("FALCON_MCP_NGSIEM_TIMEOUT", "300"))
 
+# `repository` is the only caller-supplied value in this server that reaches a URL
+# path variable (/humio/api/v1/repositories/{repository}/queryjobs). FalconPy
+# interpolates it into the route and `requests` normalizes the path before sending,
+# so a separator or a bare dot-segment retargets the request at a route the calling
+# operation never selected. A separator is what makes traversal possible, so once
+# those are rejected only a whole-value dot-segment can still alter the path —
+# `a..b` is inert and stays allowed.
+_UNSAFE_REPOSITORY_CHARS = ("/", "\\", "%")
+_DOT_SEGMENTS = (".", "..")
+
+
+def _validate_repository(repository: Any) -> dict[str, Any] | None:
+    """Reject a repository value that would change which route is called.
+
+    Returns an error response to hand straight back to the caller, or None when the
+    value is safe to interpolate.
+
+    A non-str value is an unresolved Pydantic `Field` default, which happens only when
+    the tool method is called directly instead of through FastMCP — the same reason
+    `end` is guarded with `isinstance` below. FastMCP validates against the `str`
+    annotation before dispatch, and the declared default is safe, so let it through.
+
+    Args:
+        repository: The caller-supplied repository or view name
+
+    Returns:
+        An error response dict, or None if the value is acceptable
+    """
+    if not isinstance(repository, str):
+        return None
+
+    if not repository.strip():
+        return _format_error_response(
+            "Invalid repository: must be a non-empty repository or view name, "
+            "for example 'search-all'.",
+            operation="StartSearchV1",
+        )
+
+    if any(char in repository for char in _UNSAFE_REPOSITORY_CHARS) or repository in _DOT_SEGMENTS:
+        return _format_error_response(
+            f"Invalid repository {repository!r}: must not contain '/', '\\', or '%', "
+            "or be '.' or '..'. Pass a plain repository or view name, "
+            "for example 'search-all'.",
+            operation="StartSearchV1",
+        )
+
+    return None
+
 
 def _iso_to_epoch_ms(iso_timestamp: str) -> int:
     """Convert ISO 8601 timestamp to Unix epoch milliseconds.
@@ -256,7 +304,8 @@ class NGSIEMModule(BaseModule):
                 "third-party (third-party source events), "
                 "falcon_for_it_view (Falcon for IT data), "
                 "forensics_view (Falcon Forensics triage data). "
-                "Custom and other built-in repositories/views can also be passed by name."
+                "Custom and other built-in repositories/views can also be passed by name. "
+                "Pass the bare name only: values containing '/', '\\', or '%' are rejected."
             ),
         ),
         end: str | None = Field(
@@ -286,6 +335,12 @@ class NGSIEMModule(BaseModule):
         scanned events (a real negative) or scanned none (unresolved). Search times out
         after FALCON_MCP_NGSIEM_TIMEOUT seconds (default: 300).
         """
+        # `repository` is interpolated into the request path, so validate it before it
+        # can reach any of the three calls below.
+        repository_error = _validate_repository(repository)
+        if repository_error is not None:
+            return repository_error
+
         # Step 1: Start the search job
         # Note: FalconPy uber class passes body unchanged; API expects camelCase keys
         body_params: dict[str, Any] = {

--- a/tests/integration/test_agentworks.py
+++ b/tests/integration/test_agentworks.py
@@ -1,0 +1,159 @@
+"""Integration tests for the AgentWorks module."""
+
+import pytest
+
+from falcon_mcp.modules.agentworks import AgentworksModule
+from tests.integration.utils.base_integration_test import BaseIntegrationTest
+
+
+@pytest.mark.integration
+class TestAgentWorksIntegration(BaseIntegrationTest):
+    """Integration tests for the AgentWorks module with real API calls.
+
+    Validates:
+    - Correct agentic-studio routes and operation names for every read tool
+    - Two-step search pattern returns full details, not just IDs
+    - The pagination envelope shape search tools promise
+
+    This file is the baseline for the planned migration off FalconPy's
+    `override="METHOD,/route"` escape hatch onto named operations. Every read tool
+    here must stay green across that change; a wrong operation name is invisible to
+    the mocked unit tests and surfaces only against the live API.
+
+    Two tools are deliberately NOT covered, so the migration must validate them by hand:
+
+    - `invoke_agentworks_agent` really runs an agent and consumes account credits, so
+      it does not belong in a suite meant to run repeatedly.
+    - `get_agentworks_agent_invocation` (GetAgentInvocationV3) needs an invocation ID,
+      and there is no read-only way to obtain one that resolves. Spans expose
+      `attributes["aiplatform_agent.invocation_id"]`, but those belong to a different
+      ID space — every one tested returned 404 from this endpoint, including invocations
+      only minutes old. The only source of a usable ID is invoking an agent.
+
+    Both are recorded gaps rather than always-skipping tests: a test that can only skip
+    looks like coverage while being unable to catch a regression.
+
+    Requires an AgentWorks-enabled tenant with the charlotte-ai-agent-definition:read
+    scope. Tests skip gracefully when the tenant has no agents, versions, or spans.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_module(self, falcon_client):
+        """Set up the AgentWorks module with a real client."""
+        self.module = AgentworksModule(falcon_client)
+
+    # ------------------------------------------------------------------
+    # Agents — QueryAgentsV2 / GetAgentsV2
+    # ------------------------------------------------------------------
+
+    def test_search_agents_operation_names(self):
+        """Validate the QueryAgentsV2 and GetAgentsV2 routes against the live API."""
+        result = self.call_method(self.module.search_agentworks_agents, limit=1)
+        self.assert_no_error(result, context="QueryAgentsV2 / GetAgentsV2 validation")
+
+    def test_search_agents_returns_full_details(self):
+        """Search must return whole agent records, not just the IDs it queried."""
+        result = self.call_method(self.module.search_agentworks_agents, limit=3)
+        self.assert_no_error(result, context="search_agentworks_agents")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_agentworks_agents"
+        )
+
+        agents = self._unwrap_results(result)
+        if not agents:
+            self.skip_with_warning(
+                "No AgentWorks agents in this tenant",
+                context="search_agentworks_agents full details",
+            )
+            return
+
+        assert len(agents[0]) > 1, f"Expected full agent detail, got only {list(agents[0])}"
+
+    # ------------------------------------------------------------------
+    # Agent versions — QueryAgentVersionsV1 / GetAgentVersionsV1
+    # ------------------------------------------------------------------
+
+    def test_search_agent_versions_operation_names(self):
+        """Validate QueryAgentVersionsV1 and GetAgentVersionsV1 against the live API."""
+        result = self.call_method(self.module.search_agentworks_agent_versions, limit=1)
+        self.assert_no_error(
+            result, context="QueryAgentVersionsV1 / GetAgentVersionsV1 validation"
+        )
+
+    def test_search_agent_versions_returns_full_details(self):
+        """Version search must hydrate to whole records."""
+        result = self.call_method(self.module.search_agentworks_agent_versions, limit=3)
+        self.assert_no_error(result, context="search_agentworks_agent_versions")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_agentworks_agent_versions"
+        )
+
+        versions = self._unwrap_results(result)
+        if not versions:
+            self.skip_with_warning(
+                "No AgentWorks agent versions in this tenant",
+                context="search_agentworks_agent_versions full details",
+            )
+            return
+
+        assert len(versions[0]) > 1, (
+            f"Expected full version detail, got only {list(versions[0])}"
+        )
+
+    def test_search_agent_versions_accepts_documented_filter(self):
+        """`agent_id` is the documented way to scope versions to one agent.
+
+        Discovering the agent through the agents tool rather than through a versions
+        filter keeps this from skipping silently if version filtering regresses.
+        """
+        agents = self._unwrap_results(
+            self.call_method(self.module.search_agentworks_agents, limit=1)
+        )
+        if not agents:
+            self.skip_with_warning(
+                "No AgentWorks agents in this tenant",
+                context="search_agentworks_agent_versions filter",
+            )
+            return
+
+        agent_id = agents[0].get("id")
+        assert agent_id, f"Agent record carried no id: {list(agents[0])}"
+
+        result = self.call_method(
+            self.module.search_agentworks_agent_versions,
+            filter=f"agent_id:'{agent_id}'",
+            limit=5,
+        )
+        self.assert_no_error(result, context="search_agentworks_agent_versions filter")
+
+    # ------------------------------------------------------------------
+    # Spans — QueriesSpansV1 / EntitiesSpansV1
+    # ------------------------------------------------------------------
+
+    def test_search_spans_operation_names(self):
+        """Validate QueriesSpansV1 and EntitiesSpansV1 against the live API."""
+        result = self.call_method(self.module.search_agentworks_spans, limit=1)
+        self.assert_no_error(result, context="QueriesSpansV1 / EntitiesSpansV1 validation")
+
+    def test_search_spans_returns_full_details(self):
+        """Span search must hydrate to whole records."""
+        result = self.call_method(self.module.search_agentworks_spans, limit=3)
+        self.assert_no_error(result, context="search_agentworks_spans")
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_agentworks_spans"
+        )
+
+        spans = self._unwrap_results(result)
+        if not spans:
+            self.skip_with_warning(
+                "No AgentWorks spans in this tenant",
+                context="search_agentworks_spans full details",
+            )
+            return
+
+        assert len(spans[0]) > 1, f"Expected full span detail, got only {list(spans[0])}"
+
+    # ------------------------------------------------------------------
+    # Get invocation — GetAgentInvocationV3 — NOT COVERED, see class docstring
+    # ------------------------------------------------------------------
+

--- a/tests/modules/test_ngsiem.py
+++ b/tests/modules/test_ngsiem.py
@@ -648,6 +648,107 @@ class TestNGSIEMModule(TestModules):
         self.assertIsInstance(empty["results"], list)
         self.assertEqual(sorted(populated["job"]), sorted(empty["job"]))
 
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_repository_that_would_alter_the_request_path_is_rejected(self, mock_sleep):
+        """`repository` reaches a URL path variable, so it must not carry path syntax.
+
+        FalconPy interpolates path variables into the route, and `requests` then
+        normalizes the path before sending it. An unencoded separator or dot-segment
+        therefore retargets the request: `a/../../oauth2/token` builds
+        `/humio/api/v1/repositories/a/../../oauth2/token/queryjobs`, which normalizes
+        to `/humio/api/v1/oauth2/token/queryjobs` — a different route than
+        StartSearchV1 selected. Reject before any call rather than relying on the SDK.
+
+        The client is wired to succeed, so without the guard this reports a clean
+        search result and the assertions fail on that, not on a mock error.
+        """
+        for repository in (
+            "a/../../oauth2/token",
+            "search-all/queryjobs",
+            "..",
+            "../search-all",
+            "search\\all",
+            "search%2Fall",
+        ):
+            with self.subTest(repository=repository):
+                self.mock_client.command.reset_mock()
+                self.mock_client.command.side_effect = [
+                    {"status_code": 200, "body": {"id": "job-should-not-run"}},
+                    {"status_code": 200, "body": {"done": True, "events": []}},
+                ]
+
+                result = asyncio.run(
+                    self.module.search_ngsiem(
+                        query_string="aid=abc123",
+                        start="2025-01-01T00:00:00Z",
+                        repository=repository,
+                    )
+                )
+
+                self.assertIn("error", result)
+                self.assertIn("repository", result["error"])
+                # The guard is worthless if the request still goes out.
+                self.assertEqual(self.mock_client.command.call_count, 0)
+
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_repository_rejection_does_not_offer_the_cql_guide(self, mock_sleep):
+        """A bad `repository` is not a CQL mistake, so it must not ship the CQL guide.
+
+        Every other error path here routes through `_format_cql_error_response`, which
+        attaches the full guide and tells the model to correct its query. Doing that
+        for an argument error would send the model to rewrite a query that was fine.
+        """
+        self.mock_client.command.side_effect = [
+            {"status_code": 200, "body": {"id": "job-should-not-run"}},
+            {"status_code": 200, "body": {"done": True, "events": []}},
+        ]
+
+        result = asyncio.run(
+            self.module.search_ngsiem(
+                query_string="aid=abc123",
+                start="2025-01-01T00:00:00Z",
+                repository="a/../../oauth2/token",
+            )
+        )
+
+        self.assertIn("error", result)
+        self.assertNotIn("cql_guide", result)
+        self.assertNotIn("hint", result)
+
+    @patch("falcon_mcp.modules.ngsiem.asyncio.sleep", new_callable=AsyncMock)
+    def test_documented_repository_names_still_pass_the_guard(self, mock_sleep):
+        """The guard must not reject the repositories the tool advertises.
+
+        The field description names these and says custom views may also be passed,
+        so an over-strict rule would break normal use. This is the counterweight to
+        the rejection test above.
+        """
+        for repository in (
+            "search-all",
+            "investigate_view",
+            "xdr",
+            "third-party",
+            "falcon_for_it_view",
+            "forensics_view",
+        ):
+            with self.subTest(repository=repository):
+                self.mock_client.command.reset_mock()
+                self.mock_client.command.side_effect = [
+                    {"status_code": 200, "body": {"id": "job-ok"}},
+                    {"status_code": 200, "body": {"done": True, "events": []}},
+                ]
+
+                result = asyncio.run(
+                    self.module.search_ngsiem(
+                        query_string="aid=abc123",
+                        start="2025-01-01T00:00:00Z",
+                        repository=repository,
+                    )
+                )
+
+                self.assertNotIn("error", result)
+                self.assertEqual(self.mock_client.command.call_count, 2)
+
 
 class TestNGSIEMModuleConfig(unittest.TestCase):
     """Test configuration handling for NGSIEM module."""


### PR DESCRIPTION
The `repository` argument on `falcon_search_ngsiem` is the only caller-supplied value we pass into a URL path variable. FalconPy drops it straight into the route, and `requests` normalizes the path before it goes out, so a value with a separator or a dot-segment in it can land on a completely different endpoint. `a/../../oauth2/token` normalizes down to `/humio/api/v1/oauth2/token/queryjobs`. All three operations behind the tool take the same argument, so all three are affected.

So this rejects `/`, `\`, `%`, and a bare `.` or `..` before any of the calls go out. The separator is the part that makes traversal work, and without one you can't climb out of the segment, so a name like `a..b` is harmless and still allowed. I used a deny-list rather than a pattern for valid names because the field tells callers they can pass their own view names, and I couldn't pin down what characters those are actually allowed to contain.

The error goes back in the plain shape rather than through the CQL helper the rest of the module uses. That helper bolts the whole CQL guide onto the response and tells the model to correct its query, which would be actively misleading here when the query was fine.

The second commit adds integration coverage for the AgentWorks read tools, which didn't have any. I left two of its tools uncovered on purpose rather than write tests that can only skip: invoking an agent costs credits, and there's no read-only way I could find to get an invocation ID that the get-invocation endpoint will accept. Both are written down in the test class so nobody assumes they're covered.

Newer FalconPy fixes this in the SDK itself, which is worth doing on its own. This holds either way.
