### PR TITLE
fix(tests): read search results through the pagination envelope

### DIFF
--- a/tests/integration/cloud/test_cloud_assets.py
+++ b/tests/integration/cloud/test_cloud_assets.py
@@ -88,11 +88,7 @@ class TestCloudAssetsIntegration(BaseIntegrationTest):
             limit=10,
         )
         self.assert_no_error(result, context="search_cspm_assets with tag filter")
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_cspm_assets with tag filter")
-        else:
-            assert isinstance(result, dict), "Expected dict or list response for tag filter"
-            assert "results" in result or "total" in result
+        self.assert_valid_list_response(result, min_length=0, context="search_cspm_assets with tag filter")
 
     def test_search_cspm_assets_with_sort(self):
         result = self.call_method(

--- a/tests/integration/cloud/test_cloud_iom.py
+++ b/tests/integration/cloud/test_cloud_iom.py
@@ -34,10 +34,7 @@ class TestCloudIomIntegration(BaseIntegrationTest):
             filter="severity:'critical'",
             limit=3,
         )
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_iom_findings severity filter")
-        else:
-            assert isinstance(result, dict), "Expected dict or list response"
+        self.assert_valid_list_response(result, min_length=0, context="search_iom_findings severity filter")
 
     def test_search_iom_findings_with_cloud_provider_filter(self):
         result = self.call_method(

--- a/tests/integration/test_correlation_rules.py
+++ b/tests/integration/test_correlation_rules.py
@@ -45,9 +45,10 @@ class TestCorrelationRulesIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_correlation_rules full details")
         self.assert_valid_list_response(result, min_length=0, context="search_correlation_rules")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_correlation_rules full details")
+        if len(records) > 0:
             self.assert_search_returns_details(
-                result,
+                records,
                 expected_fields=["rule_id", "id", "name", "severity", "status", "state", "search"],
                 context="search_correlation_rules full details",
             )
@@ -63,7 +64,8 @@ class TestCorrelationRulesIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search with status filter")
         self.assert_valid_list_response(result, min_length=0, context="search with status filter")
 
-        for rule in result:
+        records = self.records(result, context="search with status filter")
+        for rule in records:
             assert isinstance(rule, dict), f"Expected dict, got {type(rule)}"
             assert rule.get("status") == "active", (
                 f"Expected status 'active', got '{rule.get('status')}'"
@@ -74,8 +76,8 @@ class TestCorrelationRulesIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_correlation_rules, limit=3)
 
         self.assert_no_error(result, context="search with limit=3")
-        assert isinstance(result, list), f"Expected list, got {type(result)}"
-        assert len(result) <= 3, f"Expected at most 3 results, got {len(result)}"
+        records = self.records(result, context="search with limit=3")
+        assert len(records) <= 3, f"Expected at most 3 results, got {len(records)}"
 
     def test_search_invalid_filter_returns_error(self):
         """Test that an invalid FQL filter returns a structured error, not a crash."""
@@ -87,7 +89,8 @@ class TestCorrelationRulesIntegration(BaseIntegrationTest):
 
         # Should return a structured error response (dict or list with error), not raise
         assert result is not None, "Expected a response, got None"
-        if isinstance(result, list) and len(result) > 0 and isinstance(result[0], dict):
+        records = self.records(result, context="search_correlation_rules invalid filter")
+        if len(records) > 0 and isinstance(records[0], dict):
             # Error surfaced in list — acceptable
             pass
         elif isinstance(result, dict):
@@ -106,7 +109,8 @@ class TestCorrelationRulesIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search rule_id and version id")
         self.assert_valid_list_response(result, min_length=0, context="search rule_id and id")
 
-        for i, rule in enumerate(result):
+        records = self.records(result, context="search rule_id and version id")
+        for i, rule in enumerate(records):
             assert isinstance(rule, dict), f"Expected dict at index {i}"
             assert "rule_id" in rule, (
                 f"Missing 'rule_id' at index {i}. Fields: {list(rule.keys())}"
@@ -122,7 +126,8 @@ class TestCorrelationRulesIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search object presence")
         self.assert_valid_list_response(result, min_length=0, context="search object presence")
 
-        for i, rule in enumerate(result):
+        records = self.records(result, context="search object presence")
+        for i, rule in enumerate(records):
             assert isinstance(rule, dict), f"Expected dict at index {i}"
             assert "search" in rule, (
                 f"Missing 'search' key at index {i}. Fields: {list(rule.keys())}"
@@ -146,12 +151,11 @@ class TestCorrelationRulesIntegration(BaseIntegrationTest):
         Any created rule is deleted in a finally block to avoid leaving test data.
         """
         # Resolve customer_id from an existing rule
-        search_result = self.call_method(self.module.search_correlation_rules, limit=1)
-        if not search_result or not isinstance(search_result, list) or len(search_result) == 0:
-            self.skip_with_warning(
-                "No existing rules to derive customer_id from",
-                context="test_create_rule_lifecycle",
-            )
+        search_result = self.skip_unless_tenant_has(
+            self.call_method(self.module.search_correlation_rules, limit=1),
+            "existing rules to derive customer_id from",
+            context="test_create_rule_lifecycle",
+        )
         customer_id = search_result[0].get("customer_id")
         if not customer_id:
             self.skip_with_warning(
@@ -210,13 +214,13 @@ class TestCorrelationRulesIntegration(BaseIntegrationTest):
         search_result = self.call_method(self.module.search_correlation_rules, limit=1)
         self.assert_no_error(search_result, context="search before update test")
 
-        if not search_result or not isinstance(search_result, list) or len(search_result) == 0:
-            self.skip_with_warning(
-                "No rules available to test update",
-                context="test_update_rule",
-            )
+        records = self.skip_unless_tenant_has(
+            search_result,
+            "rules available to test update",
+            context="test_update_rule",
+        )
 
-        rule = search_result[0]
+        rule = records[0]
         rule_id = rule.get("rule_id")
         original_description = rule.get("description", "")
 

--- a/tests/integration/test_custom_ioa.py
+++ b/tests/integration/test_custom_ioa.py
@@ -95,7 +95,8 @@ class TestCustomIOAIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_returns_full_details")
         self.assert_valid_list_response(result, min_length=0, context="search_returns_full_details")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_returns_full_details")
+        if len(records) > 0:
             self.assert_search_returns_details(
                 result,
                 expected_fields=["id", "name", "platform", "enabled", "rules"],
@@ -173,8 +174,9 @@ class TestCustomIOAIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="round-trip search")
         self.assert_valid_list_response(result, min_length=1, context="round-trip search")
 
+        records = self.records(result, context="round-trip search")
         found_ids = [
-            item.get("id") for item in result if isinstance(item, dict)
+            item.get("id") for item in records if isinstance(item, dict)
         ]
         assert self.__class__._test_rule_group_id in found_ids, (
             f"Created rule group {self.__class__._test_rule_group_id} not found in search results. "

--- a/tests/integration/test_detections.py
+++ b/tests/integration/test_detections.py
@@ -33,7 +33,8 @@ class TestDetectionsIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_detections")
         self.assert_valid_list_response(result, min_length=0, context="search_detections")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_detections")
+        if len(records) > 0:
             # Verify we get full details, not just IDs
             self.assert_search_returns_details(
                 result,
@@ -69,13 +70,11 @@ class TestDetectionsIntegration(BaseIntegrationTest):
         First searches for a detection, then gets its details.
         """
         # First, search for a detection to get a valid ID
-        search_result = self.call_method(self.module.search_detections, limit=1)
-
-        if not search_result or len(search_result) == 0:
-            self.skip_with_warning(
-                "No detections available to test get_detection_details",
-                context="test_get_detection_details_with_valid_id",
-            )
+        search_result = self.skip_unless_tenant_has(
+            self.call_method(self.module.search_detections, limit=1),
+            "detections",
+            context="test_get_detection_details_with_valid_id",
+        )
 
         detection_id = self.get_first_id(search_result, id_field="composite_id")
         if not detection_id:

--- a/tests/integration/test_discover.py
+++ b/tests/integration/test_discover.py
@@ -36,7 +36,8 @@ class TestDiscoverIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_applications")
         self.assert_valid_list_response(result, min_length=0, context="search_applications")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_applications")
+        if len(records) > 0:
             # Verify we get full details
             self.assert_search_returns_details(
                 result,
@@ -78,7 +79,8 @@ class TestDiscoverIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_unmanaged_assets")
         self.assert_valid_list_response(result, min_length=0, context="search_unmanaged_assets")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_unmanaged_assets")
+        if len(records) > 0:
             # Verify we get full details
             self.assert_search_returns_details(
                 result,
@@ -119,7 +121,8 @@ class TestDiscoverIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_managed_assets")
         self.assert_valid_list_response(result, min_length=0, context="search_managed_assets")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_managed_assets")
+        if len(records) > 0:
             # Verify we get full details
             self.assert_search_returns_details(
                 result,

--- a/tests/integration/test_firewall.py
+++ b/tests/integration/test_firewall.py
@@ -45,9 +45,10 @@ class TestFirewallIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_firewall_rules")
         self.assert_valid_list_response(result, min_length=0, context="search_firewall_rules")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_firewall_rules")
+        if len(records) > 0:
             self.assert_search_returns_details(
-                result,
+                records,
                 expected_fields=["id", "platform_ids"],
                 context="search_firewall_rules",
             )
@@ -63,10 +64,9 @@ class TestFirewallIntegration(BaseIntegrationTest):
         )
 
         self.assert_no_error(result, context="search_firewall_rules with filter")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="search_firewall_rules with filter"
-            )
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_firewall_rules with filter"
+        )
 
     def test_search_firewall_rule_groups_returns_details(self):
         """Test that search_firewall_rule_groups returns full details."""
@@ -83,9 +83,10 @@ class TestFirewallIntegration(BaseIntegrationTest):
             result, min_length=0, context="search_firewall_rule_groups"
         )
 
-        if len(result) > 0:
+        records = self.records(result, context="search_firewall_rule_groups")
+        if len(records) > 0:
             self.assert_search_returns_details(
-                result,
+                records,
                 expected_fields=["id", "platform"],
                 context="search_firewall_rule_groups",
             )
@@ -101,10 +102,9 @@ class TestFirewallIntegration(BaseIntegrationTest):
         )
 
         self.assert_no_error(result, context="search_firewall_rule_groups with filter")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="search_firewall_rule_groups with filter"
-            )
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_firewall_rule_groups with filter"
+        )
 
     def test_search_firewall_policy_rules(self):
         """Test searching policy rules using a discovered rule group ID.
@@ -112,16 +112,14 @@ class TestFirewallIntegration(BaseIntegrationTest):
         Uses dynamic ID discovery: first searches for a rule group,
         then uses its ID to search for policy rules.
         """
-        groups_result = self.call_method(
-            self.module.search_firewall_rule_groups,
-            limit=1,
+        groups_result = self.skip_unless_tenant_has(
+            self.call_method(
+                self.module.search_firewall_rule_groups,
+                limit=1,
+            ),
+            "firewall rule groups",
+            context="test_search_firewall_policy_rules",
         )
-
-        if not groups_result or (isinstance(groups_result, list) and len(groups_result) == 0):
-            self.skip_with_warning(
-                "No firewall rule groups available",
-                context="test_search_firewall_policy_rules",
-            )
 
         group_id = self.get_first_id(groups_result)
         if not group_id:
@@ -137,16 +135,16 @@ class TestFirewallIntegration(BaseIntegrationTest):
         )
 
         # Gracefully handle cases where no firewall policy matches the ID
-        if isinstance(result, list) and len(result) > 0 and isinstance(result[0], dict):
-            if "error" in result[0]:
+        policy_records = self.records(result, context="search_firewall_policy_rules")
+        if len(policy_records) > 0 and isinstance(policy_records[0], dict):
+            if "error" in policy_records[0]:
                 self.skip_with_warning(
                     "No firewall policy found for the discovered ID",
                     context="test_search_firewall_policy_rules",
                 )
 
         self.assert_no_error(result, context="search_firewall_policy_rules")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="search_firewall_policy_rules"
-            )
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_firewall_policy_rules"
+        )
 

--- a/tests/integration/test_host_groups.py
+++ b/tests/integration/test_host_groups.py
@@ -122,7 +122,8 @@ class TestHostGroupsIntegration(BaseIntegrationTest):
             result, min_length=0, context="search_host_groups"
         )
 
-        if isinstance(result, list) and len(result) > 0:
+        records = self.records(result, context="search_host_groups")
+        if len(records) > 0:
             self.assert_search_returns_details(
                 result,
                 expected_fields=["id", "name", "group_type"],
@@ -152,7 +153,8 @@ class TestHostGroupsIntegration(BaseIntegrationTest):
             result, min_length=0, context="search_host_group_members"
         )
 
-        if isinstance(result, list) and len(result) > 0:
+        records = self.records(result, context="search_host_group_members")
+        if len(records) > 0:
             self.assert_search_returns_details(
                 result,
                 expected_fields=["device_id"],
@@ -170,12 +172,11 @@ class TestHostGroupsIntegration(BaseIntegrationTest):
         Note: do NOT use filter="*" here — the live API rejects it with HTTP 400.
         Omitting `filter` is the "all members" path.
         """
-        groups = self.call_method(self.module.search_host_groups, limit=50)
-        if not isinstance(groups, list) or len(groups) == 0:
-            self.skip_with_warning(
-                "No host groups in tenant", context="member filter validation"
-            )
-            return
+        groups = self.skip_unless_tenant_has(
+            self.call_method(self.module.search_host_groups, limit=50),
+            "host groups",
+            context="member filter validation",
+        )
 
         populated_id = None
         for group in groups:
@@ -184,7 +185,8 @@ class TestHostGroupsIntegration(BaseIntegrationTest):
             members = self.call_method(
                 self.module.search_host_group_members, id=group["id"], limit=1
             )
-            if isinstance(members, list) and len(members) > 0:
+            member_records = self.records(members, context="member filter validation")
+            if len(member_records) > 0:
                 populated_id = group["id"]
                 break
 
@@ -234,8 +236,9 @@ class TestHostGroupsIntegration(BaseIntegrationTest):
             result, min_length=1, context="round-trip search"
         )
 
+        records = self.records(result, context="round-trip search")
         found_ids = [
-            item.get("id") for item in result if isinstance(item, dict)
+            item.get("id") for item in records if isinstance(item, dict)
         ]
         assert lifecycle_group["id"] in found_ids, (
             f"Created group {lifecycle_group['id']} not found in search results. "

--- a/tests/integration/test_hosts.py
+++ b/tests/integration/test_hosts.py
@@ -38,7 +38,8 @@ class TestHostsIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_hosts")
         self.assert_valid_list_response(result, min_length=0, context="search_hosts")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_hosts")
+        if len(records) > 0:
             # Verify we get full details, not just IDs
             self.assert_search_returns_details(
                 result,
@@ -74,13 +75,11 @@ class TestHostsIntegration(BaseIntegrationTest):
         First searches for a host, then gets its details.
         """
         # First, search for a host to get a valid ID
-        search_result = self.call_method(self.module.search_hosts, limit=1)
-
-        if not search_result or len(search_result) == 0:
-            self.skip_with_warning(
-                "No hosts available to test get_host_details",
-                context="test_get_host_details_with_valid_id",
-            )
+        search_result = self.skip_unless_tenant_has(
+            self.call_method(self.module.search_hosts, limit=1),
+            "hosts",
+            context="test_get_host_details_with_valid_id",
+        )
 
         device_id = self.get_first_id(search_result, id_field="device_id")
         if not device_id:

--- a/tests/integration/test_intel.py
+++ b/tests/integration/test_intel.py
@@ -31,7 +31,8 @@ class TestIntelIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="query_actor_entities")
         self.assert_valid_list_response(result, min_length=0, context="query_actor_entities")
 
-        if len(result) > 0:
+        records = self.records(result, context="query_actor_entities")
+        if len(records) > 0:
             # Verify we get full details
             self.assert_search_returns_details(
                 result,
@@ -71,7 +72,8 @@ class TestIntelIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="query_indicator_entities")
         self.assert_valid_list_response(result, min_length=0, context="query_indicator_entities")
 
-        if len(result) > 0:
+        records = self.records(result, context="query_indicator_entities")
+        if len(records) > 0:
             # Verify we get full details
             self.assert_search_returns_details(
                 result,
@@ -100,7 +102,8 @@ class TestIntelIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="query_report_entities")
         self.assert_valid_list_response(result, min_length=0, context="query_report_entities")
 
-        if len(result) > 0:
+        records = self.records(result, context="query_report_entities")
+        if len(records) > 0:
             # Verify we get full details
             self.assert_search_returns_details(
                 result,
@@ -126,13 +129,11 @@ class TestIntelIntegration(BaseIntegrationTest):
         Validates both QueryIntelActorEntities and GetMitreReport operations.
         """
         # First, search for an actor to get a valid name
-        search_result = self.call_method(self.module.query_actor_entities, limit=1)
-
-        if not search_result or len(search_result) == 0:
-            self.skip_with_warning(
-                "No actors available to test get_mitre_report",
-                context="test_get_mitre_report_with_actor_name",
-            )
+        search_result = self.skip_unless_tenant_has(
+            self.call_method(self.module.query_actor_entities, limit=1),
+            "actors",
+            context="test_get_mitre_report_with_actor_name",
+        )
 
         actor_name = search_result[0].get("name")
         if not actor_name:
@@ -174,13 +175,11 @@ class TestIntelIntegration(BaseIntegrationTest):
         Validates that CSV format is not parsed and remains a string.
         """
         # First, search for an actor to get a valid name
-        search_result = self.call_method(self.module.query_actor_entities, limit=1)
-
-        if not search_result or len(search_result) == 0:
-            self.skip_with_warning(
-                "No actors available to test get_mitre_report CSV",
-                context="test_get_mitre_report_csv_format",
-            )
+        search_result = self.skip_unless_tenant_has(
+            self.call_method(self.module.query_actor_entities, limit=1),
+            "actors",
+            context="test_get_mitre_report_csv_format",
+        )
 
         actor_name = search_result[0].get("name")
         if not actor_name:

--- a/tests/integration/test_ioc.py
+++ b/tests/integration/test_ioc.py
@@ -101,7 +101,8 @@ class TestIOCIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_iocs")
         self.assert_valid_list_response(result, min_length=0, context="search_iocs")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_iocs")
+        if len(records) > 0:
             self.assert_search_returns_details(
                 result,
                 expected_fields=["id", "type", "value"],
@@ -169,8 +170,9 @@ class TestIOCIntegration(BaseIntegrationTest):
         )
 
         # Verify the test IOC is in results
+        records = self.records(result, context="round-trip search")
         found_ids = [
-            item.get("id") for item in result if isinstance(item, dict)
+            item.get("id") for item in records if isinstance(item, dict)
         ]
         assert self.__class__._test_ioc_id in found_ids, (
             f"Created IOC {self.__class__._test_ioc_id} not found in search results. "

--- a/tests/integration/test_policies.py
+++ b/tests/integration/test_policies.py
@@ -278,7 +278,8 @@ class TestPoliciesIntegration(BaseIntegrationTest):
             sort="platform_name.asc",
             limit=1,
         )
-        assert isinstance(result, list) and result and "error" in result[0], (
+        records = self.records(result, context="platform_name sort guard")
+        assert records and "error" in records[0], (
             f"platform_name sort should be rejected by _validate_sort, got: {result}"
         )
 

--- a/tests/integration/test_quarantine.py
+++ b/tests/integration/test_quarantine.py
@@ -26,13 +26,13 @@ class TestQuarantineIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_quarantined_files, limit=5)
 
         self.assert_no_error(result, context="search_quarantined_files")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result,
-                min_length=0,
-                context="search_quarantined_files",
-            )
-        if isinstance(result, list) and len(result) > 0:
+        self.assert_valid_list_response(
+            result,
+            min_length=0,
+            context="search_quarantined_files",
+        )
+        records = self.records(result, context="search_quarantined_files")
+        if len(records) > 0:
             self.assert_search_returns_details(
                 result,
                 expected_fields=["id", "sha256", "hostname"],
@@ -48,12 +48,11 @@ class TestQuarantineIntegration(BaseIntegrationTest):
         )
 
         self.assert_no_error(result, context="search_quarantined_files with sort")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result,
-                min_length=0,
-                context="search_quarantined_files with sort",
-            )
+        self.assert_valid_list_response(
+            result,
+            min_length=0,
+            context="search_quarantined_files with sort",
+        )
 
     def test_preview_quarantine_actions_with_filter(self):
         """Test the read-only quarantine action count with a valid FQL filter."""

--- a/tests/integration/test_rtr.py
+++ b/tests/integration/test_rtr.py
@@ -78,15 +78,15 @@ class TestRTRIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_sessions, limit=5)
 
         self.assert_no_error(result, context="search_rtr_sessions")
+        self.assert_valid_list_response(result, min_length=0, context="search_rtr_sessions")
 
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_rtr_sessions")
-            if len(result) > 0:
-                self.assert_search_returns_details(
-                    result,
-                    expected_fields=["id", "device_id", "hostname"],
-                    context="search_rtr_sessions",
-                )
+        records = self.records(result, context="search_rtr_sessions")
+        if len(records) > 0:
+            self.assert_search_returns_details(
+                result,
+                expected_fields=["id", "device_id", "hostname"],
+                context="search_rtr_sessions",
+            )
 
     def test_search_rtr_sessions_with_sort(self):
         """Test RTR session search with a supported sort expression."""
@@ -97,22 +97,19 @@ class TestRTRIntegration(BaseIntegrationTest):
         )
 
         self.assert_no_error(result, context="search_rtr_sessions with sort")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result,
-                min_length=0,
-                context="search_rtr_sessions with sort",
-            )
+        self.assert_valid_list_response(
+            result,
+            min_length=0,
+            context="search_rtr_sessions with sort",
+        )
 
     def test_get_rtr_session_details_with_valid_id(self):
         """Test session detail lookup using a valid session ID."""
-        search_result = self.call_method(self.module.search_sessions, limit=1)
-
-        if not isinstance(search_result, list) or len(search_result) == 0:
-            self.skip_with_warning(
-                "No RTR sessions available to test get_rtr_session_details",
-                context="test_get_rtr_session_details_with_valid_id",
-            )
+        search_result = self.skip_unless_tenant_has(
+            self.call_method(self.module.search_sessions, limit=1),
+            "RTR sessions",
+            context="test_get_rtr_session_details_with_valid_id",
+        )
 
         session_id = self.get_first_id(search_result)
         if not session_id:
@@ -151,13 +148,11 @@ class TestRTRIntegration(BaseIntegrationTest):
             "search_rtr_audit_sessions",
         )
         self.assert_no_error(result, context="search_rtr_audit_sessions")
-
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result,
-                min_length=0,
-                context="search_rtr_audit_sessions",
-            )
+        self.assert_valid_list_response(
+            result,
+            min_length=0,
+            context="search_rtr_audit_sessions",
+        )
 
     def test_aggregate_rtr_sessions(self):
         """Validate RTR session aggregation operation and request body shape."""
@@ -197,10 +192,9 @@ class TestRTRIntegration(BaseIntegrationTest):
         )
 
         self.assert_no_error(result, context="search_rtr_sessions with filter")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="search_rtr_sessions with filter"
-            )
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_rtr_sessions with filter"
+        )
 
     def test_fql_string_fields_are_accepted(self):
         """Validate that all documented string FQL fields are accepted."""
@@ -321,10 +315,11 @@ class TestRTRLifecycleIntegration(BaseIntegrationTest):
         )
         hosts_result = hosts_module.search_hosts(**host_kwargs)
 
-        if not isinstance(hosts_result, list) or len(hosts_result) == 0:
+        hosts = self.records(hosts_result, context="init_rtr_session host search")
+        if len(hosts) == 0:
             pytest.skip("No hosts found in environment")
 
-        first_host = hosts_result[0]
+        first_host = hosts[0]
         if isinstance(first_host, dict) and "error" in first_host:
             pytest.skip(f"Host search failed (check Hosts:read scope): {first_host}")
 

--- a/tests/integration/test_scheduled_reports.py
+++ b/tests/integration/test_scheduled_reports.py
@@ -34,7 +34,8 @@ class TestScheduledReportsIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_scheduled_reports")
         self.assert_valid_list_response(result, min_length=0, context="search_scheduled_reports")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_scheduled_reports")
+        if len(records) > 0:
             # Verify we get full details, not just IDs
             self.assert_search_returns_details(
                 result,
@@ -87,7 +88,8 @@ class TestScheduledReportsIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_report_executions")
         self.assert_valid_list_response(result, min_length=0, context="search_report_executions")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_report_executions")
+        if len(records) > 0:
             # Verify we get full details, not just IDs
             self.assert_search_returns_details(
                 result,
@@ -124,18 +126,16 @@ class TestScheduledReportsIntegration(BaseIntegrationTest):
         Most scheduled reports use CSV format by default.
         """
         # Search for completed executions - prefer CSV format (most common)
-        search_result = self.call_method(
-            self.module.search_report_executions,
-            filter="status:'DONE'",
-            limit=20,
-            sort="created_on.desc",
+        search_result = self.skip_unless_tenant_has(
+            self.call_method(
+                self.module.search_report_executions,
+                filter="status:'DONE'",
+                limit=20,
+                sort="created_on.desc",
+            ),
+            "completed executions",
+            context="test_download_csv_format_execution",
         )
-
-        if not search_result or len(search_result) == 0:
-            self.skip_with_warning(
-                "No completed executions available",
-                context="test_download_csv_format_execution",
-            )
 
         # Find an execution with results that uses CSV format
         # Look for executions where report_params.format is 'csv' (or not json/pdf)
@@ -180,18 +180,16 @@ class TestScheduledReportsIntegration(BaseIntegrationTest):
         These are typically scheduled searches (type=event_search).
         """
         # Search for completed executions with JSON format
-        search_result = self.call_method(
-            self.module.search_report_executions,
-            filter="status:'DONE'",
-            limit=30,
-            sort="created_on.desc",
+        search_result = self.skip_unless_tenant_has(
+            self.call_method(
+                self.module.search_report_executions,
+                filter="status:'DONE'",
+                limit=30,
+                sort="created_on.desc",
+            ),
+            "completed executions",
+            context="test_download_json_format_execution",
         )
-
-        if not search_result or len(search_result) == 0:
-            self.skip_with_warning(
-                "No completed executions available",
-                context="test_download_json_format_execution",
-            )
 
         # Find an execution with results that uses JSON format
         execution_id = None
@@ -240,18 +238,16 @@ class TestScheduledReportsIntegration(BaseIntegrationTest):
         should detect PDF bytes and return an error recommending CSV/JSON format.
         """
         # Search for completed executions with PDF format
-        search_result = self.call_method(
-            self.module.search_report_executions,
-            filter="status:'DONE'",
-            limit=100,
-            sort="created_on.desc",
+        search_result = self.skip_unless_tenant_has(
+            self.call_method(
+                self.module.search_report_executions,
+                filter="status:'DONE'",
+                limit=100,
+                sort="created_on.desc",
+            ),
+            "completed executions",
+            context="test_download_pdf_format_execution_returns_error",
         )
-
-        if not search_result or len(search_result) == 0:
-            self.skip_with_warning(
-                "No completed executions available",
-                context="test_download_pdf_format_execution_returns_error",
-            )
 
         # Find an execution with results that uses PDF format
         execution_id = None

--- a/tests/integration/test_shield.py
+++ b/tests/integration/test_shield.py
@@ -33,8 +33,7 @@ class TestShieldIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_shield_checks, limit=5)
 
         self.assert_no_error(result, context="search_shield_checks")
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_shield_checks")
+        self.assert_valid_list_response(result, min_length=0, context="search_shield_checks")
 
     def test_search_shield_checks_with_impact_filter(self):
         """Validate impact string normalization works against real API."""
@@ -48,13 +47,11 @@ class TestShieldIntegration(BaseIntegrationTest):
 
     def test_get_shield_check_affected_entities(self):
         """Validate GetSecurityCheckAffectedV3 with a real check ID."""
-        checks = self.call_method(self.module.search_shield_checks, limit=1)
-
-        if not isinstance(checks, list) or len(checks) == 0:
-            self.skip_with_warning(
-                "No security checks available",
-                context="get_shield_check_affected_entities",
-            )
+        checks = self.skip_unless_tenant_has(
+            self.call_method(self.module.search_shield_checks, limit=1),
+            "security checks",
+            context="get_shield_check_affected_entities",
+        )
 
         check_id = self.get_first_id(checks, id_field="id")
         if not check_id:
@@ -79,13 +76,11 @@ class TestShieldIntegration(BaseIntegrationTest):
 
     def test_get_shield_check_compliance(self):
         """Validate GetSecurityCheckComplianceV3 with a real check ID."""
-        checks = self.call_method(self.module.search_shield_checks, limit=1)
-
-        if not isinstance(checks, list) or len(checks) == 0:
-            self.skip_with_warning(
-                "No security checks available",
-                context="get_shield_check_compliance",
-            )
+        checks = self.skip_unless_tenant_has(
+            self.call_method(self.module.search_shield_checks, limit=1),
+            "security checks",
+            context="get_shield_check_compliance",
+        )
 
         check_id = self.get_first_id(checks, id_field="id")
         if not check_id:
@@ -108,18 +103,16 @@ class TestShieldIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_shield_alerts, limit=5)
 
         self.assert_no_error(result, context="search_shield_alerts")
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_shield_alerts")
+        self.assert_valid_list_response(result, min_length=0, context="search_shield_alerts")
 
     def test_get_shield_activity_monitor(self):
         """Validate GetActivityMonitorV3 operation name and response shape."""
         result = self.call_method(self.module.get_shield_activity_monitor, limit=5)
 
         self.assert_no_error(result, context="get_shield_activity_monitor")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="get_shield_activity_monitor"
-            )
+        self.assert_valid_list_response(
+            result, min_length=0, context="get_shield_activity_monitor"
+        )
 
     # --- Inventory tools ---
 
@@ -128,37 +121,32 @@ class TestShieldIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_shield_users, limit=5)
 
         self.assert_no_error(result, context="search_shield_users")
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_shield_users")
+        self.assert_valid_list_response(result, min_length=0, context="search_shield_users")
 
     def test_search_shield_devices(self):
         """Validate GetDeviceInventoryV3 operation name and response shape."""
         result = self.call_method(self.module.search_shield_devices, limit=5)
 
         self.assert_no_error(result, context="search_shield_devices")
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_shield_devices")
+        self.assert_valid_list_response(result, min_length=0, context="search_shield_devices")
 
     def test_search_shield_apps(self):
         """Validate GetAppInventory operation name and response shape."""
         result = self.call_method(self.module.search_shield_apps, limit=5)
 
         self.assert_no_error(result, context="search_shield_apps")
-        if isinstance(result, list):
-            self.assert_valid_list_response(result, min_length=0, context="search_shield_apps")
+        self.assert_valid_list_response(result, min_length=0, context="search_shield_apps")
 
     def test_get_shield_app_users(self):
         """Validate GetAppInventoryUsers with a real app ID.
 
         Requires apps to exist; skips gracefully if none configured.
         """
-        apps = self.call_method(self.module.search_shield_apps, limit=1)
-
-        if not isinstance(apps, list) or len(apps) == 0:
-            self.skip_with_warning(
-                "No apps available to test app users",
-                context="get_shield_app_users",
-            )
+        apps = self.skip_unless_tenant_has(
+            self.call_method(self.module.search_shield_apps, limit=1),
+            "apps",
+            context="get_shield_app_users",
+        )
 
         first_app = apps[0]
         if not isinstance(first_app, dict):
@@ -186,10 +174,9 @@ class TestShieldIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.search_shield_data_shares, limit=5)
 
         self.assert_no_error(result, context="search_shield_data_shares")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="search_shield_data_shares"
-            )
+        self.assert_valid_list_response(
+            result, min_length=0, context="search_shield_data_shares"
+        )
 
     # --- Platform management tools ---
 
@@ -198,40 +185,28 @@ class TestShieldIntegration(BaseIntegrationTest):
         result = self.call_method(self.module.get_shield_integrations)
 
         self.assert_no_error(result, context="get_shield_integrations")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="get_shield_integrations"
-            )
+        self.assert_valid_list_response(result, min_length=0, context="get_shield_integrations")
 
     def test_get_shield_system_users(self):
         """Validate GetSystemUsersV3 operation name and response shape."""
         result = self.call_method(self.module.get_shield_system_users)
 
         self.assert_no_error(result, context="get_shield_system_users")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="get_shield_system_users"
-            )
+        self.assert_valid_list_response(result, min_length=0, context="get_shield_system_users")
 
     def test_get_shield_supported_saas(self):
         """Validate GetSupportedSaasV3 operation name and response shape."""
         result = self.call_method(self.module.get_shield_supported_saas)
 
         self.assert_no_error(result, context="get_shield_supported_saas")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="get_shield_supported_saas"
-            )
+        self.assert_valid_list_response(result, min_length=0, context="get_shield_supported_saas")
 
     def test_get_shield_system_logs(self):
         """Validate GetSystemLogsV3 operation name and response shape."""
         result = self.call_method(self.module.get_shield_system_logs, limit=5)
 
         self.assert_no_error(result, context="get_shield_system_logs")
-        if isinstance(result, list):
-            self.assert_valid_list_response(
-                result, min_length=0, context="get_shield_system_logs"
-            )
+        self.assert_valid_list_response(result, min_length=0, context="get_shield_system_logs")
 
     # --- Cross-tool validation ---
 
@@ -292,9 +267,8 @@ class TestShieldIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="GetSystemLogsV3")
 
         # ID-dependent operations — need a real check ID from step 1
-        check_id = None
-        if isinstance(checks, list) and len(checks) > 0:
-            check_id = self.get_first_id(checks, id_field="id")
+        check_records = self.records(checks, context="GetSecurityChecksV3")
+        check_id = self.get_first_id(check_records, id_field="id") if check_records else None
 
         if check_id:
             # 13. GetSecurityCheckAffectedV3
@@ -313,8 +287,9 @@ class TestShieldIntegration(BaseIntegrationTest):
             self.assert_no_error(result, context="GetSecurityCheckComplianceV3")
 
         # ID-dependent: GetAppInventoryUsers — needs a real app item_id
-        if isinstance(apps, list) and len(apps) > 0:
-            first_app = apps[0]
+        app_records = self.records(apps, context="GetAppInventory")
+        if app_records:
+            first_app = app_records[0]
             if isinstance(first_app, dict):
                 app_item_id = first_app.get("item_id") or first_app.get("id")
                 if app_item_id:

--- a/tests/integration/test_spotlight.py
+++ b/tests/integration/test_spotlight.py
@@ -35,7 +35,8 @@ class TestSpotlightIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_vulnerabilities")
         self.assert_valid_list_response(result, min_length=0, context="search_vulnerabilities")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_vulnerabilities")
+        if len(records) > 0:
             # Verify we get full details, not just IDs
             self.assert_search_returns_details(
                 result,
@@ -78,7 +79,8 @@ class TestSpotlightIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_vulnerabilities with facet")
         self.assert_valid_list_response(result, min_length=0, context="search_vulnerabilities with facet")
 
-        if len(result) > 0:
+        records = self.records(result, context="search_vulnerabilities with facet")
+        if len(records) > 0:
             self.assert_search_returns_details(
                 result,
                 expected_fields=["cve"],
@@ -101,7 +103,8 @@ class TestSpotlightIntegration(BaseIntegrationTest):
 
         # Verify both requested facet blocks are actually present in a single
         # response — this is the core contract of the multi-facet enhancement.
-        if len(result) > 0:
+        records = self.records(result, context="search_vulnerabilities with multiple facets")
+        if len(records) > 0:
             self.assert_search_returns_details(
                 result,
                 expected_fields=["cve", "host_info"],

--- a/tests/integration/utils/base_integration_test.py
+++ b/tests/integration/utils/base_integration_test.py
@@ -73,9 +73,12 @@ class BaseIntegrationTest:
             assert "error" not in result, error_msg
             assert result.get("status_code", 200) < 400, error_msg
 
-        # Check for list containing error dict
-        if isinstance(result, list) and len(result) > 0:
-            first_item = result[0]
+        # Check for list containing error dict. Unwrap first: a search tool reports
+        # failure as an error dict inside the envelope's `results`, where neither the
+        # top-level key check above nor a bare `isinstance(result, list)` can see it.
+        records = self._unwrap_results(result)
+        if isinstance(records, list) and len(records) > 0:
+            first_item = records[0]
             if isinstance(first_item, dict):
                 assert "error" not in first_item, error_msg
 


### PR DESCRIPTION
Integration tests in 17 files indexed search results as bare lists, but those tools return the pagination envelope. It has three keys, so `result[0]` raises `KeyError: 0`, `len(result)` counts keys instead of records, and iterating gives you the key strings back.

The guards around those sites made it worse. `if isinstance(result, list):` is False on an envelope, so any assertion it wrapped never ran at all, and `if not isinstance(x, list) or len(x) == 0: skip(...)` always skips, with a reason that blames the tenant for being empty. Shield was the worst of it: 11 assertions that couldn't execute, and 3 tests reporting no security checks on a tenant that has plenty. The same guard in `test_all_read_operation_names_are_correct` gated the last three operations, so 3 of the 15 op names that test covers were never checked. Same story in `test_rtr`, where `init_rtr_session` quietly skipped the entire lifecycle class.

Converted the affected sites to `records()` and `skip_unless_tenant_has()` from #535 instead of adding anything new. Get-by-IDs tools like `get_host_details` and `get_cases` do return a bare list, so indexing those is correct and I left them alone, along with string-key access on the envelope itself.

One more thing turned up while fixing the guards. A search tool reports failure as an error dict nested inside the envelope's `results`, which neither the top-level key check nor a bare `isinstance(result, list)` can see — so a 403 sailed through on every tool whose only assertion was `assert_no_error`. That's a one-line unwrap in the base class.

Closes #548
