### PR TITLE
fix(scripts): resolve operation names the doc scope scan could not see

### DIFF
--- a/docs/modules/exclusions.md
+++ b/docs/modules/exclusions.md
@@ -19,6 +19,8 @@ This module provides a unified set of tools for managing CrowdStrike exclusions 
 
 ### `falcon_search_exclusions`
 
+**Required scopes:** `IOA Exclusions:read`, `Machine Learning Exclusions:read`, `Sensor Visibility Exclusions:read`
+
 Search exclusions of a given type and return full exclusion records.
 
 Use this to find IOA, machine learning, sensor visibility, or
@@ -39,6 +41,8 @@ Responses include `pagination.total` (the total number of records matching the f
 > [!NOTE]
 > This tool modifies data.
 
+**Required scopes:** `IOA Exclusions:write`, `Machine Learning Exclusions:write`, `Sensor Visibility Exclusions:write`
+
 Create an exclusion of the given type.
 
 The `exclusion_type` selects which fields are required: 'ioa' needs name,
@@ -57,6 +61,8 @@ error before any API call. Returns the created exclusion record(s).
 > [!NOTE]
 > This tool modifies data.
 
+**Required scopes:** `IOA Exclusions:write`, `Machine Learning Exclusions:write`, `Sensor Visibility Exclusions:write`
+
 Update an existing exclusion of the given type.
 
 Provide the `id` of the exclusion plus the same fields used when creating
@@ -72,6 +78,8 @@ exclusion record(s).
 
 > [!CAUTION]
 > This tool performs destructive operations.
+
+**Required scopes:** `IOA Exclusions:write`, `Machine Learning Exclusions:write`, `Sensor Visibility Exclusions:write`
 
 Delete one or more exclusions of the given type.
 

--- a/docs/modules/policies.md
+++ b/docs/modules/policies.md
@@ -25,6 +25,8 @@ This module provides a unified set of tools for managing CrowdStrike host-based 
 
 ### `falcon_search_policies`
 
+**Required scopes:** `Content Update Policies:read`, `Device Control Policies:read`, `Firewall Management:read`, `Prevention Policies:read`, `Response Policies:read`, `Sensor Update Policies:read`
+
 Search host-based policies of a given type and return full policy records.
 
 Use this to find prevention, sensor update, firewall, device control,
@@ -43,6 +45,8 @@ Responses include `pagination.total` (the total number of records matching the f
 - "Find prevention policies whose name contains 'default'"
 
 ### `falcon_search_policy_members`
+
+**Required scopes:** `Content Update Policies:read`, `Device Control Policies:read`, `Firewall Management:read`, `Prevention Policies:read`, `Response Policies:read`, `Sensor Update Policies:read`
 
 Search for the host members governed by a specific policy.
 
@@ -66,6 +70,8 @@ Responses include `pagination.total` (the total number of records matching the f
 > [!NOTE]
 > This tool modifies data.
 
+**Required scopes:** `Content Update Policies:write`, `Device Control Policies:write`, `Firewall Management:write`, `Prevention Policies:write`, `Response Policies:write`, `Sensor Update Policies:write`
+
 Create a host-based policy of the given type.
 
 Provide a name and (for every type except content_update) a platform_name.
@@ -82,6 +88,8 @@ policies are created disabled. Returns the created policy record.
 
 > [!NOTE]
 > This tool modifies data.
+
+**Required scopes:** `Content Update Policies:write`, `Device Control Policies:write`, `Firewall Management:write`, `Prevention Policies:write`, `Response Policies:write`, `Sensor Update Policies:write`
 
 Update an existing host-based policy of the given type.
 
@@ -101,6 +109,8 @@ the updated policy record.
 > [!CAUTION]
 > This tool performs destructive operations.
 
+**Required scopes:** `Content Update Policies:write`, `Device Control Policies:write`, `Firewall Management:write`, `Prevention Policies:write`, `Response Policies:write`, `Sensor Update Policies:write`
+
 Delete one or more host-based policies of the given type.
 
 Provide the policy_type and a non-empty list of policy `ids`. A policy
@@ -118,6 +128,8 @@ the API response for the deletion.
 
 > [!NOTE]
 > This tool modifies data.
+
+**Required scopes:** `Content Update Policies:write`, `Device Control Policies:write`, `Firewall Management:write`, `Prevention Policies:write`, `Response Policies:write`, `Sensor Update Policies:write`
 
 Perform an action on one or more policies of the given type.
 
@@ -137,6 +149,8 @@ records.
 
 > [!NOTE]
 > This tool modifies data.
+
+**Required scopes:** `Content Update Policies:write`, `Device Control Policies:write`, `Firewall Management:write`, `Prevention Policies:write`, `Response Policies:write`, `Sensor Update Policies:write`
 
 Set the precedence (evaluation order) of policies for a platform.
 

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -961,6 +961,36 @@ def extract_module_scopes(module_cls: type) -> list[str]:
     return sorted(scopes, key=lambda s: (":write" in s, s))
 
 
+def _module_own_functions(module_name: str) -> dict[str, str]:
+    """Source of every plain function defined in one module's own file.
+
+    A tool can reach the API through a module-level function rather than a method —
+    ``hosts.py`` names ``UpdateDeviceTags`` only inside ``_tag_error``, and ``ngsiem.py``
+    names ``StartSearchV1`` inside ``_validate_repository``. Helper tracing keys on
+    ``self.<name>``, so a bare call is invisible to it.
+
+    Only functions defined in this very file are eligible. An imported one belongs to a
+    shared module that names operations from every module, so following it would attribute
+    unrelated scopes for the same reason BaseModule is excluded.
+    """
+    module = sys.modules.get(module_name)
+    if module is None:
+        return {}
+    functions: dict[str, str] = {}
+    for name, value in vars(module).items():
+        if not inspect.isfunction(value) or getattr(value, "__module__", None) != module_name:
+            continue
+        try:
+            functions[name] = inspect.getsource(value)
+        except (TypeError, OSError):
+            continue
+    return functions
+
+
+# A call to a bare name: `helper(...)`, but not `obj.helper(...)` or `def helper(...)`
+_BARE_CALL = re.compile(r"(?<![\w.])([A-Za-z_]\w*)\s*\(")
+
+
 def extract_tool_scopes(method: Any, module_cls: type) -> list[str]:
     """Derive API scopes for a single tool method by tracing its helper calls.
 
@@ -970,7 +1000,8 @@ def extract_tool_scopes(method: Any, module_cls: type) -> list[str]:
     only through another tool method needs the union of the scopes of everything it
     calls: ``agentworks.py``'s ``invoke_agentworks_agent`` polls
     ``get_agentworks_agent_invocation``, so it needs that operation's read scope on top
-    of its own write scope.
+    of its own write scope. Module-level functions defined in the same file are followed
+    too, since an operation named only inside one would otherwise be invisible.
     """
     try:
         method_source = inspect.getsource(method)
@@ -994,17 +1025,30 @@ def extract_tool_scopes(method: Any, module_cls: type) -> list[str]:
     # Walk the chain breadth-first, guarding against recursion. Match bare `self.name`
     # too, not just `self.name(`, so a method passed as a callable rather than called
     # directly is still followed.
-    chunks: list[tuple[str, str]] = [(method_source, getattr(method, "__module__", ""))]
-    seen: set[str] = set()
-    pending = re.findall(r"self\.(\w+)", method_source)
+    method_module = getattr(method, "__module__", "")
+    chunks: list[tuple[str, str]] = [(method_source, method_module)]
+    seen: set[tuple[str, str]] = set()
+    pending: list[tuple[str, str]] = [(name, method_module)
+                                      for name in re.findall(r"self\.(\w+)", method_source)]
+    pending += [(name, method_module) for name in _BARE_CALL.findall(method_source)]
     while pending:
-        helper_name = pending.pop()
-        if helper_name in seen or helper_name not in own_method_source:
+        helper_name, from_module = pending.pop()
+        if (helper_name, from_module) in seen:
             continue
-        seen.add(helper_name)
-        helper_source, helper_module = own_method_source[helper_name]
+        seen.add((helper_name, from_module))
+
+        if helper_name in own_method_source:
+            helper_source, helper_module = own_method_source[helper_name]
+        else:
+            # A plain function, resolved only against the file the caller was written in
+            helper_source = _module_own_functions(from_module).get(helper_name, "")
+            helper_module = from_module
+            if not helper_source:
+                continue
+
         chunks.append((helper_source, helper_module))
-        pending.extend(re.findall(r"self\.(\w+)", helper_source))
+        pending += [(name, helper_module) for name in re.findall(r"self\.(\w+)", helper_source)]
+        pending += [(name, helper_module) for name in _BARE_CALL.findall(helper_source)]
 
     # Find all string literals (and constant- or container-referenced operation names)
     # and look them up in API_SCOPE_REQUIREMENTS

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -15,6 +15,7 @@ import inspect
 import pkgutil
 import re
 import sys
+import textwrap
 from pathlib import Path
 from typing import Any
 
@@ -773,6 +774,10 @@ def _module_string_constants(module_name: str) -> dict[str, str]:
     the literal is absent and the tool silently documents no scopes at all. Resolving
     these constants first closes that hole for any module that factors its operation
     name out.
+
+    Annotated assignments (``NAME: str = "literal"``) count too — the annotation is
+    invisible at runtime but changes the AST node type, and missing that would reopen
+    the same hole for a module that spells its constant with a type.
     """
     module = sys.modules.get(module_name)
     if module is None:
@@ -784,15 +789,135 @@ def _module_string_constants(module_name: str) -> dict[str, str]:
 
     constants: dict[str, str] = {}
     for node in tree.body:
-        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
-            if isinstance(node.value.value, str):
-                for target in node.targets:
-                    if isinstance(target, ast.Name):
-                        constants[target.id] = node.value.value
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+        if not (isinstance(node.value, ast.Constant) and isinstance(node.value.value, str)):
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name):
+                constants[target.id] = node.value.value
     return constants
 
 
-def _operation_names_in(chunks: list[tuple[str, str]]) -> set[str]:
+def _class_literal_containers(module_cls: type) -> dict[str, Any]:
+    """Class-level attributes whose value is a pure literal, as real Python objects.
+
+    A module that dispatches on a discriminator keeps its operation names in a class
+    attribute rather than at a call site — ``policies.py`` and ``exclusions.py`` both
+    hold every operation in an ``_OPERATIONS`` dict and select one with
+    ``self._OPERATIONS[type]["verb"]``. Helper tracing only follows callables, so a dict
+    is skipped and none of those operation names is ever seen. Unlike module globals,
+    these really are class attributes, so the earliest definition in the MRO wins,
+    exactly as attribute lookup resolves it.
+    """
+    containers: dict[str, Any] = {}
+    for klass in _own_classes(module_cls):
+        try:
+            tree = ast.parse(textwrap.dedent(inspect.getsource(klass)))
+        except (TypeError, OSError, SyntaxError):
+            continue
+        if not (tree.body and isinstance(tree.body[0], ast.ClassDef)):
+            continue
+        for node in tree.body[0].body:
+            target: str | None = None
+            value: ast.expr | None = None
+            if isinstance(node, ast.Assign) and len(node.targets) == 1 \
+                    and isinstance(node.targets[0], ast.Name):
+                target, value = node.targets[0].id, node.value
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                target, value = node.target.id, node.value
+            if target is None or value is None or target in containers:
+                continue
+            try:
+                containers[target] = ast.literal_eval(value)
+            except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+                continue
+    return containers
+
+
+def _flatten_strings(obj: Any) -> set[str]:
+    """Every string reachable inside a nested literal container."""
+    if isinstance(obj, str):
+        return {obj}
+    if isinstance(obj, dict):
+        return set().union(*(_flatten_strings(v) for v in obj.values())) if obj else set()
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        return set().union(*(_flatten_strings(v) for v in obj)) if obj else set()
+    return set()
+
+
+# self.ATTR["key"] / self.ATTR[var] / self.ATTR[a]["b"] — one group per subscript level
+_SUBSCRIPT_CHAIN = re.compile(r"self\.(\w+)((?:\[[^\[\]]*\])+)")
+_SUBSCRIPT_LEVEL = re.compile(r"\[([^\[\]]*)\]")
+_QUOTED_KEY = re.compile(r"""^\s*(?:"([^"]*)"|'([^']*)')\s*$""")
+
+
+def _local_literal_values(source: str, name: str) -> set[str]:
+    """String literals assigned to ``name`` anywhere in ``source``.
+
+    Lets a variable subscript key narrow instead of widening to every entry:
+    ``op_key = "update" if is_update else "create"`` reaches only two of the verbs, so a
+    tool selecting ``[op_key]`` should not claim the scopes of the ones it cannot reach.
+    """
+    values: set[str] = set()
+    for match in re.finditer(rf"\b{re.escape(name)}\s*=(?!=)([^\n]*)", source):
+        values |= {
+            dq if dq else sq for dq, sq in re.findall(r'"([^"]*)"|\'([^\']*)\'', match.group(1))
+        }
+    return values
+
+
+def _container_ops_in(source: str, containers: dict[str, Any]) -> set[str]:
+    """Operation names reached by subscripting a class-level literal container.
+
+    A literal key narrows to that entry. A variable key is resolved against literals
+    assigned to that name in the same source, and only widens to every entry at the level
+    when that yields nothing usable — widening is the honest answer there, because the
+    tool really can call any of them depending on its argument.
+    """
+    names: set[str] = set()
+    for attr, subscripts in _SUBSCRIPT_CHAIN.findall(source):
+        if attr not in containers:
+            continue
+        level: list[Any] = [containers[attr]]
+        for raw_key in _SUBSCRIPT_LEVEL.findall(subscripts):
+            quoted = _QUOTED_KEY.match(raw_key)
+            keys: set[str] | None = None
+            if quoted:
+                keys = {quoted.group(1) if quoted.group(1) is not None else quoted.group(2)}
+            elif re.fullmatch(r"\s*[A-Za-z_]\w*\s*", raw_key):
+                candidates = _local_literal_values(source, raw_key.strip())
+                # Only trust the narrowing if it actually names entries at this level;
+                # otherwise those literals were something else and we must widen.
+                usable = {
+                    c
+                    for c in candidates
+                    for obj in level
+                    if isinstance(obj, dict) and c in obj
+                }
+                keys = usable or None
+            nxt: list[Any] = []
+            for obj in level:
+                if not isinstance(obj, dict):
+                    continue
+                if keys is None:
+                    nxt.extend(obj.values())
+                else:
+                    nxt.extend(obj[k] for k in keys if k in obj)
+            level = nxt
+        for obj in level:
+            names |= _flatten_strings(obj)
+    return names
+
+
+def _operation_names_in(
+    chunks: list[tuple[str, str]], containers: dict[str, Any] | None = None
+) -> set[str]:
     """Operation names referenced by each ``(source, defining module)`` chunk.
 
     A module assembled from mixins spreads its methods over several files, and each file
@@ -801,6 +926,9 @@ def _operation_names_in(chunks: list[tuple[str, str]]) -> set[str]:
     function reads its globals from where it was written rather than from its class's
     position in the MRO. Merging every file's constants into one map instead would let a
     same-named constant in a sibling mixin win and attribute the wrong operation.
+
+    ``containers`` carries the module's class-level literal containers, so an operation
+    selected out of a dict is found as well as one written inline.
     """
     names: set[str] = set()
     for source, module_name in chunks:
@@ -809,6 +937,8 @@ def _operation_names_in(chunks: list[tuple[str, str]]) -> set[str]:
         if constants:
             referenced = set(re.findall(r"\b([A-Za-z_]\w*)\b", source))
             names |= {constants[n] for n in referenced & constants.keys()}
+        if containers:
+            names |= _container_ops_in(source, containers)
     return names
 
 
@@ -821,7 +951,7 @@ def extract_module_scopes(module_cls: type) -> list[str]:
         except (TypeError, OSError):
             pass
 
-    all_strings = _operation_names_in(chunks)
+    all_strings = _operation_names_in(chunks, _class_literal_containers(module_cls))
     scopes: set[str] = set()
     for op_name, op_scopes in API_SCOPE_REQUIREMENTS.items():
         if op_name in all_strings:
@@ -876,9 +1006,9 @@ def extract_tool_scopes(method: Any, module_cls: type) -> list[str]:
         chunks.append((helper_source, helper_module))
         pending.extend(re.findall(r"self\.(\w+)", helper_source))
 
-    # Find all string literals (and constant-referenced operation names) and look
-    # them up in API_SCOPE_REQUIREMENTS
-    all_strings = _operation_names_in(chunks)
+    # Find all string literals (and constant- or container-referenced operation names)
+    # and look them up in API_SCOPE_REQUIREMENTS
+    all_strings = _operation_names_in(chunks, _class_literal_containers(module_cls))
     scopes: set[str] = set()
     for op_name, op_scopes in API_SCOPE_REQUIREMENTS.items():
         if op_name in all_strings:

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -742,45 +742,6 @@ def discover_module_classes() -> dict[str, dict[str, Any]]:
     return result
 
 
-def _module_string_constants(module_cls: type) -> dict[str, str]:
-    """Map the module-level ``NAME = "literal"`` assignments a module class can see.
-
-    Scope detection works by spotting operation-name string literals in the source. A
-    module may instead name its operation once in a module-level constant and reference
-    it by name at every call site, as ``agentworks.py`` does with ``_GET_INVOCATION_OP``.
-    `inspect.getsource` on the class, or on one method, never sees that assignment, so
-    the literal is absent and the tool silently documents no scopes at all. Resolving
-    these constants first closes that hole for any module that factors its operation
-    name out.
-    """
-    module = sys.modules.get(module_cls.__module__)
-    if module is None:
-        return {}
-    try:
-        tree = ast.parse(inspect.getsource(module))
-    except (TypeError, OSError, SyntaxError):
-        return {}
-
-    constants: dict[str, str] = {}
-    for node in tree.body:
-        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
-            if isinstance(node.value.value, str):
-                for target in node.targets:
-                    if isinstance(target, ast.Name):
-                        constants[target.id] = node.value.value
-    return constants
-
-
-def _operation_names_in(source: str, module_cls: type) -> set[str]:
-    """Operation names referenced by ``source``, as literals or via a constant."""
-    names = set(re.findall(r'["\'](\w+)["\']', source))
-    constants = _module_string_constants(module_cls)
-    if constants:
-        referenced = set(re.findall(r"\b([A-Za-z_]\w*)\b", source))
-        names |= {constants[n] for n in referenced & constants.keys()}
-    return names
-
-
 def _own_classes(module_cls: type) -> list[type]:
     """The MRO classes belonging to this module, stopping before BaseModule.
 
@@ -802,17 +763,65 @@ def _own_classes(module_cls: type) -> list[type]:
     return classes
 
 
+def _module_string_constants(module_name: str) -> dict[str, str]:
+    """Map the module-level ``NAME = "literal"`` assignments declared in one file.
+
+    Scope detection works by spotting operation-name string literals in the source. A
+    module may instead name its operation once in a module-level constant and reference
+    it by name at every call site, as ``agentworks.py`` does with ``_GET_INVOCATION_OP``.
+    `inspect.getsource` on the class, or on one method, never sees that assignment, so
+    the literal is absent and the tool silently documents no scopes at all. Resolving
+    these constants first closes that hole for any module that factors its operation
+    name out.
+    """
+    module = sys.modules.get(module_name)
+    if module is None:
+        return {}
+    try:
+        tree = ast.parse(inspect.getsource(module))
+    except (TypeError, OSError, SyntaxError):
+        return {}
+
+    constants: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, str):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        constants[target.id] = node.value.value
+    return constants
+
+
+def _operation_names_in(chunks: list[tuple[str, str]]) -> set[str]:
+    """Operation names referenced by each ``(source, defining module)`` chunk.
+
+    A module assembled from mixins spreads its methods over several files, and each file
+    may declare its own constants, so every chunk resolves against the module that
+    defines it — the same file Python resolves the reference against at runtime, since a
+    function reads its globals from where it was written rather than from its class's
+    position in the MRO. Merging every file's constants into one map instead would let a
+    same-named constant in a sibling mixin win and attribute the wrong operation.
+    """
+    names: set[str] = set()
+    for source, module_name in chunks:
+        names |= set(re.findall(r'["\'](\w+)["\']', source))
+        constants = _module_string_constants(module_name)
+        if constants:
+            referenced = set(re.findall(r"\b([A-Za-z_]\w*)\b", source))
+            names |= {constants[n] for n in referenced & constants.keys()}
+    return names
+
+
 def extract_module_scopes(module_cls: type) -> list[str]:
     """Derive API scopes by finding operation names in module source and looking them up in API_SCOPE_REQUIREMENTS."""
-    parts: list[str] = []
+    chunks: list[tuple[str, str]] = []
     for klass in _own_classes(module_cls):
         try:
-            parts.append(inspect.getsource(klass))
+            chunks.append((inspect.getsource(klass), klass.__module__))
         except (TypeError, OSError):
             pass
-    source = "\n".join(parts)
 
-    all_strings = _operation_names_in(source, module_cls)
+    all_strings = _operation_names_in(chunks)
     scopes: set[str] = set()
     for op_name, op_scopes in API_SCOPE_REQUIREMENTS.items():
         if op_name in all_strings:
@@ -838,23 +847,24 @@ def extract_tool_scopes(method: Any, module_cls: type) -> list[str]:
     except (TypeError, OSError):
         return []
 
-    # Build a map of method name → source from every class this module owns, so a mixin
-    # package resolves a helper that lives on a sibling mixin. Public methods are included
-    # too: a tool that reaches the API only through another tool method needs that
+    # Build a map of method name → (source, defining module) from every class this module
+    # owns, so a mixin package resolves a helper that lives on a sibling mixin. The module
+    # is carried alongside because each file resolves its own constants. Public methods are
+    # included too: a tool that reaches the API only through another tool method needs that
     # operation's scopes as well.
-    own_method_source: dict[str, str] = {}
+    own_method_source: dict[str, tuple[str, str]] = {}
     for klass in _own_classes(module_cls):
         for attr, val in klass.__dict__.items():
             if attr not in own_method_source and callable(val):
                 try:
-                    own_method_source[attr] = inspect.getsource(val)
+                    own_method_source[attr] = (inspect.getsource(val), klass.__module__)
                 except (TypeError, OSError):
                     pass
 
     # Walk the chain breadth-first, guarding against recursion. Match bare `self.name`
     # too, not just `self.name(`, so a method passed as a callable rather than called
     # directly is still followed.
-    combined_source = method_source
+    chunks: list[tuple[str, str]] = [(method_source, getattr(method, "__module__", ""))]
     seen: set[str] = set()
     pending = re.findall(r"self\.(\w+)", method_source)
     while pending:
@@ -862,13 +872,13 @@ def extract_tool_scopes(method: Any, module_cls: type) -> list[str]:
         if helper_name in seen or helper_name not in own_method_source:
             continue
         seen.add(helper_name)
-        helper_source = own_method_source[helper_name]
-        combined_source += "\n" + helper_source
+        helper_source, helper_module = own_method_source[helper_name]
+        chunks.append((helper_source, helper_module))
         pending.extend(re.findall(r"self\.(\w+)", helper_source))
 
     # Find all string literals (and constant-referenced operation names) and look
     # them up in API_SCOPE_REQUIREMENTS
-    all_strings = _operation_names_in(combined_source, module_cls)
+    all_strings = _operation_names_in(chunks)
     scopes: set[str] = set()
     for op_name, op_scopes in API_SCOPE_REQUIREMENTS.items():
         if op_name in all_strings:

--- a/tests/test_generate_module_docs.py
+++ b/tests/test_generate_module_docs.py
@@ -1,6 +1,10 @@
 """Tests for scripts/generate_module_docs.py."""
 
+import importlib
+import shutil
 import sys
+import tempfile
+import textwrap
 import types
 import unittest
 from pathlib import Path
@@ -519,14 +523,34 @@ class TestExtractToolScopes(unittest.TestCase):
         result = extract_tool_scopes(len, type("C", (), {}))
         self.assertEqual(result, [])
 
-    def test_traces_private_helper_on_class(self):
-        """Lines 690-695: helper defined on the class is included in scope extraction."""
+    def test_does_not_trace_basemodule_helpers(self):
+        """Helpers inherited from BaseModule contribute no scopes.
+
+        search_detections reaches the API through self._base_search_with_meta and
+        self._base_get_by_ids, both defined on BaseModule. BaseModule's source mentions
+        operation names belonging to every module, so tracing into it would attribute
+        unrelated scopes here. The assertion is exact: only the two operations named
+        inline in search_detections itself may contribute, and both map to Alerts:read.
+        """
         from falcon_mcp.modules.detections import DetectionsModule
-        # search_detections calls self._base_search_with_meta — defined on BaseModule,
-        # NOT in DetectionsModule.__dict__, so it should NOT be traced (by design).
-        # We verify the function runs without error and returns a list.
+
         result = extract_tool_scopes(DetectionsModule.search_detections, DetectionsModule)
-        self.assertIsInstance(result, list)
+        self.assertEqual(result, ["Alerts:read"])
+
+    def test_traces_helper_chain_on_own_class(self):
+        """A tool reaching the API only through a sibling method gets that method's scopes.
+
+        invoke_agentworks_agent writes, then polls get_agentworks_agent_invocation for
+        the result. Its own read scope therefore has to come from following that call,
+        whose operation name is itself held in a module-level constant.
+        """
+        from falcon_mcp.modules.agentworks import AgentworksModule
+
+        result = extract_tool_scopes(AgentworksModule.invoke_agentworks_agent, AgentworksModule)
+        self.assertEqual(
+            result,
+            ["Charlotte AI Agent Definition:read", "Charlotte AI Agent Definition:write"],
+        )
 
     def test_helper_getsource_failure_silently_skipped(self):
         """An OSError fetching a helper's source is skipped rather than raised.
@@ -552,6 +576,132 @@ class TestExtractToolScopes(unittest.TestCase):
         with patch.object(_inspect, "getsource", side_effect=fake_getsource):
             result = extract_tool_scopes(fake_method, cls)
         self.assertIsInstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# TestMixinDeclaredConstants — operation name behind a constant in a mixin file
+# ---------------------------------------------------------------------------
+
+class TestMixinDeclaredConstants(unittest.TestCase):
+    """A mixin may name its operation in a constant declared in the mixin's own file.
+
+    Scope detection has to read every file the module owns, and resolve each file's
+    constants against that file. No shipped module does this yet — the cloud mixins hold
+    only an FQL filter in a constant — so the fixtures are synthetic. They write real
+    files because inspect.getsource reads them off disk.
+    """
+
+    def _build(self, files: dict[str, str], root_module: str, class_name: str) -> type:
+        """Write files to a throwaway importable directory and return one of their classes."""
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, True)
+        for filename, source in files.items():
+            Path(tmpdir, filename).write_text(textwrap.dedent(source).lstrip())
+
+        # Scope detection resolves a class's constants through sys.modules, so the fixture
+        # has to be really imported. Unimport it again so the next test starts clean.
+        preexisting = set(sys.modules)
+
+        def _restore() -> None:
+            for name in set(sys.modules) - preexisting:
+                del sys.modules[name]
+            if tmpdir in sys.path:
+                sys.path.remove(tmpdir)
+
+        self.addCleanup(_restore)
+        sys.path.insert(0, tmpdir)
+        importlib.invalidate_caches()
+
+        return getattr(importlib.import_module(root_module), class_name)
+
+    def test_constant_declared_in_mixin_file_resolves(self):
+        """The operation name lives in the mixin's file, the concrete class is elsewhere."""
+        cls = self._build(
+            {
+                "t552a_mixin.py": '''
+                    """Mixin naming its operation once, in a module-level constant."""
+
+                    _T552A_OP = "QueryRule"  # requires Cloud Security Policies:read
+
+
+                    class T552AMixin:
+                        def _do_query(self):
+                            return self.client.command(_T552A_OP)
+                ''',
+                "t552a_concrete.py": '''
+                    """Concrete module assembled from the mixin."""
+
+                    from t552a_mixin import T552AMixin
+
+
+                    class T552AModule(T552AMixin):
+                        def my_tool(self):
+                            return self._do_query()
+                ''',
+            },
+            "t552a_concrete",
+            "T552AModule",
+        )
+
+        self.assertEqual(
+            extract_tool_scopes(cls.my_tool, cls),
+            ["Cloud Security Policies:read"],
+        )
+
+    def test_collision_resolves_against_the_method_s_own_file(self):
+        """Two mixin files declare the same constant name; the method's own file wins.
+
+        The method that reads the constant lives in the file holding the *second* value,
+        while an unrelated sibling earlier in the MRO happens to reuse the name. Python
+        resolves the reference through the defining module's globals, so the operation
+        really invoked is the second one. Anything that merges both files into a single
+        map picks by MRO position instead and reports the sibling's unrelated scope.
+        """
+        cls = self._build(
+            {
+                "t552b_first.py": '''
+                    """Earlier in the MRO, reusing the name for an unrelated operation."""
+
+                    _T552B_OP = "QueryRule"  # requires Cloud Security Policies:read
+
+
+                    class T552BFirst:
+                        def _unrelated(self):
+                            return self.client.command(_T552B_OP)
+                ''',
+                "t552b_second.py": '''
+                    """Later in the MRO, and the file that actually defines _do_query."""
+
+                    _T552B_OP = "QueryDevicesByFilter"  # requires Hosts:read
+
+
+                    class T552BSecond:
+                        def _do_query(self):
+                            return self.client.command(_T552B_OP)
+                ''',
+                "t552b_concrete.py": '''
+                    """Concrete module assembled from both mixins."""
+
+                    from t552b_first import T552BFirst
+                    from t552b_second import T552BSecond
+
+
+                    class T552BModule(T552BFirst, T552BSecond):
+                        def my_tool(self):
+                            return self._do_query()
+                ''',
+            },
+            "t552b_concrete",
+            "T552BModule",
+        )
+
+        # Guard the premise: confirm which operation Python itself reaches, so this test
+        # cannot drift into asserting the generator agrees with the wrong answer.
+        instance = cls.__new__(cls)
+        instance.client = types.SimpleNamespace(command=lambda op: op)
+        self.assertEqual(instance.my_tool(), "QueryDevicesByFilter")
+
+        self.assertEqual(extract_tool_scopes(cls.my_tool, cls), ["Hosts:read"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_generate_module_docs.py
+++ b/tests/test_generate_module_docs.py
@@ -579,6 +579,96 @@ class TestExtractToolScopes(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# TestClassContainerOperations — operation names held in a class-level dict
+# ---------------------------------------------------------------------------
+
+class TestClassContainerOperations(unittest.TestCase):
+    """Modules that dispatch on a discriminator keep their operations in a class dict.
+
+    `policies.py` and `exclusions.py` both hold every operation in an `_OPERATIONS`
+    class attribute and select one with `self._OPERATIONS[type]["verb"]`. A dict is not
+    callable, so helper tracing skips it, and every one of those tools documented no
+    scopes at all. These are real modules rather than fixtures because the bug is live.
+    """
+
+    def test_policies_tools_all_document_scopes(self):
+        from falcon_mcp.modules.policies import PoliciesModule
+
+        blank = [
+            name
+            for name in extract_registered_tool_names(PoliciesModule)
+            if not extract_tool_scopes(getattr(PoliciesModule, name), PoliciesModule)
+        ]
+        self.assertEqual(blank, [], f"policies tools documenting no scopes: {blank}")
+
+    def test_exclusions_tools_all_document_scopes(self):
+        from falcon_mcp.modules.exclusions import ExclusionsModule
+
+        blank = [
+            name
+            for name in extract_registered_tool_names(ExclusionsModule)
+            if not extract_tool_scopes(getattr(ExclusionsModule, name), ExclusionsModule)
+        ]
+        self.assertEqual(blank, [], f"exclusions tools documenting no scopes: {blank}")
+
+    def test_subscript_key_selects_only_that_verb(self):
+        """A literal subscript key narrows to that verb; it must not pull in every op.
+
+        falcon_delete_policies reaches `_OPERATIONS[policy_type]["delete"]`, so it needs
+        write scopes. It must not acquire a scope that only a *different* verb's endpoint
+        would need — resolving the whole container instead of the path would do that.
+        """
+        from falcon_mcp.modules.policies import PoliciesModule
+
+        scopes = extract_tool_scopes(PoliciesModule.delete_policies, PoliciesModule)
+        self.assertTrue(scopes, "delete_policies must document scopes")
+        self.assertEqual([s for s in scopes if s.endswith(":read")], [])
+        self.assertTrue(all(s.endswith(":write") for s in scopes), scopes)
+
+    def test_variable_subscript_key_narrows_to_its_assigned_literals(self):
+        """A variable key resolves through the literals assigned to it, not by widening.
+
+        create_policy and update_policy share _build_policy_body, which selects
+        `_OPERATIONS[policy_type][op_key]` where `op_key` is `"update" if is_update else
+        "create"`. Both are writes, so neither tool may claim a read scope; widening to
+        every verb at that level would hand them the query/get endpoints' read scopes and
+        over-state what a caller has to grant.
+        """
+        from falcon_mcp.modules.policies import PoliciesModule
+
+        for name in ("create_policy", "update_policy"):
+            scopes = extract_tool_scopes(getattr(PoliciesModule, name), PoliciesModule)
+            with self.subTest(tool=name):
+                self.assertTrue(scopes)
+                self.assertEqual([s for s in scopes if s.endswith(":read")], [])
+
+    def test_read_only_dispatching_tool_gets_no_write_scope(self):
+        """The converse: a search tool over the same container stays read-only."""
+        from falcon_mcp.modules.policies import PoliciesModule
+
+        scopes = extract_tool_scopes(PoliciesModule.search_policies, PoliciesModule)
+        self.assertTrue(scopes)
+        self.assertEqual([s for s in scopes if s.endswith(":write")], [])
+
+    def test_no_tool_in_any_module_documents_zero_scopes(self):
+        """Every registered tool in every module resolves to at least one scope.
+
+        A tool that reaches the API but documents nothing is the silent failure mode this
+        whole area keeps regressing into, so assert it globally rather than per module.
+        """
+        blank: list[str] = []
+        for key, info in discover_module_classes().items():
+            module_cls = info["cls"]
+            for name, tool_name in extract_registered_tool_names(module_cls).items():
+                method = getattr(module_cls, name, None)
+                if method is None:
+                    continue
+                if not extract_tool_scopes(method, module_cls):
+                    blank.append(f"{key}/falcon_{tool_name}")
+        self.assertEqual(sorted(blank), [], f"tools documenting no scopes: {sorted(blank)}")
+
+
+# ---------------------------------------------------------------------------
 # TestMixinDeclaredConstants — operation name behind a constant in a mixin file
 # ---------------------------------------------------------------------------
 

--- a/tests/test_generate_module_docs.py
+++ b/tests/test_generate_module_docs.py
@@ -794,6 +794,112 @@ class TestMixinDeclaredConstants(unittest.TestCase):
         self.assertEqual(extract_tool_scopes(cls.my_tool, cls), ["Hosts:read"])
 
 
+    def test_annotated_module_constant_resolves(self):
+        """A module constant spelled with a type annotation still resolves.
+
+        `NAME: str = "op"` is an ast.AnnAssign, a different node type from `NAME = "op"`,
+        though the annotation means nothing at runtime. Both _OPERATIONS dicts in the tree
+        are written this way, so missing the node type would reopen the blank-scope hole
+        for any module that types its constant.
+        """
+        cls = self._build(
+            {
+                "t552c_mixin.py": '''
+                    """Mixin whose operation constant carries a type annotation."""
+
+                    _T552C_OP: str = "QueryRule"  # requires Cloud Security Policies:read
+
+
+                    class T552CMixin:
+                        def _do_query(self):
+                            return self.client.command(_T552C_OP)
+                ''',
+                "t552c_concrete.py": '''
+                    """Concrete module assembled from the mixin."""
+
+                    from t552c_mixin import T552CMixin
+
+
+                    class T552CModule(T552CMixin):
+                        def my_tool(self):
+                            return self._do_query()
+                ''',
+            },
+            "t552c_concrete",
+            "T552CModule",
+        )
+
+        self.assertEqual(
+            extract_tool_scopes(cls.my_tool, cls),
+            ["Cloud Security Policies:read"],
+        )
+
+    def test_module_level_function_in_the_same_file_is_followed(self):
+        """A tool that reaches the API through a plain function, not a method.
+
+        `hosts.py` and `ngsiem.py` both name an operation inside a module-level helper
+        (`_tag_error`, `_validate_repository`) rather than a method. Helper tracing keys on
+        `self.<name>`, so a bare call is invisible; today those two are correct only
+        because the calling tool repeats the literal.
+        """
+        cls = self._build(
+            {
+                "t552d_mod.py": '''
+                    """Module whose operation name lives in a free function."""
+
+
+                    def _build_error():
+                        return {"operation": "QueryRule"}
+
+
+                    class T552DModule:
+                        def my_tool(self):
+                            return _build_error()
+                ''',
+            },
+            "t552d_mod",
+            "T552DModule",
+        )
+
+        self.assertEqual(
+            extract_tool_scopes(cls.my_tool, cls),
+            ["Cloud Security Policies:read"],
+        )
+
+    def test_imported_function_is_not_followed(self):
+        """A function imported from elsewhere contributes nothing.
+
+        Shared helpers live outside the module and mention operations belonging to other
+        modules, exactly like BaseModule. Following them would attribute unrelated scopes,
+        so only functions defined in the module's own file may be traced.
+        """
+        cls = self._build(
+            {
+                "t552e_shared.py": '''
+                    """Stands in for a shared helper module naming many operations."""
+
+
+                    def shared_helper():
+                        return {"operation": "QueryDevicesByFilter"}
+                ''',
+                "t552e_mod.py": '''
+                    """Module that only calls the shared helper."""
+
+                    from t552e_shared import shared_helper
+
+
+                    class T552EModule:
+                        def my_tool(self):
+                            return shared_helper()
+                ''',
+            },
+            "t552e_mod",
+            "T552EModule",
+        )
+
+        self.assertEqual(extract_tool_scopes(cls.my_tool, cls), [])
+
+
 # ---------------------------------------------------------------------------
 # TestExtractRegisteredToolNamesCoverage — nested paren depth (line 736)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #552 and closes #553, plus one more hole in the same scan that I hit while confirming them.

Scope detection only parsed the file holding the concrete module class, so an operation named in a constant declared in a mixin file resolved to nothing and the tool documented no scopes. Constants now resolve per defining file. Worth flagging that I didn't take the fix suggested in the issue: merging every owned class's constants into one map picks by MRO position, but a function reads its globals from the file it was written in, so a sibling mixin reusing the name for a different operation wins and you get a wrong scope instead of a blank one.

Chasing that down turned up something already live in the published docs. policies.py and exclusions.py dispatch on a discriminator and keep every operation in an _OPERATIONS dict, selected with self._OPERATIONS[type]["verb"]. Tracing only followed attributes that are callable, so the dict was skipped: all seven policies tools and four of the five exclusions tools shipped with no API scopes at all. Module-level scopes were fine, since those come from the whole class source, which is why the pages didn't look broken. Class-level literal containers are now resolved, with literal subscript keys narrowing so a delete-only tool doesn't inherit the query endpoints' read scopes, and variable keys resolving through the literals assigned to them so create and update don't pick up reads for verbs they can't reach.

Last one is dormant but the same shape: an operation named only inside a module-level function was invisible, because tracing keys on self.<name>. hosts.py names UpdateDeviceTags only in _tag_error, ngsiem.py names StartSearchV1 only in _validate_repository, and both are correct today purely because the calling tool repeats the literal. Own-file functions are now followed. Imported ones aren't, since shared helpers name operations from every module and would drag in unrelated scopes.

Only doc change is the scope lines for those eleven tools.
