### PR TITLE
fix(modules): reject sort expressions the policy APIs cannot serve

### DIFF
--- a/falcon_mcp/modules/cloud/cloud_iom.py
+++ b/falcon_mcp/modules/cloud/cloud_iom.py
@@ -85,6 +85,12 @@ class _CloudIomMixin(_CloudBase):
                 service: Cloud service name
                 status: Finding status
 
+                Sort field names do NOT match where the value lands in the response —
+                none of them are at the record root. Read them back from:
+                severity, status, first_detected, last_detected -> evaluation.<field>
+                cloud_provider -> cloud.provider
+                service -> resource.service
+
                 Examples: 'severity.desc', 'last_detected.desc', 'first_detected.asc'
             """
             ).strip(),

--- a/falcon_mcp/modules/data_protection.py
+++ b/falcon_mcp/modules/data_protection.py
@@ -160,7 +160,7 @@ class DataProtectionModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="Sort order. Ex: name.asc, precedence.asc, created_at.desc",
+            description="Sort order. Ex: name.asc, precedence.asc, created_at.desc. Note: 'precedence.asc' returns correctly ordered results, but 'precedence.desc' does not — the API returns rows out of order. Sort ascending and reverse the results yourself if you need descending precedence.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for Data Protection policies in your CrowdStrike environment.
@@ -220,7 +220,7 @@ class DataProtectionModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="Sort order. Ex: name.asc, category.asc, region.asc",
+            description="Sort order. Ex: name.asc, category.asc, region.asc. Note: 'name' does not order results correctly in either direction on this endpoint — sort on another field, or order the results yourself.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search for Data Protection content patterns in your CrowdStrike environment.

--- a/falcon_mcp/modules/policies.py
+++ b/falcon_mcp/modules/policies.py
@@ -269,6 +269,11 @@ class PoliciesModule(BaseModule):
         "precedence",
     }
 
+    # Sort fields that are safe on other types but return HTTP 500 on a specific one.
+    _UNSAFE_SORT_FIELDS_BY_TYPE = {
+        "device_control": {"created_by", "modified_by"},
+    }
+
     def register_tools(self, server: FastMCP) -> None:
         """Register tools with the MCP server.
 
@@ -376,17 +381,27 @@ class PoliciesModule(BaseModule):
             )
         return None
 
-    def _validate_sort(self, sort: str | None) -> dict[str, Any] | None:
-        """Reject platform_name sorts (HTTP 500) and unknown sort fields.
+    def _validate_sort(self, policy_type: str, sort: str | None) -> dict[str, Any] | None:
+        """Reject sort expressions the API cannot serve, before the request goes out.
 
-        Returns an error dict if the sort base is platform_name or not in the
-        allowed set, else None. Accepts an optional `.asc`/`.desc`/`|asc`/`|desc`
-        direction suffix.
+        Three cases, each verified against the live API: the pipe direction separator
+        (rejected with HTTP 400 on all six types), platform_name (HTTP 500 on all six),
+        and per-type fields that 500 only for one type. Returns an error dict, else None.
+        Accepts a `.asc`/`.desc` direction suffix.
         """
         if not sort:
             return None
 
-        base = sort.split(".")[0].split("|")[0].strip()
+        # The policy query endpoints accept only the dot separator. Every one of the six
+        # answers HTTP 400 for `field|desc`, so catch it here with a message that names the
+        # fix instead of surfacing the API's generic "not an allowable value".
+        if "|" in sort:
+            return _format_error_response(
+                f"Invalid sort separator in '{sort}'. The policy APIs accept only the dot "
+                f"form — use '{sort.replace('|', '.')}' instead.",
+            )
+
+        base = sort.split(".")[0].strip()
         if base == "platform_name":
             return _format_error_response(
                 "Sorting by 'platform_name' is not supported (the API returns "
@@ -397,6 +412,15 @@ class PoliciesModule(BaseModule):
             return _format_error_response(
                 f"Invalid sort field '{base}'. Valid sort fields are: "
                 f"{', '.join(sorted(self._SAFE_SORT_FIELDS))}.",
+            )
+        if base in self._UNSAFE_SORT_FIELDS_BY_TYPE.get(policy_type, set()):
+            allowed = sorted(
+                self._SAFE_SORT_FIELDS - self._UNSAFE_SORT_FIELDS_BY_TYPE[policy_type]
+            )
+            return _format_error_response(
+                f"Sorting by '{base}' is not supported for policy_type "
+                f"'{policy_type}' (the API returns HTTP 500), though it works for other "
+                f"types. Use one of: {', '.join(allowed)}.",
             )
         return None
 
@@ -426,7 +450,7 @@ class PoliciesModule(BaseModule):
         ),
         sort: str | None = Field(
             default=None,
-            description="Sort expression (e.g. 'modified_timestamp.desc'). See `falcon://policies/search/fql-guide`. Do NOT sort by platform_name (returns HTTP 500).",
+            description="Sort expression using the dot form only (e.g. 'modified_timestamp.desc'); the pipe form 'field|desc' is rejected. Do NOT sort by platform_name (HTTP 500 on every type), or by created_by/modified_by when policy_type is 'device_control' (HTTP 500). For device_control, created_timestamp and modified_timestamp ignore the direction and always return ascending order. See `falcon://policies/search/fql-guide`.",
         ),
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Search host-based policies of a given type and return full policy records.
@@ -444,7 +468,7 @@ class PoliciesModule(BaseModule):
         if type_error is not None:
             return [type_error]
 
-        sort_error = self._validate_sort(sort)
+        sort_error = self._validate_sort(policy_type, sort)
         if sort_error is not None:
             return [sort_error]
 

--- a/falcon_mcp/modules/recon.py
+++ b/falcon_mcp/modules/recon.py
@@ -208,6 +208,10 @@ class ReconModule(BaseModule):
                 updated_date: When the notification was last updated
 
                 Append .asc or .desc for direction (default desc).
+
+                Both sort fields read back from `notification.<field>`, not the record
+                root — a notification record's root holds only `id` and `notification`.
+
                 Examples: 'created_date.desc', 'updated_date.asc'
             """).strip(),
             examples=["created_date.desc", "updated_date.asc"],

--- a/falcon_mcp/resources/policies.py
+++ b/falcon_mcp/resources/policies.py
@@ -94,14 +94,27 @@ The `name` field is matched differently depending on `policy_type`:
 
 ## Sort and limit notes
 
-Safe sort fields (each accepts a `.asc` / `.desc` direction): `name`,
-`created_timestamp`, `modified_timestamp`, `enabled`, `created_by`, `modified_by`,
-`precedence`.
+Safe sort fields: `name`, `created_timestamp`, `modified_timestamp`, `enabled`,
+`created_by`, `modified_by`, `precedence`.
+
+**Use the dot direction separator only.** `created_timestamp.desc` works;
+`created_timestamp|desc` is rejected with HTTP 400 on all six policy types, so the
+tool rejects the pipe form up front.
 
 **Do NOT sort by `platform_name`.** Sorting by `platform_name` in either
 direction returns an HTTP 500 error on every policy type — it is not a valid sort
 field even though it is a valid filter field. Use one of the safe sort fields
 above instead.
+
+**`device_control` has two extra sort restrictions** (live-validated; they do not
+apply to the other five types):
+
+- `created_by` and `modified_by` return HTTP 500. The tool rejects both up front
+  for this type.
+- `created_timestamp` and `modified_timestamp` ignore the requested direction and
+  return the same ascending order for `.asc` and `.desc`. Do not rely on
+  `created_timestamp.desc` to surface the newest device_control policies — sort on
+  `precedence` or `enabled`, or order the results yourself.
 
 ## Example queries (each confirmed to return data)
 

--- a/tests/integration/cloud/test_cloud_assets.py
+++ b/tests/integration/cloud/test_cloud_assets.py
@@ -103,6 +103,28 @@ class TestCloudAssetsIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_cspm_assets with sort")
         self.assert_valid_list_response(result, min_length=0, context="search_cspm_assets with sort")
 
+    def test_search_cspm_assets_returns_rows_in_query_step_order(self):
+        """Hydrated assets come back in the order the query step reported them.
+
+        A reorder-contract test rather than a monotonicity one, because
+        `search_cspm_assets` has no strictly monotone sort field on this tenant — every
+        documented key (`updated_at`, `resource_type`, `region`, ...) ties across rows, so
+        an asc/desc comparison would tie-break unstably and flake.
+
+        The contract is load-bearing here: `cloud_security_assets_entities_get` returned a
+        different order than it was handed on 6 of 6 measured trials, so without the reorder
+        the tool's `sort` would be silently discarded on essentially every call.
+
+        Limit is 50 to stay under the 100-ID detail batch size, so the query step's order is
+        captured in a single request.
+        """
+        self.assert_rows_in_query_step_order(
+            self.module.search_cspm_assets,
+            id_field="id",
+            context="search_cspm_assets reorder contract",
+            limit=50,
+        )
+
     def test_search_cspm_assets_batching(self):
         """A limit above the 100-per-request detail batch size still returns every record.
 

--- a/tests/integration/cloud/test_cloud_iom.py
+++ b/tests/integration/cloud/test_cloud_iom.py
@@ -57,37 +57,47 @@ class TestCloudIomIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_iom_findings with sort")
         self.assert_valid_list_response(result, min_length=0, context="search_iom_findings with sort")
 
-    def test_iom_sort_keys_are_nested_under_evaluation(self):
-        """The `severity` sort key is not a top-level response field.
+    def test_iom_sort_keys_are_never_at_the_record_root(self):
+        """Every documented sort field reads back from a nested key, not the root.
 
-        `sort="severity.desc"` is valid, but the returned record has no top-level
-        `severity` — the value lives at `evaluation.severity`. A consumer that sorts by a
-        documented key and then reads that key off the record gets `None`, silently.
+        `sort="severity.desc"` is valid, but the returned record's root holds only
+        id/cid/cloud/cloud_groups/cloud_labels/evaluation/resource. A consumer that sorts by
+        a documented key and then reads that key off the record gets `None`, silently.
 
-        Pinned as a test because it is a schema fact the tool's own `sort` description does
-        not mention, and because it is the trap a sort-order test here would fall into: the
+        Pinned because the mapping is a schema fact the `sort` description has to state
+        correctly, and because it is the trap a sort-order test here would fall into: the
         obvious `[r["severity"] for r in rows]` raises KeyError rather than comparing
-        anything.
+        anything. The expected locations below are live-validated.
         """
+        expected_location = {
+            "severity": ("evaluation", "severity"),
+            "status": ("evaluation", "status"),
+            "first_detected": ("evaluation", "first_detected"),
+            "last_detected": ("evaluation", "last_detected"),
+            "cloud_provider": ("cloud", "provider"),
+            "service": ("resource", "service"),
+        }
+
         result = self.call_method(self.module.search_iom_findings, sort="severity.desc", limit=3)
         self.assert_no_error(result, context="search_iom_findings severity.desc")
         findings = self.skip_unless_tenant_has(result, "IOM findings", "iom sort key nesting")
-
         first = findings[0]
-        assert "severity" not in first, (
-            "`severity` is now a top-level IOM field. The sort key and response key agree, "
-            f"so this pin is obsolete — drop it. Keys: {sorted(first.keys())}"
-        )
 
-        evaluation = first.get("evaluation")
-        assert isinstance(evaluation, dict), (
-            f"Expected an `evaluation` dict holding the sort key; got {type(evaluation)}. "
-            f"Keys: {sorted(first.keys())}"
-        )
-        assert "severity" in evaluation, (
-            "`severity` is under neither the record root nor `evaluation`; the sort key has "
-            f"moved again. evaluation keys: {sorted(evaluation.keys())}"
-        )
+        for sort_field, (parent, key) in expected_location.items():
+            assert sort_field not in first, (
+                f"`{sort_field}` is now a root-level IOM field, so the sort description's "
+                f"nesting note is stale for it. Root keys: {sorted(first.keys())}"
+            )
+            block = first.get(parent)
+            assert isinstance(block, dict), (
+                f"Expected a `{parent}` dict to hold `{sort_field}`; got {type(block)}. "
+                f"Root keys: {sorted(first.keys())}"
+            )
+            assert key in block, (
+                f"Sort field `{sort_field}` is documented as reading from "
+                f"`{parent}.{key}`, but that key is absent. {parent} keys: "
+                f"{sorted(block.keys())}"
+            )
 
     def test_search_iom_findings_batching(self):
         """A limit above the 100-per-request detail batch size still returns every record.

--- a/tests/integration/cloud/test_cloud_iom.py
+++ b/tests/integration/cloud/test_cloud_iom.py
@@ -57,6 +57,38 @@ class TestCloudIomIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_iom_findings with sort")
         self.assert_valid_list_response(result, min_length=0, context="search_iom_findings with sort")
 
+    def test_iom_sort_keys_are_nested_under_evaluation(self):
+        """The `severity` sort key is not a top-level response field.
+
+        `sort="severity.desc"` is valid, but the returned record has no top-level
+        `severity` — the value lives at `evaluation.severity`. A consumer that sorts by a
+        documented key and then reads that key off the record gets `None`, silently.
+
+        Pinned as a test because it is a schema fact the tool's own `sort` description does
+        not mention, and because it is the trap a sort-order test here would fall into: the
+        obvious `[r["severity"] for r in rows]` raises KeyError rather than comparing
+        anything.
+        """
+        result = self.call_method(self.module.search_iom_findings, sort="severity.desc", limit=3)
+        self.assert_no_error(result, context="search_iom_findings severity.desc")
+        findings = self.skip_unless_tenant_has(result, "IOM findings", "iom sort key nesting")
+
+        first = findings[0]
+        assert "severity" not in first, (
+            "`severity` is now a top-level IOM field. The sort key and response key agree, "
+            f"so this pin is obsolete — drop it. Keys: {sorted(first.keys())}"
+        )
+
+        evaluation = first.get("evaluation")
+        assert isinstance(evaluation, dict), (
+            f"Expected an `evaluation` dict holding the sort key; got {type(evaluation)}. "
+            f"Keys: {sorted(first.keys())}"
+        )
+        assert "severity" in evaluation, (
+            "`severity` is under neither the record root nor `evaluation`; the sort key has "
+            f"moved again. evaluation keys: {sorted(evaluation.keys())}"
+        )
+
     def test_search_iom_findings_batching(self):
         """A limit above the 100-per-request detail batch size still returns every record.
 

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -91,6 +91,33 @@ class TestCasesIntegration(BaseIntegrationTest):
             result, min_length=0, context="search_cases with sort"
         )
 
+    def test_search_cases_sort_order_survives_hydration(self):
+        """The requested sort order survives the query -> get-by-IDs hydration step.
+
+        `entities_cases_post_v2` returns cases in an order unrelated to the query step's
+        (measured: a different order on 6 of 6 trials), so this is the sort assertion with
+        real teeth — `test_search_cases_with_sort` above only checks that the parameter is
+        accepted, which stays green even if hydration scrambles every row.
+
+        `created_timestamp` is the probe because it is strictly monotone in both directions
+        on this endpoint. Reach for it rather than a plausible-looking alternative:
+        `status`, `severity` and the other low-cardinality fields tie across rows here, and
+        a tied key tie-breaks unstably, which makes for a flaky test instead of a real one.
+        """
+        key = "created_timestamp"
+        ascending = self.call_method(self.module.search_cases, sort=f"{key}.asc", limit=20)
+        descending = self.call_method(self.module.search_cases, sort=f"{key}.desc", limit=20)
+
+        self.assert_no_error(ascending, context=f"search_cases {key}.asc")
+        self.assert_no_error(descending, context=f"search_cases {key}.desc")
+
+        self.assert_sort_orders_rows(
+            [case[key] for case in self._unwrap_results(ascending)],
+            [case[key] for case in self._unwrap_results(descending)],
+            key,
+            context="search_cases",
+        )
+
     def test_search_cases_with_q(self):
         """Test search_cases with free-text search."""
         result = self.call_method(

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -488,9 +488,17 @@ class TestCasesIntegration(BaseIntegrationTest):
         )
 
     def test_aggregate_bad_filter_returns_fql_guide(self):
-        """Test that an unsupported filter field surfaces the FQL guide."""
-        result = self._aggregate(
-            "aggregate_case_templates", field="name", filter="not_a_real_field:'x'"
+        """Test that an unsupported filter field surfaces the FQL guide.
+
+        Retried through `retry_on_transient` because the gateway intermittently returns an
+        unparseable body, which arrives as a list-shaped error and fails the isinstance
+        check below for a reason unrelated to filter handling.
+        """
+        result = self.retry_on_transient(
+            lambda: self._aggregate(
+                "aggregate_case_templates", field="name", filter="not_a_real_field:'x'"
+            ),
+            context="aggregate bad filter",
         )
 
         assert isinstance(result, dict), "filter error should return a dict"

--- a/tests/integration/test_data_protection.py
+++ b/tests/integration/test_data_protection.py
@@ -72,6 +72,70 @@ class TestDataProtectionIntegration(BaseIntegrationTest):
             result, min_length=0, context="search_data_protection_classifications with sort"
         )
 
+    def test_policy_precedence_sorts_ascending_but_not_descending(self):
+        """Backs the `sort` description's precedence caveat with a live check.
+
+        `precedence.asc` orders correctly (4 of 4 trials, 20 of 20 distinct values) while
+        `precedence.desc` does not (0 of 4). Both directions are pinned together so the
+        asymmetry is what fails if either half changes: if desc starts working, drop the
+        caveat from the `sort` description; if asc stops, the description is wrong the other
+        way.
+
+        Not a `_reorder_by_ids` concern — this endpoint's get step preserves the order it is
+        handed (0 of 4 trials scrambled), so the defect is in the API's own sort.
+        """
+        def precedences(direction: str) -> list:
+            result = self.call_method(
+                self.module.search_data_protection_policies,
+                platform_name="win",
+                sort=f"precedence.{direction}",
+                limit=20,
+            )
+            self.assert_no_error(result, context=f"dp policies precedence.{direction}")
+            return [p["precedence"] for p in self._unwrap_results(result)]
+
+        ascending = precedences("asc")
+        descending = precedences("desc")
+
+        assert len(ascending) > 1, (
+            f"Need 2+ win data-protection policies to compare order, got {len(ascending)}"
+        )
+        assert ascending == sorted(ascending), (
+            f"precedence.asc is no longer ascending, so the `sort` description's claim that "
+            f"ascending works is wrong: {ascending}"
+        )
+        assert descending != sorted(descending, reverse=True), (
+            "precedence.desc now returns correctly ordered results — the known defect is "
+            "fixed. Drop the caveat from the search_data_protection_policies `sort` "
+            f"description. Got: {descending}"
+        )
+
+    def test_content_pattern_name_sort_orders_neither_direction(self):
+        """Backs the `sort` description's name caveat with a live check.
+
+        `name` fails to order results in either direction (0 of 4 trials each way, with 20
+        of 20 distinct names, so this is an ordering defect rather than a tie-break). If
+        either direction starts working, drop the caveat from the `sort` description.
+
+        Not a `_reorder_by_ids` concern — this endpoint's get step preserves the order it is
+        handed (0 of 4 trials scrambled).
+        """
+        for direction in ("asc", "desc"):
+            result = self.call_method(
+                self.module.search_data_protection_content_patterns,
+                sort=f"name.{direction}",
+                limit=20,
+            )
+            self.assert_no_error(result, context=f"dp content patterns name.{direction}")
+            names = [p["name"] for p in self._unwrap_results(result)]
+
+            assert len(names) > 1, f"Need 2+ content patterns to compare order, got {len(names)}"
+            assert names != sorted(names, reverse=(direction == "desc")), (
+                f"name.{direction} now orders results correctly — the known defect is fixed. "
+                "Drop the caveat from the search_data_protection_content_patterns `sort` "
+                f"description. Got: {names}"
+            )
+
     # --- Policies ---
 
     def test_search_policies_windows(self):

--- a/tests/integration/test_detections.py
+++ b/tests/integration/test_detections.py
@@ -63,6 +63,33 @@ class TestDetectionsIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_detections with sort")
         self.assert_valid_list_response(result, min_length=0, context="search_detections with sort")
 
+    def test_search_detections_rows_in_query_step_order(self):
+        """Hydrated detections come back in the order the query step reported them.
+
+        A reorder-contract test rather than a monotonicity one, because no sort field on
+        this endpoint is strictly monotone in both directions on a live tenant:
+
+        - `updated_timestamp` is monotone ascending but reliably *not* descending (3 of 3
+          trials). The field mutates between the query step and hydration, so the newest
+          rows — the ones at the head of a descending page — come back carrying a timestamp
+          newer than the one they were sorted on. That is a race in the data, not in the
+          tool, and no assertion on the value can be made stable.
+        - `created_timestamp` is monotone in neither direction (3 of 3 trials each way, with
+          all 20 values distinct, so this is an ordering issue rather than a tie).
+        - `severity` and `status` tie across rows.
+
+        Asserting the reorder contract sidesteps all three: it compares IDs, which do not
+        mutate, so it is immune to both the update race and the API's ordering quirks while
+        still failing if the reorder is dropped. `PostEntitiesAlertsV2` scrambled the order
+        it was handed on 6 of 6 measured trials, so the contract is load-bearing.
+        """
+        self.assert_rows_in_query_step_order(
+            self.module.search_detections,
+            id_field="composite_id",
+            context="search_detections reorder contract",
+            limit=20,
+        )
+
     def test_get_detection_details_with_valid_id(self):
         """Test get_detection_details with a valid detection ID.
 

--- a/tests/integration/test_detections.py
+++ b/tests/integration/test_detections.py
@@ -66,22 +66,24 @@ class TestDetectionsIntegration(BaseIntegrationTest):
     def test_search_detections_rows_in_query_step_order(self):
         """Hydrated detections come back in the order the query step reported them.
 
-        A reorder-contract test rather than a monotonicity one, because no sort field on
-        this endpoint is strictly monotone in both directions on a live tenant:
+        A reorder-contract test rather than a monotonicity one, because no sort field here
+        is dependably monotone in both directions on a live tenant:
 
-        - `updated_timestamp` is monotone ascending but reliably *not* descending (3 of 3
-          trials). The field mutates between the query step and hydration, so the newest
-          rows — the ones at the head of a descending page — come back carrying a timestamp
-          newer than the one they were sorted on. That is a race in the data, not in the
-          tool, and no assertion on the value can be made stable.
-        - `created_timestamp` is monotone in neither direction (3 of 3 trials each way, with
-          all 20 values distinct, so this is an ordering issue rather than a tie).
+        - `created_timestamp.asc` is reliably non-monotone (0 of 8 trials), while
+          `created_timestamp.desc` is monotone whenever the tenant is quiet (5 of 5).
+        - `updated_timestamp` measured monotone both ways on an idle tenant (5 of 5 each),
+          but `.desc` collapsed to 0 of 3 while detections were actively being written.
+          `updated_timestamp` changes between the query step and hydration, so the newest
+          rows — the head of a descending page — come back carrying a timestamp newer than
+          the one they were sorted on.
         - `severity` and `status` tie across rows.
 
-        Asserting the reorder contract sidesteps all three: it compares IDs, which do not
-        mutate, so it is immune to both the update race and the API's ordering quirks while
-        still failing if the reorder is dropped. `PostEntitiesAlertsV2` scrambled the order
-        it was handed on 6 of 6 measured trials, so the contract is load-bearing.
+        So a value-based assertion here is a function of how busy the tenant is, which is
+        not something this test should be measuring. Comparing IDs instead sidesteps it:
+        IDs do not mutate, so the check is immune to the write race and to the API's
+        per-direction quirks while still failing if the reorder is dropped.
+        `PostEntitiesAlertsV2` scrambled the order it was handed on 6 of 6 measured trials,
+        so the contract is load-bearing.
         """
         self.assert_rows_in_query_step_order(
             self.module.search_detections,

--- a/tests/integration/test_policies.py
+++ b/tests/integration/test_policies.py
@@ -282,6 +282,101 @@ class TestPoliciesIntegration(BaseIntegrationTest):
             f"platform_name sort should be rejected by _validate_sort, got: {result}"
         )
 
+    def test_device_control_sort_direction_is_ignored_by_the_api(self):
+        """Pins a live API defect: queryDeviceControlPolicies ignores sort direction.
+
+        `created_timestamp.asc` and `created_timestamp.desc` return byte-identical ID lists,
+        both in ascending order, across 2 of 2 measured trials with 20 of 20 distinct
+        timestamps — so this is the direction being dropped, not a tie-break.
+
+        Isolated to the API, not to us: the query step returns the same order for both
+        directions, and the get step faithfully preserves whatever it is handed (measured:
+        0 of 4 trials scrambled). So `_reorder_by_ids` is not implicated, and
+        `search_policies` cannot be given a meaningful sort-order test — which is the
+        reason this pin exists. Without it, someone adds a monotonicity test here, it passes
+        against ascending data for either direction, and they conclude sort works.
+
+        A failure here most likely means the API was fixed. Replace this with a real
+        `assert_sort_orders_rows` test if so.
+        """
+        if not self._scopes_available("device_control"):
+            self.skip_with_warning(
+                "device_control scope unavailable", "device_control sort direction"
+            )
+            return
+
+        def ids_for(direction: str) -> list[str]:
+            result = self.call_method(
+                self.module.search_policies,
+                policy_type="device_control",
+                sort=f"created_timestamp.{direction}",
+                limit=20,
+            )
+            self.assert_no_error(result, context=f"device_control created_timestamp.{direction}")
+            return [policy["id"] for policy in self._unwrap_results(result)]
+
+        ascending, descending = ids_for("asc"), ids_for("desc")
+
+        if len(ascending) < 2:
+            self.skip_with_warning(
+                f"tenant has {len(ascending)} device_control policies, need 2+ to compare order",
+                "device_control sort direction",
+            )
+            return
+
+        assert ascending == descending, (
+            "queryDeviceControlPolicies now distinguishes sort direction — the known defect "
+            "this test pins appears to be fixed. Replace this with a real sort-order "
+            f"assertion.\n asc: {ascending}\ndesc: {descending}"
+        )
+
+    def test_device_control_rejects_pipe_sort_separator(self):
+        """Pins a gap: _validate_sort accepts `|`, but this endpoint rejects it.
+
+        `PoliciesModule._validate_sort` strips either a `.` or `|` direction suffix, so
+        `created_timestamp|desc` passes our guard and reaches the API, which answers HTTP
+        400 ("Query string parameter 'sort' is not an allowable value"). Every other policy
+        type accepts both separators.
+
+        The failure is loud rather than silent, so this is pinned rather than fixed: callers
+        get an error dict naming the problem, not wrong data. If the tool is ever changed to
+        reject `|` for device_control up front, this test should assert that instead.
+        """
+        if not self._scopes_available("device_control"):
+            self.skip_with_warning(
+                "device_control scope unavailable", "device_control pipe sort"
+            )
+            return
+
+        assert self.module._validate_sort("created_timestamp|desc") is None, (
+            "_validate_sort now rejects the pipe form up front; this test should assert "
+            "that guard instead of the API's 400."
+        )
+
+        result = self.call_method(
+            self.module.search_policies,
+            policy_type="device_control",
+            sort="created_timestamp|desc",
+            limit=5,
+        )
+
+        # A query-step 400 comes back through _format_fql_error_response, so the shape is
+        # the FQL-error envelope rather than a bare list.
+        assert isinstance(result, dict) and "fql_guide" in result, (
+            "queryDeviceControlPolicies now accepts the pipe separator — the known defect "
+            f"this test pins appears to be fixed. Got: {result}"
+        )
+
+        # Classify on the raw API message, not the composed one: handle_api_response
+        # prefixes every 400 with FQL boilerplate, so matching the composed string would
+        # match any bad request and this test would pass for the wrong reason.
+        errors = result["results"][0]["details"]["body"]["errors"]
+        raw_messages = [error.get("message", "") for error in errors]
+        assert any("sort" in message for message in raw_messages), (
+            "device_control returned a 400, but not about `sort` — this test is no longer "
+            f"pinning the pipe-separator defect. API messages: {raw_messages}"
+        )
+
     def test_members_returns_hosts(self):
         """search_policy_members returns host-shaped entities when a policy has members."""
         for policy_type in POLICY_TYPES:

--- a/tests/integration/test_policies.py
+++ b/tests/integration/test_policies.py
@@ -317,12 +317,13 @@ class TestPoliciesIntegration(BaseIntegrationTest):
 
         ascending, descending = ids_for("asc"), ids_for("desc")
 
-        if len(ascending) < 2:
-            self.skip_with_warning(
-                f"tenant has {len(ascending)} device_control policies, need 2+ to compare order",
-                "device_control sort direction",
-            )
-            return
+        # Fail rather than skip on too little data, matching assert_sort_orders_rows: with
+        # fewer than two policies `ascending == descending` is trivially true, so a skip here
+        # would quietly stop verifying both that the defect exists and that it was fixed.
+        assert len(ascending) > 1, (
+            f"Need 2+ device_control policies to compare sort order, got {len(ascending)}. "
+            "This pin cannot verify anything on a smaller dataset."
+        )
 
         assert ascending == descending, (
             "queryDeviceControlPolicies now distinguishes sort direction — the known defect "

--- a/tests/integration/test_policies.py
+++ b/tests/integration/test_policies.py
@@ -62,10 +62,20 @@ class TestPoliciesIntegration(BaseIntegrationTest):
     # ---- Helpers ----------------------------------------------------------------
 
     def _scopes_available(self, policy_type: str) -> bool:
-        """Return True if a search for the given type does not error on scope."""
+        """Return True if a search for the given type is not blocked by missing scope.
+
+        Retries through `retry_on_transient` first. Without that, an intermittent gateway
+        error reads as "scope unavailable" here, and every caller then skips — turning a
+        transient into a silent pass for whatever the test was supposed to verify. If the
+        error persists across retries, `retry_on_transient` fails rather than letting this
+        return a misleading False.
+        """
         result = self._unwrap_results(
-            self.call_method(
-                self.module.search_policies, policy_type=policy_type, limit=1
+            self.retry_on_transient(
+                lambda: self.call_method(
+                    self.module.search_policies, policy_type=policy_type, limit=1
+                ),
+                context=f"{policy_type} scope probe",
             )
         )
         if isinstance(result, dict) and "error" in result:
@@ -282,22 +292,26 @@ class TestPoliciesIntegration(BaseIntegrationTest):
             f"platform_name sort should be rejected by _validate_sort, got: {result}"
         )
 
-    def test_device_control_sort_direction_is_ignored_by_the_api(self):
-        """Pins a live API defect: queryDeviceControlPolicies ignores sort direction.
+    def test_device_control_timestamp_sorts_ignore_direction(self):
+        """Pins a live API defect: device_control timestamp sorts drop the direction.
 
         `created_timestamp.asc` and `created_timestamp.desc` return byte-identical ID lists,
-        both in ascending order, across 2 of 2 measured trials with 20 of 20 distinct
-        timestamps — so this is the direction being dropped, not a tie-break.
+        both ascending, across 5 of 5 measured trials with 20 of 20 distinct timestamps — so
+        the direction is being dropped, not tie-broken. `modified_timestamp` behaves the same
+        (3 of 3). The scope is deliberately narrow: `enabled` and `precedence` do vary with
+        direction on this type, and the other five policy types honor direction on
+        `created_timestamp`, so this is not a blanket "device_control ignores sort".
 
         Isolated to the API, not to us: the query step returns the same order for both
-        directions, and the get step faithfully preserves whatever it is handed (measured:
-        0 of 4 trials scrambled). So `_reorder_by_ids` is not implicated, and
-        `search_policies` cannot be given a meaningful sort-order test — which is the
-        reason this pin exists. Without it, someone adds a monotonicity test here, it passes
-        against ascending data for either direction, and they conclude sort works.
+        directions, and the get step preserves whatever it is handed (0 of 4 trials
+        scrambled). `_reorder_by_ids` is not implicated, and `search_policies` cannot be
+        given a meaningful sort-order test on these fields — which is why this pin exists.
+        Without it, someone adds a monotonicity test here, it passes against ascending data
+        for either direction, and concludes sort works.
 
-        A failure here most likely means the API was fixed. Replace this with a real
-        `assert_sort_orders_rows` test if so.
+        A failure here most likely means the API was fixed. If so, replace this with a real
+        `assert_sort_orders_rows` test and drop the matching caveat from the `sort`
+        description and the FQL guide.
         """
         if not self._scopes_available("device_control"):
             self.skip_with_warning(
@@ -305,78 +319,146 @@ class TestPoliciesIntegration(BaseIntegrationTest):
             )
             return
 
-        def ids_for(direction: str) -> list[str]:
+        def ids_for(field: str, direction: str) -> list[str]:
             result = self.call_method(
                 self.module.search_policies,
                 policy_type="device_control",
-                sort=f"created_timestamp.{direction}",
+                sort=f"{field}.{direction}",
                 limit=20,
             )
-            self.assert_no_error(result, context=f"device_control created_timestamp.{direction}")
+            self.assert_no_error(result, context=f"device_control {field}.{direction}")
             return [policy["id"] for policy in self._unwrap_results(result)]
 
-        ascending, descending = ids_for("asc"), ids_for("desc")
+        for field in ("created_timestamp", "modified_timestamp"):
+            ascending, descending = ids_for(field, "asc"), ids_for(field, "desc")
 
-        # Fail rather than skip on too little data, matching assert_sort_orders_rows: with
-        # fewer than two policies `ascending == descending` is trivially true, so a skip here
-        # would quietly stop verifying both that the defect exists and that it was fixed.
-        assert len(ascending) > 1, (
-            f"Need 2+ device_control policies to compare sort order, got {len(ascending)}. "
-            "This pin cannot verify anything on a smaller dataset."
-        )
-
-        assert ascending == descending, (
-            "queryDeviceControlPolicies now distinguishes sort direction — the known defect "
-            "this test pins appears to be fixed. Replace this with a real sort-order "
-            f"assertion.\n asc: {ascending}\ndesc: {descending}"
-        )
-
-    def test_device_control_rejects_pipe_sort_separator(self):
-        """Pins a gap: _validate_sort accepts `|`, but this endpoint rejects it.
-
-        `PoliciesModule._validate_sort` strips either a `.` or `|` direction suffix, so
-        `created_timestamp|desc` passes our guard and reaches the API, which answers HTTP
-        400 ("Query string parameter 'sort' is not an allowable value"). Every other policy
-        type accepts both separators.
-
-        The failure is loud rather than silent, so this is pinned rather than fixed: callers
-        get an error dict naming the problem, not wrong data. If the tool is ever changed to
-        reject `|` for device_control up front, this test should assert that instead.
-        """
-        if not self._scopes_available("device_control"):
-            self.skip_with_warning(
-                "device_control scope unavailable", "device_control pipe sort"
+            # Fail rather than skip on too little data, matching assert_sort_orders_rows:
+            # with fewer than two policies `ascending == descending` is trivially true, so a
+            # skip would quietly stop verifying both that the defect exists and that it was
+            # fixed.
+            assert len(ascending) > 1, (
+                f"Need 2+ device_control policies to compare sort order, got "
+                f"{len(ascending)}. This pin cannot verify anything on a smaller dataset."
             )
-            return
 
-        assert self.module._validate_sort("created_timestamp|desc") is None, (
-            "_validate_sort now rejects the pipe form up front; this test should assert "
-            "that guard instead of the API's 400."
-        )
+            assert ascending == descending, (
+                f"device_control now distinguishes sort direction for {field} — the known "
+                "defect this test pins appears to be fixed. Replace this with a real "
+                f"sort-order assertion.\n asc: {ascending}\ndesc: {descending}"
+            )
 
+    def test_pipe_sort_separator_is_rejected_for_every_type(self):
+        """The pipe direction separator is unusable on all six policy types.
+
+        Verifies the live behavior behind `_validate_sort`'s pipe guard. Every one of the
+        six query endpoints answers HTTP 400 ("Query string parameter 'sort' is not an
+        allowable value") for `created_timestamp|desc`, so the guard rejects it locally and
+        this test confirms the API still would.
+
+        Bypasses `search_policies` deliberately: the tool now short-circuits before the
+        request, so reaching the API means calling `_search_by_type` directly. If a type
+        starts accepting the pipe form, narrow the guard rather than leaving it blanket.
+        """
+        for policy_type in POLICY_TYPES:
+            if not self._scopes_available(policy_type):
+                self.skip_with_warning(
+                    f"{policy_type} policy scope unavailable", "pipe sort separator"
+                )
+                continue
+
+            result = self.retry_on_transient(
+                lambda pt=policy_type: self.module._search_by_type(
+                    pt, None, 5, None, "created_timestamp|desc"
+                ),
+                context=f"{policy_type} pipe sort",
+            )
+
+            # A query-step 400 comes back through _format_fql_error_response, so the shape
+            # is the FQL-error envelope rather than a bare list.
+            assert isinstance(result, dict) and "fql_guide" in result, (
+                f"{policy_type} now accepts the pipe sort separator. _validate_sort's "
+                f"blanket pipe rejection is too broad — narrow it. Got: {result}"
+            )
+
+            # Classify on the raw API message, not the composed one: handle_api_response
+            # prefixes every 400 with FQL boilerplate, so matching the composed string
+            # would match any bad request and this test would pass for the wrong reason.
+            errors = result["results"][0]["details"]["body"]["errors"]
+            raw_messages = [error.get("message", "") for error in errors]
+            assert any("sort" in message for message in raw_messages), (
+                f"{policy_type} returned a 400, but not about `sort` — this test is no "
+                f"longer pinning the pipe-separator behavior. API messages: {raw_messages}"
+            )
+
+    def test_pipe_sort_separator_rejected_before_the_request(self):
+        """`search_policies` rejects the pipe form locally, naming the dot form to use."""
         result = self.call_method(
             self.module.search_policies,
             policy_type="device_control",
             sort="created_timestamp|desc",
             limit=5,
         )
-
-        # A query-step 400 comes back through _format_fql_error_response, so the shape is
-        # the FQL-error envelope rather than a bare list.
-        assert isinstance(result, dict) and "fql_guide" in result, (
-            "queryDeviceControlPolicies now accepts the pipe separator — the known defect "
-            f"this test pins appears to be fixed. Got: {result}"
+        assert isinstance(result, list) and result and "error" in result[0], (
+            f"Expected a local validation error for the pipe form, got: {result}"
+        )
+        assert "created_timestamp.desc" in result[0]["error"], (
+            f"The error should name the dot form as the fix. Got: {result[0]['error']}"
         )
 
-        # Classify on the raw API message, not the composed one: handle_api_response
-        # prefixes every 400 with FQL boilerplate, so matching the composed string would
-        # match any bad request and this test would pass for the wrong reason.
-        errors = result["results"][0]["details"]["body"]["errors"]
-        raw_messages = [error.get("message", "") for error in errors]
-        assert any("sort" in message for message in raw_messages), (
-            "device_control returned a 400, but not about `sort` — this test is no longer "
-            f"pinning the pipe-separator defect. API messages: {raw_messages}"
-        )
+    def test_device_control_actor_sorts_return_500_on_the_api(self):
+        """Verifies the live behavior behind the per-type created_by/modified_by guard.
+
+        Both fields sort fine on the other five types but return HTTP 500 on
+        device_control (measured deterministic, 12 of 12 attempts). `_validate_sort` blocks
+        them for this type only, so this reaches the API directly to confirm the underlying
+        defect is still there — if it is fixed, drop the guard and this test.
+        """
+        if not self._scopes_available("device_control"):
+            self.skip_with_warning(
+                "device_control scope unavailable", "device_control actor sorts"
+            )
+            return
+
+        for field in ("created_by", "modified_by"):
+            result = self.retry_on_transient(
+                lambda f=field: self.module._search_by_type(
+                    "device_control", None, 5, None, f"{f}.desc"
+                ),
+                context=f"device_control {field} sort",
+            )
+            records = self._unwrap_results(result)
+            assert isinstance(records, list) and records and "error" in records[0], (
+                f"device_control sort by {field} no longer errors — the guard in "
+                f"_validate_sort can be dropped for this field. Got: {result}"
+            )
+            status = records[0].get("details", {}).get("status_code")
+            assert status == 500, (
+                f"device_control sort by {field} failed with status {status}, not the 500 "
+                f"this guard exists for. Re-check whether the guard is still right."
+            )
+
+    def test_device_control_actor_sorts_rejected_before_the_request(self):
+        """`search_policies` blocks created_by/modified_by for device_control only."""
+        for field in ("created_by", "modified_by"):
+            blocked = self.call_method(
+                self.module.search_policies,
+                policy_type="device_control",
+                sort=f"{field}.desc",
+                limit=5,
+            )
+            assert isinstance(blocked, list) and blocked and "error" in blocked[0], (
+                f"Expected a local validation error for device_control {field}, got: {blocked}"
+            )
+
+            if not self._scopes_available("prevention"):
+                continue
+            allowed = self.call_method(
+                self.module.search_policies,
+                policy_type="prevention",
+                sort=f"{field}.desc",
+                limit=5,
+            )
+            self.assert_no_error(allowed, context=f"prevention {field}.desc")
 
     def test_members_returns_hosts(self):
         """search_policy_members returns host-shaped entities when a policy has members."""

--- a/tests/integration/test_recon.py
+++ b/tests/integration/test_recon.py
@@ -139,6 +139,33 @@ class TestReconIntegration(BaseIntegrationTest):
         )
         self.assert_no_error(result, context="search_recon_rules filter=status:'active'")
 
+    def test_search_recon_rules_sort_order_survives_hydration(self):
+        """The requested sort order survives the QueryRulesV1 -> GetRulesV1 hydration step.
+
+        `GetRulesV1` returns rules in an order unrelated to the query step's (measured: a
+        different order on 6 of 6 trials), so without this the sort could be scrambled on
+        every call and the rest of this file would still pass.
+
+        `created_timestamp` is the probe because it is strictly monotone in both directions
+        here. `priority` and `topic` — the other documented sort keys — tie across rows on
+        this tenant, and a tied key tie-breaks unstably, so they would flake. The limit is
+        deliberately 8 rather than 20: the tenant holds few rules, and asking for more than
+        exist gives no extra coverage.
+        """
+        key = "created_timestamp"
+        ascending = self.call_method(self.module.search_recon_rules, sort=f"{key}.asc", limit=8)
+        descending = self.call_method(self.module.search_recon_rules, sort=f"{key}.desc", limit=8)
+
+        self.assert_no_error(ascending, context=f"search_recon_rules {key}.asc")
+        self.assert_no_error(descending, context=f"search_recon_rules {key}.desc")
+
+        self.assert_sort_orders_rows(
+            [rule[key] for rule in self._unwrap_results(ascending)],
+            [rule[key] for rule in self._unwrap_results(descending)],
+            key,
+            context="search_recon_rules",
+        )
+
     # ------------------------------------------------------------------
     # Exposed-data records
     # ------------------------------------------------------------------
@@ -190,6 +217,26 @@ class TestReconIntegration(BaseIntegrationTest):
         )
         self.assert_no_error(
             result, context="search_recon_exposed_data_records sort=created_date|desc"
+        )
+
+    def test_search_recon_exposed_data_records_rows_in_query_step_order(self):
+        """Hydrated records come back in the order the query step reported them.
+
+        A reorder-contract test rather than a monotonicity one: this endpoint has no
+        strictly monotone sort field on this tenant. Exposed-data records are created in
+        bulk per notification, so `created_date` and `exposure_date` both repeat heavily
+        (measured: 3 distinct `created_date` values across 8 rows, and 1 distinct
+        `exposure_date`), and a tied key tie-breaks unstably. Asserting the reorder contract
+        instead keeps the guard without the flakiness.
+
+        The contract is load-bearing here: `GetNotificationsExposedDataRecordsV1` returned a
+        different order than it was handed on 5 of 6 measured trials.
+        """
+        self.assert_rows_in_query_step_order(
+            self.module.search_recon_exposed_data_records,
+            id_field="id",
+            context="search_recon_exposed_data_records reorder contract",
+            limit=8,
         )
 
     # ------------------------------------------------------------------

--- a/tests/integration/test_recon.py
+++ b/tests/integration/test_recon.py
@@ -85,15 +85,14 @@ class TestReconIntegration(BaseIntegrationTest):
         self.assert_no_error(result, context="search_recon_notifications sort=created_date|desc")
 
     def test_notification_sort_keys_are_nested_under_notification(self):
-        """The `created_date` sort key is not a top-level response field.
+        """Both documented sort fields read back from `notification.<field>`, not the root.
 
-        `sort="created_date.desc"` is valid, but a notification record has only `id` and
-        `notification` at the root — the value lives at `notification.created_date`. A
-        consumer that sorts by a documented key and then reads that key off the record gets
-        `None`, silently.
+        `sort="created_date.desc"` is valid, but a notification record's root holds only
+        `id` and `notification`. A consumer that sorts by a documented key and then reads
+        that key off the record gets `None`, silently.
 
-        Pinned because it is a schema fact the tool's `sort` description does not mention,
-        and because it is why this tool gets no sort-order test: the obvious
+        Pinned because the mapping is a schema fact the `sort` description has to state
+        correctly, and because it is why this tool gets no sort-order test: the obvious
         `[r["created_date"] for r in rows]` raises KeyError instead of comparing anything.
         """
         result = self.call_method(
@@ -103,22 +102,24 @@ class TestReconIntegration(BaseIntegrationTest):
         records = self.skip_unless_tenant_has(
             result, "recon notifications", "notification sort key nesting"
         )
-
         first = records[0]
-        assert "created_date" not in first, (
-            "`created_date` is now a top-level notification field. The sort key and response "
-            f"key agree, so this pin is obsolete — drop it. Keys: {sorted(first.keys())}"
-        )
 
         notification = first.get("notification")
         assert isinstance(notification, dict), (
-            f"Expected a `notification` dict holding the sort key; got {type(notification)}. "
-            f"Keys: {sorted(first.keys())}"
+            f"Expected a `notification` dict to hold the sort keys; got {type(notification)}. "
+            f"Root keys: {sorted(first.keys())}"
         )
-        assert "created_date" in notification, (
-            "`created_date` is under neither the record root nor `notification`; the sort key "
-            f"has moved again. notification keys: {sorted(notification.keys())}"
-        )
+
+        for sort_field in ("created_date", "updated_date"):
+            assert sort_field not in first, (
+                f"`{sort_field}` is now a root-level field, so the sort description's "
+                f"nesting note is stale for it. Root keys: {sorted(first.keys())}"
+            )
+            assert sort_field in notification, (
+                f"Sort field `{sort_field}` is documented as reading from "
+                f"`notification.{sort_field}`, but that key is absent. notification keys: "
+                f"{sorted(notification.keys())}"
+            )
 
     def test_search_recon_notifications_with_q(self):
         """Test free-text q parameter."""

--- a/tests/integration/test_recon.py
+++ b/tests/integration/test_recon.py
@@ -84,6 +84,42 @@ class TestReconIntegration(BaseIntegrationTest):
         )
         self.assert_no_error(result, context="search_recon_notifications sort=created_date|desc")
 
+    def test_notification_sort_keys_are_nested_under_notification(self):
+        """The `created_date` sort key is not a top-level response field.
+
+        `sort="created_date.desc"` is valid, but a notification record has only `id` and
+        `notification` at the root — the value lives at `notification.created_date`. A
+        consumer that sorts by a documented key and then reads that key off the record gets
+        `None`, silently.
+
+        Pinned because it is a schema fact the tool's `sort` description does not mention,
+        and because it is why this tool gets no sort-order test: the obvious
+        `[r["created_date"] for r in rows]` raises KeyError instead of comparing anything.
+        """
+        result = self.call_method(
+            self.module.search_recon_notifications, sort="created_date.desc", limit=3
+        )
+        self.assert_no_error(result, context="search_recon_notifications created_date.desc")
+        records = self.skip_unless_tenant_has(
+            result, "recon notifications", "notification sort key nesting"
+        )
+
+        first = records[0]
+        assert "created_date" not in first, (
+            "`created_date` is now a top-level notification field. The sort key and response "
+            f"key agree, so this pin is obsolete — drop it. Keys: {sorted(first.keys())}"
+        )
+
+        notification = first.get("notification")
+        assert isinstance(notification, dict), (
+            f"Expected a `notification` dict holding the sort key; got {type(notification)}. "
+            f"Keys: {sorted(first.keys())}"
+        )
+        assert "created_date" in notification, (
+            "`created_date` is under neither the record root nor `notification`; the sort key "
+            f"has moved again. notification keys: {sorted(notification.keys())}"
+        )
+
     def test_search_recon_notifications_with_q(self):
         """Test free-text q parameter."""
         result = self.call_method(

--- a/tests/integration/utils/base_integration_test.py
+++ b/tests/integration/utils/base_integration_test.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import warnings
 from typing import Any, Callable, Optional
+from unittest.mock import patch
 
 import pytest
 from pydantic.fields import FieldInfo
@@ -125,6 +126,128 @@ class BaseIntegrationTest:
         assert (
             len(result) >= min_length
         ), f"Expected at least {min_length} items{ctx}, got {len(result)}"
+
+    def assert_sort_orders_rows(
+        self,
+        asc: list[Any],
+        desc: list[Any],
+        key: str,
+        context: str = "",
+    ) -> None:
+        """Assert an ascending/descending sort really ordered the rows.
+
+        This is the assertion that gives a two-step search tool's sort handling teeth. A
+        tool that forwards `sort` but then loses the order during hydration (the bug
+        `BaseModule._reorder_by_ids` exists to fix) still returns rows and still passes
+        `assert_no_error` — only comparing the actual key sequence catches it.
+
+        Both directions must be *strictly* monotone. Ties are treated as a failure rather
+        than tolerated, because a tied key tie-breaks unstably and would make the test
+        flaky; if this starts failing on ties, the field is no longer a valid probe and
+        the test should move to a different one rather than relax the assertion.
+
+        Args:
+            asc: The sort key's value for each row, from the ascending call.
+            desc: The same, from the descending call.
+            key: The sort field name, for error messages.
+            context: Optional context string for the error messages.
+        """
+        ctx = f" ({context})" if context else ""
+
+        # Too little data is a failure, not a skip: silently passing on one row is how a
+        # regression in the reorder path stays green forever.
+        assert len(asc) > 1, (
+            f"Need more than one row to test {key} ordering{ctx}, got {len(asc)}. "
+            "Either the tenant has no data for this query or the filter is too narrow."
+        )
+        assert len(desc) > 1, (
+            f"Need more than one row to test {key} ordering{ctx}, got {len(desc)}"
+        )
+
+        assert len(set(map(str, asc))) == len(asc), (
+            f"{key} has tied values{ctx}, so sort order is not deterministic and this "
+            f"test cannot distinguish a real ordering from a tie-break: {asc}"
+        )
+        assert len(set(map(str, desc))) == len(desc), (
+            f"{key} has tied values{ctx}: {desc}"
+        )
+
+        assert asc == sorted(asc), f"{key}.asc is not ascending{ctx}: {asc}"
+        assert desc == sorted(desc, reverse=True), f"{key}.desc is not descending{ctx}: {desc}"
+        assert asc != desc, (
+            f"{key}.asc and {key}.desc returned the same order{ctx}, so the sort "
+            f"direction was ignored: {asc}"
+        )
+
+    def assert_rows_in_query_step_order(
+        self,
+        method: Callable[..., Any],
+        id_field: str = "id",
+        context: str = "",
+        **kwargs: Any,
+    ) -> Any:
+        """Assert a two-step search returns rows in the order its query step reported.
+
+        This is the alternative to `assert_sort_orders_rows` for endpoints with no strictly
+        monotone sort field, where an asc/desc comparison would tie-break unstably. Rather
+        than checking a sort direction, it asserts `BaseModule._reorder_by_ids`' documented
+        contract directly: whatever order the query step returned IDs in, the hydrated
+        output preserves it. No monotonicity means no tie flakiness.
+
+        Spies on `_base_get_by_ids` because the query step's ID order is only observable
+        from inside a single tool invocation — by the time the tool returns, the reorder has
+        already happened (or failed to).
+
+        Args:
+            method: The bound search method to drive (e.g. `self.module.search_hosts`).
+            id_field: Key holding each row's ID in the response.
+            context: Optional context string for the error messages.
+            **kwargs: Passed to the search method; keep the limit at or under the tool's
+                detail batch size so the query step is captured in one request.
+
+        Returns:
+            The raw tool result, for further assertions.
+        """
+        ctx = f" ({context})" if context else ""
+        captured_id_batches: list[list[str]] = []
+        real_get_by_ids = self.module._base_get_by_ids
+
+        def spy(*args: Any, **spy_kwargs: Any) -> Any:
+            ids = spy_kwargs.get("ids")
+            captured_id_batches.append(list(ids) if ids is not None else [])
+            return real_get_by_ids(*args, **spy_kwargs)
+
+        with patch.object(self.module, "_base_get_by_ids", side_effect=spy):
+            result = self.call_method(method, **kwargs)
+
+        self.assert_no_error(result, context=context)
+        rows = self.skip_unless_tenant_has(result, "records", context)
+
+        assert len(captured_id_batches) == 1, (
+            f"Expected exactly one detail request{ctx}, got {len(captured_id_batches)}. "
+            "Lower the limit below the tool's batch size, or reassemble the query-step "
+            "order across batches before comparing."
+        )
+        query_order = captured_id_batches[0]
+        assert len(query_order) > 1, (
+            f"Need more than one ID to test ordering{ctx}, got {len(query_order)}"
+        )
+
+        returned_order = [row[id_field] for row in rows]
+        # IDs that did not hydrate are skipped rather than reordered, per the helper's
+        # contract, so compare against the query order restricted to what came back.
+        returned_set = set(returned_order)
+        expected_order = [
+            entity_id for entity_id in query_order if entity_id in returned_set
+        ]
+
+        assert returned_order == expected_order, (
+            f"Rows came back in an order that does not match the query step{ctx}. The "
+            "_reorder_by_ids call is missing, or reorders against the wrong list.\n"
+            f"query step: {query_order}\n"
+            f"returned:   {returned_order}"
+        )
+        return result
 
     def assert_search_returns_details(
         self,

--- a/tests/integration/utils/base_integration_test.py
+++ b/tests/integration/utils/base_integration_test.py
@@ -241,6 +241,15 @@ class BaseIntegrationTest:
             entity_id for entity_id in query_order if entity_id in returned_set
         ]
 
+        # Guard on the *intersection*, not the query count. If hydration only returned one
+        # row out of many queried, `expected_order` collapses to a single element and the
+        # comparison below is trivially true — a pass that checked nothing.
+        assert len(expected_order) > 1, (
+            f"Only {len(expected_order)} of {len(query_order)} queried IDs came back from "
+            f"hydration{ctx}, which is too few to verify ordering. The comparison would be "
+            "vacuous, so this fails rather than reporting success."
+        )
+
         assert returned_order == expected_order, (
             f"Rows came back in an order that does not match the query step{ctx}. The "
             "_reorder_by_ids call is missing, or reorders against the wrong list.\n"

--- a/tests/integration/utils/base_integration_test.py
+++ b/tests/integration/utils/base_integration_test.py
@@ -45,6 +45,17 @@ def resolve_field_defaults(method: Callable, kwargs: dict[str, Any]) -> dict[str
     return resolved_kwargs
 
 
+#: Error messages that mean the request never really reached the endpoint. FalconPy raises
+#: the bytes/get one when the gateway hands back a binary or truncated body instead of JSON;
+#: it surfaces as a 500-shaped error dict on any endpoint, has nothing to do with the request
+#: that triggered it, and clears on retry. Observed on ~1 in 8 long runs.
+TRANSIENT_API_ERROR_MARKERS = (
+    "'bytes' object has no attribute 'get'",
+    "Connection aborted",
+    "Connection reset by peer",
+)
+
+
 class BaseIntegrationTest:
     """Base class providing common assertions for integration tests.
 
@@ -126,6 +137,59 @@ class BaseIntegrationTest:
         assert (
             len(result) >= min_length
         ), f"Expected at least {min_length} items{ctx}, got {len(result)}"
+
+    def is_transient_api_error(self, result: Any) -> bool:
+        """True if `result` is a gateway/transport failure rather than a real API answer.
+
+        Tests that assert on a *specific* error (a 400 naming a bad parameter, say) need to
+        tell that apart from the gateway intermittently returning an unparseable body — the
+        latter arrives shaped like an error dict and would otherwise read as "the API gave
+        me the wrong error", failing the test for a reason that has nothing to do with the
+        behavior under test.
+        """
+        candidates = result if isinstance(result, list) else [result]
+        if isinstance(result, dict) and isinstance(result.get("results"), list):
+            candidates = result["results"]
+
+        for item in candidates:
+            if not isinstance(item, dict):
+                continue
+            blob = str(item.get("error", "")) + str(item.get("details", ""))
+            if any(marker in blob for marker in TRANSIENT_API_ERROR_MARKERS):
+                return True
+        return False
+
+    def retry_on_transient(
+        self,
+        call: Callable[[], Any],
+        attempts: int = 3,
+        context: str = "",
+    ) -> Any:
+        """Call `call`, retrying while the result is a transient gateway failure.
+
+        Fails rather than skips if every attempt is transient: the behavior under test went
+        unverified, and reporting that as a pass is how a real regression hides behind
+        infrastructure noise.
+        """
+        result = None
+        for attempt in range(1, attempts + 1):
+            result = call()
+            if not self.is_transient_api_error(result):
+                return result
+            # Reported via print rather than warnings.warn on purpose: skip_with_warning
+            # uses UserWarning, and suites run with `-W error::UserWarning` to prove no test
+            # went green by skipping. Routing retries through the same channel would make a
+            # retry indistinguishable from a skip.
+            print(
+                f"Transient API error on attempt {attempt}/{attempts}"
+                f"{f' ({context})' if context else ''}; retrying."
+            )
+
+        pytest.fail(
+            f"Every one of {attempts} attempts hit a transient gateway error"
+            f"{f' ({context})' if context else ''}, so the behavior under test could not be "
+            f"verified. Last result: {result}"
+        )
 
     def assert_sort_orders_rows(
         self,

--- a/tests/modules/test_policies.py
+++ b/tests/modules/test_policies.py
@@ -256,6 +256,63 @@ class TestPoliciesModule(TestModules):
         self.assertIn("error", result[0])
         self.assertEqual(self.mock_client.command.call_count, 0)
 
+    def test_search_pipe_sort_separator_rejected(self):
+        """The pipe direction separator is rejected before any API call.
+
+        All six policy query endpoints answer HTTP 400 for `field|desc` (live-validated),
+        so the guard catches it locally and the error names the dot form to use instead.
+        """
+        for policy_type in ("prevention", "device_control"):
+            with self.subTest(policy_type=policy_type):
+                self.mock_client.command.reset_mock()
+                result = self.module.search_policies(
+                    policy_type=policy_type,
+                    filter=None,
+                    limit=10,
+                    offset=0,
+                    sort="created_timestamp|desc",
+                )
+                self.assertIn("error", result[0])
+                self.assertIn("created_timestamp.desc", result[0]["error"])
+                self.assertEqual(self.mock_client.command.call_count, 0)
+
+    def test_search_device_control_rejects_actor_sort_fields(self):
+        """created_by/modified_by are rejected for device_control only.
+
+        Both return HTTP 500 on device_control (live-validated, 12 of 12 attempts) while
+        working normally on the other five types, so the guard is per-type rather than
+        removing them from the shared safe-field set.
+        """
+        for field in ("created_by", "modified_by"):
+            with self.subTest(field=field):
+                self.mock_client.command.reset_mock()
+                result = self.module.search_policies(
+                    policy_type="device_control",
+                    filter=None,
+                    limit=10,
+                    offset=0,
+                    sort=f"{field}.desc",
+                )
+                self.assertIn("error", result[0])
+                self.assertIn("device_control", result[0]["error"])
+                self.assertEqual(self.mock_client.command.call_count, 0)
+
+    def test_search_actor_sort_fields_allowed_for_other_types(self):
+        """created_by sorting still reaches the API for non-device_control types."""
+        self.mock_client.command.return_value = {
+            "status_code": 200,
+            "body": {"resources": [{"id": "pol-1"}]},
+        }
+        result = self.module.search_policies(
+            policy_type="prevention",
+            filter=None,
+            limit=10,
+            offset=0,
+            sort="created_by.desc",
+        )
+        self.assertNotIn("error", result)
+        self.assertGreater(self.mock_client.command.call_count, 0)
+
     def test_search_empty_returns_fql_guide(self):
         """Empty combined results include the FQL guide context."""
         self.mock_client.command.return_value = {

--- a/tests/modules/test_reorder_wiring.py
+++ b/tests/modules/test_reorder_wiring.py
@@ -5,23 +5,32 @@ arbitrary order, discarding the sort the query step applied. ``tests/modules/tes
 already covers the helper's own logic; what is untested is the *wiring* at each call site:
 whether a tool actually calls it, against the right ID list, with the right ``id_field``.
 
-Each case drives one tool with a stubbed query step (IDs ``a, b, c``) and a stubbed get
-step that returns the entities **reversed**, then asserts the tool's output comes back in
-``a, b, c`` order. That fails if a site drops the reorder call, passes the wrong
-``id_field``, or reorders against the wrong list.
+Each case drives one tool with a stubbed query step and a stubbed get step that returns the
+same entities in a different order, then asserts the tool's output comes back in the query
+step's order. That fails if a site drops the reorder call, passes the wrong ``id_field``, or
+reorders against the wrong list. See ``ORDERED_IDS`` for why those two specific orders — a
+naive ascending/reversed pair lets two plausible broken implementations pass.
 
-Deliberately out of scope: parameter forwarding. These tests patch the helpers that bracket
-the reorder call rather than ``client.command``, so they say nothing about which operation
-name or parameters a site sends. Per-module tests cover that.
+Deliberately out of scope: parameter forwarding. Most cases patch the helpers that bracket
+the reorder call rather than ``client.command`` (the four sites that bypass those helpers
+patch ``client.command`` directly, since that is the only seam they have), so these tests say
+nothing about which operation name or parameters a site sends. Per-module tests cover that.
 
-``test_table_covers_every_call_site`` re-derives the live call sites from the source with
-the same AST scan used to build the table, so a newly added site fails here until it gets a
-case — the same guard spirit as ``test_filter_hints_registry_covers_search_tools``.
+Three guards keep the table honest as the source changes:
+
+- ``test_table_covers_every_call_site`` re-derives the live call sites from the source with
+  an AST scan, so a newly added site fails here until it gets a case — the same guard spirit
+  as ``test_filter_hints_registry_covers_search_tools``.
+- ``test_each_site_has_exactly_one_reorder_call`` catches a second reorder call bolted onto
+  an already-covered function, which would otherwise hide behind the first.
+- ``test_reorder_is_only_ever_called_directly`` pins the convention that makes the AST scan
+  complete: aliasing the method before calling it would make a live site invisible.
 """
 
 import ast
 import inspect
 import pathlib
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -29,6 +38,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic.fields import FieldInfo
 
+import falcon_mcp
 from falcon_mcp.client import FalconClient
 from falcon_mcp.modules.agentworks import AgentworksModule
 from falcon_mcp.modules.cases import CasesModule
@@ -47,10 +57,25 @@ from falcon_mcp.modules.rtr import RTRModule
 from falcon_mcp.modules.scheduled_reports import ScheduledReportsModule
 from falcon_mcp.modules.zero_trust_assessment import ZeroTrustAssessmentModule
 
-MODULES_DIR = pathlib.Path("falcon_mcp/modules")
+# Derived from the installed package rather than the process CWD, so the guards scan the
+# real tree no matter where pytest is invoked from.
+REPO_ROOT = pathlib.Path(falcon_mcp.__file__).resolve().parent.parent
+MODULES_DIR = REPO_ROOT / "falcon_mcp" / "modules"
 
-#: The IDs the stubbed query step reports, in the order the caller asked for.
-ORDERED_IDS = ["a", "b", "c"]
+#: The IDs the stubbed query step reports, in the order the caller asked for — and therefore
+#: the order every tool's output must come back in.
+#:
+#: Deliberately NOT in sorted order, and ``HYDRATED_IDS`` below is deliberately not its
+#: reverse. With an ascending expected order and a merely-reversed get step, a reorder that
+#: ignored ``ordered_ids`` entirely and just sorted entities by ID — or just reversed
+#: whatever list it was handed — would produce the expected answer and pass every case while
+#: restoring nothing. Both of those mutations yield a wrong order against these two.
+ORDERED_IDS = ["beta", "delta", "alpha", "gamma"]
+
+#: The order the stubbed get-by-IDs step returns entities in, standing in for an endpoint
+#: that discards the query sort. Sorted, which differs from ``ORDERED_IDS``, from its
+#: reverse, and from a re-sort of itself.
+HYDRATED_IDS = sorted(ORDERED_IDS)
 
 #: A cloud asset record shaped so it survives the insight grouping/filtering in
 #: ``cloud_insights``: an asset whose ``cloud_context.insights.external`` has no
@@ -370,6 +395,13 @@ def _resolve_kwargs(method: Any, supplied: dict[str, Any]) -> dict[str, Any]:
                 f"{method.__qualname__} parameter {name!r} is required; "
                 "add it to the case's kwargs"
             )
+            # No module uses default_factory today. If one starts, `.default` is
+            # PydanticUndefined and would be passed through as a live value, so fail loudly
+            # rather than exercise the tool with a sentinel.
+            assert default.default_factory is None, (
+                f"{method.__qualname__} parameter {name!r} uses default_factory; resolve it "
+                "here the way FastMCP does instead of reading .default"
+            )
             resolved[name] = default.default
         elif default is not inspect.Parameter.empty:
             resolved[name] = default
@@ -435,18 +467,18 @@ def _drive(case: ReorderCase, entities: list[dict[str, Any]]) -> Any:
 def test_reorder_restores_query_step_order(case: ReorderCase) -> None:
     """The tool re-sorts hydrated entities back into the query step's ID order.
 
-    The stubbed get step hands back the entities reversed, mimicking a get-by-IDs endpoint
-    that ignores the requested sort. A correctly wired site undoes that.
+    The stubbed get step hands back the entities in ``HYDRATED_IDS`` order, mimicking a
+    get-by-IDs endpoint that ignores the requested sort. A correctly wired site undoes that.
     """
     entities = [
-        {case.id_field: entity_id, **case.entity_extra} for entity_id in reversed(ORDERED_IDS)
+        {case.id_field: entity_id, **case.entity_extra} for entity_id in HYDRATED_IDS
     ]
 
     rows = _extract_rows(_drive(case, entities))
 
     assert [row[case.output_key] for row in rows] == ORDERED_IDS, (
-        f"{case.tool} did not restore the query-step order; "
-        "the site is missing a _reorder_by_ids call or passes the wrong id_field"
+        f"{case.tool} did not restore the query-step order; the site is missing a "
+        "_reorder_by_ids call, passes the wrong id_field, or reorders against the wrong list"
     )
 
 
@@ -476,23 +508,43 @@ def test_policies_single_call_types_skip_reorder(policy_type: str) -> None:
     assert [row["id"] for row in _extract_rows(result)] == list(reversed(ORDERED_IDS))
 
 
-def _live_call_sites() -> set[tuple[str, str]]:
-    """Every ``(module file, enclosing method)`` that calls ``_reorder_by_ids``."""
-    sites: set[tuple[str, str]] = set()
+def _reorder_call_counts() -> dict[tuple[str, str], int]:
+    """Map every ``(module file, enclosing function)`` to its number of reorder calls.
+
+    Calls are attributed to their *nearest* enclosing function: nested functions get their
+    own entry rather than inflating the outer one, so a reorder call hidden inside a closure
+    still shows up as a site needing coverage.
+    """
+    counts: Counter[tuple[str, str]] = Counter()
+
     for path in sorted(MODULES_DIR.rglob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"))
+        rel = path.relative_to(REPO_ROOT).as_posix()
+
         for node in ast.walk(tree):
             if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
                 continue
-            for call in ast.walk(node):
+
+            # Walk this function's body but stop at nested function definitions, which
+            # ast.walk would otherwise fold into this function's count as well.
+            found = 0
+            stack = list(ast.iter_child_nodes(node))
+            while stack:
+                child = stack.pop()
+                if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                    continue
                 if (
-                    isinstance(call, ast.Call)
-                    and isinstance(call.func, ast.Attribute)
-                    and call.func.attr == "_reorder_by_ids"
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Attribute)
+                    and child.func.attr == "_reorder_by_ids"
                 ):
-                    sites.add((path.as_posix(), node.name))
-                    break
-    return sites
+                    found += 1
+                stack.extend(ast.iter_child_nodes(child))
+
+            if found:
+                counts[(rel, node.name)] = found
+
+    return dict(counts)
 
 
 def test_table_covers_every_call_site() -> None:
@@ -501,10 +553,65 @@ def test_table_covers_every_call_site() -> None:
     Derived from the source rather than a hardcoded count, so adding a call site without a
     case fails here and names the offender.
     """
-    live = _live_call_sites()
+    live = set(_reorder_call_counts())
     assert live, "found no _reorder_by_ids call sites — is the AST scan looking in the right place?"
 
     covered = {case.site for case in CASES}
 
     assert not live - covered, f"call sites with no wiring case: {sorted(live - covered)}"
-    assert not covered - live, f"cases pointing at call sites that no longer exist: {sorted(covered - live)}"
+    assert not covered - live, (
+        f"cases pointing at call sites that no longer exist: {sorted(covered - live)}"
+    )
+
+
+def test_each_site_has_exactly_one_reorder_call() -> None:
+    """No function calls ``_reorder_by_ids`` more than once.
+
+    The coverage guard keys on ``(file, function)``, so a second reorder call added to an
+    already-covered function would inherit the first one's case and never be exercised.
+    Rather than silently under-covering, fail and make the author split the function or
+    extend the table's shape to count calls per site.
+    """
+    multiples = {site: count for site, count in _reorder_call_counts().items() if count > 1}
+
+    assert not multiples, (
+        "these functions call _reorder_by_ids more than once, so the per-site wiring case "
+        f"only covers the first: {sorted(multiples.items())}"
+    )
+
+
+def test_reorder_is_only_ever_called_directly() -> None:
+    """``_reorder_by_ids`` is always invoked as a direct attribute call.
+
+    The coverage guard finds sites by AST-matching ``<obj>._reorder_by_ids(...)``. Binding
+    the method first (``fn = self._reorder_by_ids``) or reaching it by name
+    (``getattr(self, "_reorder_by_ids")``) would make a live call site invisible to that
+    scan, so this pins the convention that keeps the scan complete.
+    """
+    offenders: list[str] = []
+
+    for path in sorted(MODULES_DIR.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        tree = ast.parse(source)
+
+        in_call_position = {
+            id(node.func)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        offenders.extend(
+            f"{rel}:{node.lineno} binds _reorder_by_ids without calling it"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and node.attr == "_reorder_by_ids"
+            and id(node) not in in_call_position
+        )
+
+        if '"_reorder_by_ids"' in source or "'_reorder_by_ids'" in source:
+            offenders.append(f"{rel} references _reorder_by_ids by name string")
+
+    assert not offenders, (
+        "_reorder_by_ids must be called directly so the coverage guard can see the call "
+        f"site: {offenders}"
+    )

--- a/tests/modules/test_reorder_wiring.py
+++ b/tests/modules/test_reorder_wiring.py
@@ -1,0 +1,510 @@
+"""Per-call-site wiring tests for ``BaseModule._reorder_by_ids``.
+
+``_reorder_by_ids`` exists because "get entities by IDs" endpoints return resources in
+arbitrary order, discarding the sort the query step applied. ``tests/modules/test_base.py``
+already covers the helper's own logic; what is untested is the *wiring* at each call site:
+whether a tool actually calls it, against the right ID list, with the right ``id_field``.
+
+Each case drives one tool with a stubbed query step (IDs ``a, b, c``) and a stubbed get
+step that returns the entities **reversed**, then asserts the tool's output comes back in
+``a, b, c`` order. That fails if a site drops the reorder call, passes the wrong
+``id_field``, or reorders against the wrong list.
+
+Deliberately out of scope: parameter forwarding. These tests patch the helpers that bracket
+the reorder call rather than ``client.command``, so they say nothing about which operation
+name or parameters a site sends. Per-module tests cover that.
+
+``test_table_covers_every_call_site`` re-derives the live call sites from the source with
+the same AST scan used to build the table, so a newly added site fails here until it gets a
+case — the same guard spirit as ``test_filter_hints_registry_covers_search_tools``.
+"""
+
+import ast
+import inspect
+import pathlib
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic.fields import FieldInfo
+
+from falcon_mcp.client import FalconClient
+from falcon_mcp.modules.agentworks import AgentworksModule
+from falcon_mcp.modules.cases import CasesModule
+from falcon_mcp.modules.cloud.cloud import CloudModule
+from falcon_mcp.modules.custom_ioa import CustomIOAModule
+from falcon_mcp.modules.data_protection import DataProtectionModule
+from falcon_mcp.modules.detections import DetectionsModule
+from falcon_mcp.modules.exclusions import ExclusionsModule
+from falcon_mcp.modules.firewall import FirewallModule
+from falcon_mcp.modules.hosts import HostsModule
+from falcon_mcp.modules.ioc import IOCModule
+from falcon_mcp.modules.policies import PoliciesModule
+from falcon_mcp.modules.quarantine import QuarantineModule
+from falcon_mcp.modules.recon import ReconModule
+from falcon_mcp.modules.rtr import RTRModule
+from falcon_mcp.modules.scheduled_reports import ScheduledReportsModule
+from falcon_mcp.modules.zero_trust_assessment import ZeroTrustAssessmentModule
+
+MODULES_DIR = pathlib.Path("falcon_mcp/modules")
+
+#: The IDs the stubbed query step reports, in the order the caller asked for.
+ORDERED_IDS = ["a", "b", "c"]
+
+#: A cloud asset record shaped so it survives the insight grouping/filtering in
+#: ``cloud_insights``: an asset whose ``cloud_context.insights.external`` has no
+#: well-formed entry is dropped from the response entirely, which would mask a
+#: reorder regression as an empty result.
+CLOUD_INSIGHT_EXTRA: dict[str, Any] = {
+    "cloud_context": {"insights": {"external": [{"id": "insight-1", "stringValue": "v"}]}}
+}
+
+
+@dataclass(frozen=True)
+class ReorderCase:
+    """One ``_reorder_by_ids`` call site, and how to drive the tool that reaches it."""
+
+    tool: str
+    module_cls: type
+    method: str
+    id_field: str
+    site: tuple[str, str]
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    #: Key holding the entity's identity in the tool's *output*, when post-processing
+    #: renames it (cloud insights re-emits ``id`` as ``asset_id``).
+    out_id_field: str | None = None
+    #: Extra keys every fake entity carries, for sites that post-process entities.
+    entity_extra: dict[str, Any] = field(default_factory=dict)
+    #: Helper returning the query-step IDs. ``None`` for sites with no query step,
+    #: which reorder against caller-supplied IDs instead.
+    query_patch: str | None = "_base_search_with_meta"
+    #: Helper returning the hydrated entities.
+    get_patch: str = "_base_get_by_ids"
+    #: Extra attributes to patch on the module before calling the tool.
+    extra_patches: dict[str, Any] = field(default_factory=dict)
+    #: What the query step returns, when the endpoint hands back something other than
+    #: bare ID strings (Zero Trust Assessment returns ``{aid, score}`` records).
+    query_resources: list[Any] | None = None
+
+    @property
+    def output_key(self) -> str:
+        return self.out_id_field or self.id_field
+
+    def __str__(self) -> str:  # keeps pytest -k / IDs readable
+        suffix = "".join(f"[{v}]" for v in self.kwargs.values() if isinstance(v, str))
+        return f"{self.tool}{suffix}"
+
+
+CASES: list[ReorderCase] = [
+    # --- Standard two-step sites: _base_search_with_meta -> _base_get_by_ids ---
+    ReorderCase(
+        tool="falcon_search_hosts",
+        module_cls=HostsModule,
+        method="search_hosts",
+        id_field="device_id",
+        site=("falcon_mcp/modules/hosts.py", "search_hosts"),
+    ),
+    ReorderCase(
+        tool="falcon_search_detections",
+        module_cls=DetectionsModule,
+        method="search_detections",
+        id_field="composite_id",
+        site=("falcon_mcp/modules/detections.py", "search_detections"),
+    ),
+    ReorderCase(
+        tool="falcon_search_cases",
+        module_cls=CasesModule,
+        method="search_cases",
+        id_field="id",
+        site=("falcon_mcp/modules/cases.py", "search_cases"),
+    ),
+    ReorderCase(
+        tool="falcon_search_iocs",
+        module_cls=IOCModule,
+        method="search_iocs",
+        id_field="id",
+        site=("falcon_mcp/modules/ioc.py", "search_iocs"),
+    ),
+    ReorderCase(
+        tool="falcon_search_quarantined_files",
+        module_cls=QuarantineModule,
+        method="search_quarantined_files",
+        id_field="id",
+        site=("falcon_mcp/modules/quarantine.py", "search_quarantined_files"),
+    ),
+    ReorderCase(
+        tool="falcon_search_sessions",
+        module_cls=RTRModule,
+        method="search_sessions",
+        id_field="id",
+        site=("falcon_mcp/modules/rtr.py", "search_sessions"),
+    ),
+    ReorderCase(
+        tool="falcon_search_zta_assessments",
+        module_cls=ZeroTrustAssessmentModule,
+        method="search_zta_assessments",
+        id_field="aid",
+        # getAssessmentsByScoreV1 returns {aid, score} records, not bare IDs.
+        query_resources=[{"aid": entity_id, "score": 1} for entity_id in ORDERED_IDS],
+        site=("falcon_mcp/modules/zero_trust_assessment.py", "search_zta_assessments"),
+    ),
+    ReorderCase(
+        tool="falcon_search_firewall_rules",
+        module_cls=FirewallModule,
+        method="search_firewall_rules",
+        id_field="id",
+        site=("falcon_mcp/modules/firewall.py", "search_firewall_rules"),
+    ),
+    ReorderCase(
+        tool="falcon_search_firewall_rule_groups",
+        module_cls=FirewallModule,
+        method="search_firewall_rule_groups",
+        id_field="id",
+        site=("falcon_mcp/modules/firewall.py", "search_firewall_rule_groups"),
+    ),
+    ReorderCase(
+        tool="falcon_search_firewall_policy_rules",
+        module_cls=FirewallModule,
+        method="search_firewall_policy_rules",
+        id_field="id",
+        kwargs={"policy_id": "policy-1"},
+        site=("falcon_mcp/modules/firewall.py", "search_firewall_policy_rules"),
+    ),
+    ReorderCase(
+        tool="falcon_search_data_protection_classifications",
+        module_cls=DataProtectionModule,
+        method="search_data_protection_classifications",
+        id_field="id",
+        site=(
+            "falcon_mcp/modules/data_protection.py",
+            "search_data_protection_classifications",
+        ),
+    ),
+    ReorderCase(
+        tool="falcon_search_data_protection_policies",
+        module_cls=DataProtectionModule,
+        method="search_data_protection_policies",
+        id_field="id",
+        kwargs={"platform_name": "win"},
+        site=("falcon_mcp/modules/data_protection.py", "search_data_protection_policies"),
+    ),
+    ReorderCase(
+        tool="falcon_search_data_protection_content_patterns",
+        module_cls=DataProtectionModule,
+        method="search_data_protection_content_patterns",
+        id_field="id",
+        site=(
+            "falcon_mcp/modules/data_protection.py",
+            "search_data_protection_content_patterns",
+        ),
+    ),
+    ReorderCase(
+        tool="falcon_search_scheduled_reports",
+        module_cls=ScheduledReportsModule,
+        method="search_scheduled_reports",
+        id_field="id",
+        site=("falcon_mcp/modules/scheduled_reports.py", "search_scheduled_reports"),
+    ),
+    ReorderCase(
+        tool="falcon_search_report_executions",
+        module_cls=ScheduledReportsModule,
+        method="search_report_executions",
+        id_field="id",
+        site=("falcon_mcp/modules/scheduled_reports.py", "search_report_executions"),
+    ),
+    ReorderCase(
+        tool="falcon_search_recon_notifications",
+        module_cls=ReconModule,
+        method="search_recon_notifications",
+        id_field="id",
+        site=("falcon_mcp/modules/recon.py", "search_recon_notifications"),
+    ),
+    ReorderCase(
+        tool="falcon_search_recon_rules",
+        module_cls=ReconModule,
+        method="search_recon_rules",
+        id_field="id",
+        site=("falcon_mcp/modules/recon.py", "search_recon_rules"),
+    ),
+    ReorderCase(
+        tool="falcon_search_recon_exposed_data_records",
+        module_cls=ReconModule,
+        method="search_recon_exposed_data_records",
+        id_field="id",
+        site=("falcon_mcp/modules/recon.py", "search_recon_exposed_data_records"),
+    ),
+    # --- Discriminated site: one reorder call serves four exclusion types ---
+    *[
+        ReorderCase(
+            tool="falcon_search_exclusions",
+            module_cls=ExclusionsModule,
+            method="search_exclusions",
+            id_field="id",
+            kwargs={"exclusion_type": exclusion_type},
+            site=("falcon_mcp/modules/exclusions.py", "_search_by_type"),
+        )
+        for exclusion_type in ("ioa", "ml", "sensor_visibility", "certificate")
+    ],
+    # --- Discriminated site: only device_control takes the two-step reorder path.
+    # The other five policy types are pinned by test_policies_single_call_types_skip_reorder.
+    ReorderCase(
+        tool="falcon_search_policies",
+        module_cls=PoliciesModule,
+        method="search_policies",
+        id_field="id",
+        kwargs={"policy_type": "device_control"},
+        site=("falcon_mcp/modules/policies.py", "_search_by_type"),
+    ),
+    # --- Cloud sites. _batch_get_cspm_assets and _batch_get_iom_entities both route
+    # through _base_get_by_ids, so the standard get seam reaches them.
+    ReorderCase(
+        tool="falcon_search_cspm_assets",
+        module_cls=CloudModule,
+        method="search_cspm_assets",
+        id_field="id",
+        site=("falcon_mcp/modules/cloud/cloud_assets.py", "search_cspm_assets"),
+    ),
+    ReorderCase(
+        tool="falcon_search_iom_findings",
+        module_cls=CloudModule,
+        method="search_iom_findings",
+        id_field="id",
+        site=("falcon_mcp/modules/cloud/cloud_iom.py", "search_iom_findings"),
+    ),
+    ReorderCase(
+        tool="falcon_search_cloud_insights",
+        module_cls=CloudModule,
+        method="search_cloud_insights",
+        id_field="id",
+        out_id_field="asset_id",
+        entity_extra=CLOUD_INSIGHT_EXTRA,
+        # Skip the Policy Framework round-trip that builds the auto filter.
+        extra_patches={"_build_insight_filter": lambda _fql: ("insights.id:['x']", 1)},
+        site=("falcon_mcp/modules/cloud/cloud_insights.py", "search_cloud_insights"),
+    ),
+    # --- No query step: reorders against the caller's own ID list ---
+    ReorderCase(
+        tool="falcon_get_cloud_asset_insights",
+        module_cls=CloudModule,
+        method="get_cloud_asset_insights",
+        id_field="id",
+        out_id_field="asset_id",
+        kwargs={"asset_ids": ORDERED_IDS},
+        entity_extra=CLOUD_INSIGHT_EXTRA,
+        query_patch=None,
+        site=("falcon_mcp/modules/cloud/cloud_insights.py", "get_cloud_asset_insights"),
+    ),
+    # --- Sites whose query step is _base_search_api_call (no pagination tuple) ---
+    ReorderCase(
+        tool="falcon_list_case_templates",
+        module_cls=CasesModule,
+        method="list_case_templates",
+        id_field="id",
+        query_patch="_base_search_api_call",
+        site=("falcon_mcp/modules/cases.py", "list_case_templates"),
+    ),
+    ReorderCase(
+        tool="falcon_get_ioa_platforms",
+        module_cls=CustomIOAModule,
+        method="get_ioa_platforms",
+        id_field="id",
+        query_patch="_base_search_api_call",
+        site=("falcon_mcp/modules/custom_ioa.py", "get_ioa_platforms"),
+    ),
+    ReorderCase(
+        tool="falcon_get_ioa_rule_types",
+        module_cls=CustomIOAModule,
+        method="get_ioa_rule_types",
+        id_field="id",
+        query_patch="_base_search_api_call",
+        site=("falcon_mcp/modules/custom_ioa.py", "get_ioa_rule_types"),
+    ),
+    # --- Sites that bypass the base helpers and call client.command directly ---
+    ReorderCase(
+        tool="falcon_search_cspm_suppression_rules",
+        module_cls=CloudModule,
+        method="search_cspm_suppression_rules",
+        id_field="id",
+        query_patch="client.command",
+        get_patch="client.command",
+        site=("falcon_mcp/modules/cloud/cloud_iom.py", "search_cspm_suppression_rules"),
+    ),
+    # One reorder call in the shared _search_agentworks helper serves all three
+    # agentworks search tools; each public tool is driven so a wrapper cannot bypass it.
+    *[
+        ReorderCase(
+            tool=f"falcon_{method}",
+            module_cls=AgentworksModule,
+            method=method,
+            id_field="id",
+            query_patch="client.command",
+            get_patch="client.command",
+            site=("falcon_mcp/modules/agentworks.py", "_search_agentworks"),
+        )
+        for method in (
+            "search_agentworks_agents",
+            "search_agentworks_agent_versions",
+            "search_agentworks_spans",
+        )
+    ],
+]
+
+
+def _resolve_kwargs(method: Any, supplied: dict[str, Any]) -> dict[str, Any]:
+    """Build a full kwargs dict, resolving Pydantic ``Field`` defaults to real values.
+
+    Tool parameters default to ``FieldInfo`` objects, which FastMCP resolves at call time
+    but a direct Python call does not. Some sites do arithmetic on those values before the
+    patched helper is reached (``exclusions._clamp_limit`` on ``limit``), so leaving a
+    ``FieldInfo`` in place raises instead of exercising the reorder path.
+    """
+    resolved: dict[str, Any] = {}
+    for name, param in inspect.signature(method).parameters.items():
+        if name in supplied:
+            resolved[name] = supplied[name]
+            continue
+        default = param.default
+        if isinstance(default, FieldInfo):
+            assert not default.is_required(), (
+                f"{method.__qualname__} parameter {name!r} is required; "
+                "add it to the case's kwargs"
+            )
+            resolved[name] = default.default
+        elif default is not inspect.Parameter.empty:
+            resolved[name] = default
+        else:
+            raise AssertionError(
+                f"{method.__qualname__} parameter {name!r} has no default; "
+                "add it to the case's kwargs"
+            )
+    return resolved
+
+
+def _extract_rows(result: Any) -> list[dict[str, Any]]:
+    """Pull the ordered record list out of a tool result.
+
+    Search tools return the pagination envelope; a few sites return the reordered list
+    directly.
+    """
+    if isinstance(result, dict):
+        assert "results" in result, f"unexpected dict result: {sorted(result)}"
+        return result["results"]
+    assert isinstance(result, list), f"unexpected result type: {type(result)}"
+    return result
+
+
+def _api_response(resources: list[Any]) -> dict[str, Any]:
+    """A minimal successful FalconPy response body."""
+    return {"status_code": 200, "body": {"resources": resources}}
+
+
+def _drive(case: ReorderCase, entities: list[dict[str, Any]]) -> Any:
+    """Call the tool with its query step stubbed to ORDERED_IDS and its get step to
+    ``entities``, and return the raw tool result."""
+    module = case.module_cls(MagicMock(spec=FalconClient))
+    resources: list[Any] = case.query_resources if case.query_resources is not None else list(ORDERED_IDS)
+
+    for name, value in case.extra_patches.items():
+        setattr(module, name, value)
+
+    bound = getattr(module, case.method)
+    kwargs = _resolve_kwargs(bound, case.kwargs)
+
+    if case.query_patch == "client.command":
+        # Both steps go through client.command, in query-then-get order.
+        module.client.command = MagicMock(
+            side_effect=[_api_response(resources), _api_response(entities)]
+        )
+        return bound(**kwargs)
+
+    with patch.object(module, case.get_patch, return_value=entities):
+        if case.query_patch is None:
+            return bound(**kwargs)
+
+        if case.query_patch == "_base_search_with_meta":
+            query_return: Any = (resources, {"total": len(resources)})
+        else:
+            query_return = resources
+
+        with patch.object(module, case.query_patch, return_value=query_return):
+            return bound(**kwargs)
+
+
+@pytest.mark.parametrize("case", CASES, ids=str)
+def test_reorder_restores_query_step_order(case: ReorderCase) -> None:
+    """The tool re-sorts hydrated entities back into the query step's ID order.
+
+    The stubbed get step hands back the entities reversed, mimicking a get-by-IDs endpoint
+    that ignores the requested sort. A correctly wired site undoes that.
+    """
+    entities = [
+        {case.id_field: entity_id, **case.entity_extra} for entity_id in reversed(ORDERED_IDS)
+    ]
+
+    rows = _extract_rows(_drive(case, entities))
+
+    assert [row[case.output_key] for row in rows] == ORDERED_IDS, (
+        f"{case.tool} did not restore the query-step order; "
+        "the site is missing a _reorder_by_ids call or passes the wrong id_field"
+    )
+
+
+@pytest.mark.parametrize(
+    "policy_type", ["prevention", "sensor_update", "firewall", "response", "content_update"]
+)
+def test_policies_single_call_types_skip_reorder(policy_type: str) -> None:
+    """The five combined-op policy types never reach the get-by-IDs reorder path.
+
+    Only ``device_control`` is two-step, because its combined op has no V2 and drops
+    V2-only fields. The others get full objects from one call, so there is no query order
+    to restore — pinning that keeps a future refactor from quietly routing them through
+    hydration (or from making device_control single-call and losing its reorder).
+    """
+    module = PoliciesModule(MagicMock(spec=FalconClient))
+    combined = [{"id": entity_id} for entity_id in reversed(ORDERED_IDS)]
+
+    with (
+        patch.object(module, "_base_search_with_meta", return_value=(combined, {"total": 3})),
+        patch.object(module, "_base_get_by_ids") as mock_get,
+    ):
+        result = module.search_policies(
+            **_resolve_kwargs(module.search_policies, {"policy_type": policy_type})
+        )
+
+    mock_get.assert_not_called()
+    assert [row["id"] for row in _extract_rows(result)] == list(reversed(ORDERED_IDS))
+
+
+def _live_call_sites() -> set[tuple[str, str]]:
+    """Every ``(module file, enclosing method)`` that calls ``_reorder_by_ids``."""
+    sites: set[tuple[str, str]] = set()
+    for path in sorted(MODULES_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for call in ast.walk(node):
+                if (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "_reorder_by_ids"
+                ):
+                    sites.add((path.as_posix(), node.name))
+                    break
+    return sites
+
+
+def test_table_covers_every_call_site() -> None:
+    """Every ``_reorder_by_ids`` call site in the source has a wiring case.
+
+    Derived from the source rather than a hardcoded count, so adding a call site without a
+    case fails here and names the offender.
+    """
+    live = _live_call_sites()
+    assert live, "found no _reorder_by_ids call sites — is the AST scan looking in the right place?"
+
+    covered = {case.site for case in CASES}
+
+    assert not live - covered, f"call sites with no wiring case: {sorted(live - covered)}"
+    assert not covered - live, f"cases pointing at call sites that no longer exist: {sorted(covered - live)}"


### PR DESCRIPTION
`_reorder_by_ids` exists because Falcon's get-entities-by-ID endpoints hand resources back in whatever order they like, discarding the sort the query step asked for. Nothing verified it was actually wired up at any of its 29 call sites, so a regression of the bug it was written to fix would have gone straight through CI.

This adds a deterministic layer that drives every call site with a stubbed query step and a get step that returns entities in a different order, then asserts each tool puts them back. A guard derives the live call sites from the source, so a new one fails until it gets a case. There are also live tests on the endpoints where the reorder is provably load-bearing, either asserting a sort field is strictly monotone or comparing IDs against the query step's order where no field is stable enough to sort on.

A few problems surfaced along the way that aren't about the reorder, so they're fixed here too. `_validate_sort` was stripping a direction separator that all six policy query endpoints reject outright, and it let through two sort fields that return a 500 on device_control while working fine everywhere else. Both are rejected up front now, with a message naming the fix. `search_iom_findings` and `search_recon_notifications` both document sort fields whose values don't land where you would read them back from, so sorting by `severity` and then reading `severity` gives you `None`. The descriptions now say where those values actually are.

Last one, found while chasing an intermittent failure: `_scopes_available` treated any error as missing scope, so a transient gateway blip silently skipped whichever policy test happened to ask. Transients are identified and retried now, and fail loudly if they persist.

Closes #549
