### PR TITLE
chore(test): remove vestigial tools/list payload budget warning

### DIFF
--- a/tests/test_tools_list_output_schema.py
+++ b/tests/test_tools_list_output_schema.py
@@ -6,7 +6,6 @@ clients (VS Code Copilot) to silently drop tools.
 """
 
 import unittest
-import warnings
 from unittest.mock import MagicMock, patch
 
 from mcp.shared.memory import create_connected_server_and_client_session
@@ -65,29 +64,6 @@ class TestToolsListOutputSchema(unittest.IsolatedAsyncioTestCase):
             "Tools missing inputSchema (regression of issue #325 fix):\n"
             + "\n".join(f"  - {name}" for name in sorted(missing)),
         )
-
-    async def test_tools_list_payload_within_budget(self):
-        """Warn if tools/list payload exceeds client context budgets.
-
-        This is a soft check — new modules naturally grow the payload.
-        Use --modules to limit tools for context-constrained clients.
-        """
-        async with create_connected_server_and_client_session(
-            self.mcp_server.server
-        ) as session:
-            tools = (await session.list_tools()).tools
-
-        total = sum(
-            len(t.model_dump_json(by_alias=True, exclude_none=True))
-            for t in tools
-        )
-        budget = 120_000
-        if total >= budget:
-            warnings.warn(
-                f"tools/list payload is {total:,} bytes, exceeding {budget:,} byte budget. "
-                f"Consider using --modules to limit enabled modules for constrained clients.",
-                stacklevel=1,
-            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
test_tools_list_payload_within_budget never asserted anything. The whole body was one
warnings.warn call, and there's no error entry in our filterwarnings config, so the
branch did nothing. The default catalogue serializes to 242,972 bytes against a 120,000
byte threshold right now and the test still passes.

The message it printed told contributors to use --modules, which is an operator
deployment choice, not something you can change in a PR. So it fired on every test run
with nothing to do about it, and people learned to skim past warnings.

The invariant #325 was really about is asserted directly now. structured_output=False is
set at all six registration points, including the shared _add_tool, and
test_every_tool_omits_output_schema fails loudly if any of them regresses. I checked that
by flipping base.py back to True, and it does. Dynamic mode also gives constrained
clients a real path at 4,172 bytes, so capping the default configuration was measuring
the one operators already control.

I did look at the two alternatives before deleting. A ratchet's useful firing threshold
lands inside the range a single legitimate new module already occupies, so it can't tell
bloat from ordinary growth without someone editing a baseline on every module PR. The
description limit is a bigger miss: parameter schemas are about two thirds of the
payload and descriptions about a quarter, so it would be a style guard sold as a payload
fix, and 70 of the 141 current tools would fail it on day one.

Both hard assertions in the file are untouched. Closes #546.
