### PR TITLE
docs(modules): document CrowdStrike-hosted MCP differences

### DIFF
--- a/docs/modules/agentworks.md
+++ b/docs/modules/agentworks.md
@@ -6,9 +6,6 @@
 
 Calling, listing, and observing CrowdStrike AgentWorks (agentic-studio) Charlotte AI agents and their execution traces
 
-> [!NOTE]
-> This module is not available on CrowdStrike's hosted Falcon MCP; it is only available when self-hosting this server. See [module overview](/falcon-mcp/modules/overview/#crowdstrike-hosted-mcp-differences).
-
 ## API Scopes
 
 - `Charlotte AI Agent Definition:read`

--- a/docs/modules/agentworks.md
+++ b/docs/modules/agentworks.md
@@ -6,6 +6,9 @@
 
 Calling, listing, and observing CrowdStrike AgentWorks (agentic-studio) Charlotte AI agents and their execution traces
 
+> [!NOTE]
+> This module is not available on CrowdStrike's hosted Falcon MCP; it is only available when self-hosting this server. See [module overview](/falcon-mcp/modules/overview/#crowdstrike-hosted-mcp-differences).
+
 ## API Scopes
 
 - `Charlotte AI Agent Definition:read`

--- a/docs/modules/cloud.md
+++ b/docs/modules/cloud.md
@@ -20,6 +20,9 @@ Accessing and analyzing CrowdStrike Falcon cloud resources like Kubernetes & Con
 
 ### `falcon_search_cloud_insights`
 
+> [!NOTE]
+> Not available on CrowdStrike's hosted Falcon MCP. See [module overview](/falcon-mcp/modules/overview/#crowdstrike-hosted-mcp-differences).
+
 **Required scopes:** `Cloud Security API Assets:read`, `Cloud Security Policies:read`
 
 Search for cloud security insights using FQL.
@@ -40,6 +43,9 @@ Responses include `pagination.total` and `pagination.next` for cursor-based pagi
 
 ### `falcon_get_cloud_asset_insights`
 
+> [!NOTE]
+> Not available on CrowdStrike's hosted Falcon MCP. See [module overview](/falcon-mcp/modules/overview/#crowdstrike-hosted-mcp-differences).
+
 **Required scopes:** `Cloud Security API Assets:read`
 
 Retrieve the full insight detail for one or more cloud ASSET IDs.
@@ -57,6 +63,9 @@ requested asset that has insight data.
 - "Why is this asset flagged — give me its full insight detail"
 
 ### `falcon_list_cloud_insight_definitions`
+
+> [!NOTE]
+> Not available on CrowdStrike's hosted Falcon MCP. See [module overview](/falcon-mcp/modules/overview/#crowdstrike-hosted-mcp-differences).
 
 **Required scopes:** `Cloud Security Policies:read`
 

--- a/docs/modules/discover.md
+++ b/docs/modules/discover.md
@@ -45,6 +45,9 @@ Responses include `pagination.total` (the total number of records matching the f
 
 ### `falcon_search_managed_assets`
 
+> [!NOTE]
+> Not available on CrowdStrike's hosted Falcon MCP. See [module overview](/falcon-mcp/modules/overview/#crowdstrike-hosted-mcp-differences).
+
 **Required scopes:** `Assets:read`
 
 Search hosts by asset and configuration posture: drive encryption status, encrypted/unencrypted drives, OS security settings (Secure Boot, Credential Guard, IOMMU), disk/memory/CPU usage, asset criticality, and internet exposure.

--- a/docs/modules/fusion.md
+++ b/docs/modules/fusion.md
@@ -6,6 +6,9 @@
 
 Searching Fusion SOAR workflow definitions and executions, reading what an execution produced, and running an on-demand workflow
 
+> [!NOTE]
+> This module is not available on CrowdStrike's hosted Falcon MCP; it is only available when self-hosting this server. See [module overview](/falcon-mcp/modules/overview/#crowdstrike-hosted-mcp-differences).
+
 ## API Scopes
 
 - `Workflows:read`

--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -41,9 +41,9 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 > [!NOTE]
 > This section compares this self-hosted server against CrowdStrike's hosted Falcon MCP. Skip it unless you also use the hosted MCP, or are moving between the two.
 
-The two servers differ in how a client reaches a tool. The hosted Falcon MCP works through discovery: a client calls `search_tools` to find a Falcon tool by name or keyword, then `execute_tool` to run it with arguments. This server registers each `falcon_*` tool up front instead, so a client calls one by name with no discovery round-trip.
+The two servers differ in how a client reaches a tool. The hosted Falcon MCP works through discovery: a client calls `search_tools` to find a Falcon tool by name or keyword, then `execute_tool` to run it with arguments. The self-hosted falcon-mcp server registers each `falcon_*` tool up front instead, so a client calls one by name with no discovery round-trip.
 
-If you self-host and want the same discovery pattern, enable [dynamic mode](/falcon-mcp/usage/dynamic-mode/): it swaps the full tool surface for `falcon_search_tools`, `falcon_execute_tool`, and an always-on `falcon_list_enabled_tools` inventory. Mind the `falcon_` prefix — those three are this server's tools, not the hosted MCP's.
+If you self-host and want the same discovery pattern, enable [dynamic mode](/falcon-mcp/usage/dynamic-mode/): it swaps the full tool surface for `falcon_search_tools`, `falcon_execute_tool`, and an always-on `falcon_list_enabled_tools` inventory. Mind the `falcon_` prefix — those three are the self-hosted falcon-mcp server's tools, not the hosted MCP's.
 
 Module and tool coverage also differs:
 

--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -47,7 +47,7 @@ If you self-host and want the same discovery pattern, enable [dynamic mode](/fal
 
 Module and tool coverage also differs:
 
-- [Fusion SOAR](/falcon-mcp/modules/fusion/) and [Zero Trust Assessment](/falcon-mcp/modules/zero-trust-assessment/) are available only on this self-hosted server; the hosted MCP has no equivalent modules.
+- [Fusion SOAR](/falcon-mcp/modules/fusion/), [Zero Trust Assessment](/falcon-mcp/modules/zero-trust-assessment/), and [Real Time Response](/falcon-mcp/modules/rtr/) are available only on this self-hosted server; the hosted MCP has no equivalent modules.
 - [Cloud Security](/falcon-mcp/modules/cloud/): `falcon_search_cloud_insights`, `falcon_list_cloud_insight_definitions`, and `falcon_get_cloud_asset_insights` are not available on the hosted MCP.
 - [Discover](/falcon-mcp/modules/discover/): `falcon_search_managed_assets` is not available on the hosted MCP.
 - [Policies](/falcon-mcp/modules/policies/): the hosted MCP does not use the unified `policy_type`-discriminated tools. It instead exposes six policy-type-specific variants of each tool (for example `falcon_search_policies_firewall`, `falcon_create_policy_prevention`).

--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -35,3 +35,17 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 | [Shield](/falcon-mcp/modules/shield/) | `SaaS Security:read`, `SaaS Security:write` | Shield module for CrowdStrike Falcon. |
 | [Spotlight](/falcon-mcp/modules/spotlight/) | `Vulnerabilities:read` | Accessing and managing CrowdStrike Falcon Spotlight vulnerabilities |
 | [Zero Trust Assessment](/falcon-mcp/modules/zero-trust-assessment/) | `Zero Trust Assessment:read` | Retrieving Zero Trust Assessment posture scores and sensor and OS hardening signals for hosts |
+
+## CrowdStrike-hosted MCP differences
+
+> [!NOTE]
+> This section compares this self-hosted server against CrowdStrike's hosted Falcon MCP. It does not apply if you're only running this server yourself.
+
+The hosted Falcon MCP does not register each `falcon_*` tool directly. Instead it exposes two tools, `search_tools` and `execute_tool`: a client calls `search_tools` to find the right Falcon tool by name or keyword, then `execute_tool` to invoke it by name with arguments. This server registers every `falcon_*` tool (and its `falcon://` resources) directly, so no discovery step is needed.
+
+Module and tool coverage also differs:
+
+- **AgentWorks**, **Fusion SOAR**, and **Zero Trust Assessment** are available only on this self-hosted server; the hosted MCP has no equivalent modules.
+- [Cloud Security](/falcon-mcp/modules/cloud/): `falcon_search_cloud_insights`, `falcon_list_cloud_insight_definitions`, and `falcon_get_cloud_asset_insights` are not yet available on the hosted MCP.
+- [Discover](/falcon-mcp/modules/discover/): `falcon_search_managed_assets` is not available on the hosted MCP.
+- [Policies](/falcon-mcp/modules/policies/): the hosted MCP does not use the unified `policy_type`-discriminated tools. It instead exposes six policy-type-specific variants of each tool (for example `falcon_search_policies_firewall`, `falcon_create_policy_prevention`).

--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -39,13 +39,15 @@ The Falcon MCP Server provides the following modules. Each module requires speci
 ## CrowdStrike-hosted MCP differences
 
 > [!NOTE]
-> This section compares this self-hosted server against CrowdStrike's hosted Falcon MCP. It does not apply if you're only running this server yourself.
+> This section compares this self-hosted server against CrowdStrike's hosted Falcon MCP. Skip it unless you also use the hosted MCP, or are moving between the two.
 
-The hosted Falcon MCP does not register each `falcon_*` tool directly. Instead it exposes two tools, `search_tools` and `execute_tool`: a client calls `search_tools` to find the right Falcon tool by name or keyword, then `execute_tool` to invoke it by name with arguments. This server registers every `falcon_*` tool (and its `falcon://` resources) directly, so no discovery step is needed.
+The two servers differ in how a client reaches a tool. The hosted Falcon MCP works through discovery: a client calls `search_tools` to find a Falcon tool by name or keyword, then `execute_tool` to run it with arguments. This server registers each `falcon_*` tool up front instead, so a client calls one by name with no discovery round-trip.
+
+If you self-host and want the same discovery pattern, enable [dynamic mode](/falcon-mcp/usage/dynamic-mode/): it swaps the full tool surface for `falcon_search_tools`, `falcon_execute_tool`, and an always-on `falcon_list_enabled_tools` inventory. Mind the `falcon_` prefix — those three are this server's tools, not the hosted MCP's.
 
 Module and tool coverage also differs:
 
-- **AgentWorks**, **Fusion SOAR**, and **Zero Trust Assessment** are available only on this self-hosted server; the hosted MCP has no equivalent modules.
-- [Cloud Security](/falcon-mcp/modules/cloud/): `falcon_search_cloud_insights`, `falcon_list_cloud_insight_definitions`, and `falcon_get_cloud_asset_insights` are not yet available on the hosted MCP.
+- [Fusion SOAR](/falcon-mcp/modules/fusion/) and [Zero Trust Assessment](/falcon-mcp/modules/zero-trust-assessment/) are available only on this self-hosted server; the hosted MCP has no equivalent modules.
+- [Cloud Security](/falcon-mcp/modules/cloud/): `falcon_search_cloud_insights`, `falcon_list_cloud_insight_definitions`, and `falcon_get_cloud_asset_insights` are not available on the hosted MCP.
 - [Discover](/falcon-mcp/modules/discover/): `falcon_search_managed_assets` is not available on the hosted MCP.
 - [Policies](/falcon-mcp/modules/policies/): the hosted MCP does not use the unified `policy_type`-discriminated tools. It instead exposes six policy-type-specific variants of each tool (for example `falcon_search_policies_firewall`, `falcon_create_policy_prevention`).

--- a/docs/modules/policies.md
+++ b/docs/modules/policies.md
@@ -6,6 +6,9 @@
 
 This module provides a unified set of tools for managing CrowdStrike host-based policies across all six policy types — prevention, sensor_update, firewall, device_control, response, and content_update — behind a single `policy_type` discriminator
 
+> [!NOTE]
+> CrowdStrike's hosted Falcon MCP does not use these unified, `policy_type`-discriminated tools. It instead exposes six policy-type-specific variants of each tool below, suffixed by type (`_prevention`, `_sensor_update`, `_firewall`, `_device_control`, `_response`, `_content_update`) with no `policy_type` parameter — for example `falcon_search_policies` here corresponds to `falcon_search_policies_firewall`, `falcon_search_policies_prevention`, etc. on the hosted MCP. See [module overview](/falcon-mcp/modules/overview/#crowdstrike-hosted-mcp-differences).
+
 ## API Scopes
 
 - `Content Update Policies:read`

--- a/docs/modules/rtr.md
+++ b/docs/modules/rtr.md
@@ -6,6 +6,9 @@
 
 Initiating and inspecting RTR sessions and for executing read-only RTR commands during host investigations
 
+> [!NOTE]
+> This module is not available on CrowdStrike's hosted Falcon MCP; it is only available when self-hosting this server. See [module overview](/falcon-mcp/modules/overview/#crowdstrike-hosted-mcp-differences).
+
 ## API Scopes
 
 - `Real time response:read`

--- a/docs/modules/zero-trust-assessment.md
+++ b/docs/modules/zero-trust-assessment.md
@@ -6,6 +6,9 @@
 
 Retrieving Zero Trust Assessment posture scores and sensor and OS hardening signals for hosts
 
+> [!NOTE]
+> This module is not available on CrowdStrike's hosted Falcon MCP; it is only available when self-hosting this server. See [module overview](/falcon-mcp/modules/overview/#crowdstrike-hosted-mcp-differences).
+
 ## API Scopes
 
 - `Zero Trust Assessment:read`

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -1445,9 +1445,9 @@ def generate_overview_page(modules: dict[str, dict[str, Any]]) -> str:
     lines.append(
         "The two servers differ in how a client reaches a tool. The hosted Falcon MCP works "
         "through discovery: a client calls `search_tools` to find a Falcon tool by name or "
-        "keyword, then `execute_tool` to run it with arguments. This server registers each "
-        "`falcon_*` tool up front instead, so a client calls one by name with no discovery "
-        "round-trip."
+        "keyword, then `execute_tool` to run it with arguments. The self-hosted falcon-mcp "
+        "server registers each `falcon_*` tool up front instead, so a client calls one by name "
+        "with no discovery round-trip."
     )
     lines.append("")
     lines.append(
@@ -1455,7 +1455,7 @@ def generate_overview_page(modules: dict[str, dict[str, Any]]) -> str:
         f"[dynamic mode]({SITE_BASE_PATH}/usage/dynamic-mode/): it swaps the full tool surface "
         "for `falcon_search_tools`, `falcon_execute_tool`, and an always-on "
         "`falcon_list_enabled_tools` inventory. Mind the `falcon_` prefix — those three are "
-        "this server's tools, not the hosted MCP's."
+        "the self-hosted falcon-mcp server's tools, not the hosted MCP's."
     )
     lines.append("")
     lines.append("Module and tool coverage also differs:")

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -77,14 +77,17 @@ MODULE_METADATA: dict[str, dict[str, Any]] = {
 
 _OVERVIEW_LINK = f"{SITE_BASE_PATH}/modules/overview/#crowdstrike-hosted-mcp-differences"
 
+
+def _module_link(module_key: str) -> str:
+    """Site URL for a module page, honoring any slug override in MODULE_METADATA."""
+    slug = MODULE_METADATA.get(module_key, {}).get("slug", module_key)
+    return f"{SITE_BASE_PATH}/modules/{slug}/"
+
+
 # Notes on differences from CrowdStrike's hosted Falcon MCP, rendered as an
 # admonition under the module description. Keyed by module_key. See
 # generate_overview_page for the summary of these differences.
 HOSTED_MCP_MODULE_NOTES: dict[str, str] = {
-    "agentworks": (
-        "This module is not available on CrowdStrike's hosted Falcon MCP; it is only "
-        f"available when self-hosting this server. See [module overview]({_OVERVIEW_LINK})."
-    ),
     "fusion": (
         "This module is not available on CrowdStrike's hosted Falcon MCP; it is only "
         f"available when self-hosting this server. See [module overview]({_OVERVIEW_LINK})."
@@ -1432,34 +1435,43 @@ def generate_overview_page(modules: dict[str, dict[str, Any]]) -> str:
     lines.append("> [!NOTE]")
     lines.append(
         "> This section compares this self-hosted server against CrowdStrike's hosted "
-        "Falcon MCP. It does not apply if you're only running this server yourself."
+        "Falcon MCP. Skip it unless you also use the hosted MCP, or are moving between the two."
     )
     lines.append("")
     lines.append(
-        "The hosted Falcon MCP does not register each `falcon_*` tool directly. Instead it "
-        "exposes two tools, `search_tools` and `execute_tool`: a client calls `search_tools` "
-        "to find the right Falcon tool by name or keyword, then `execute_tool` to invoke it by "
-        "name with arguments. This server registers every `falcon_*` tool (and its `falcon://` "
-        "resources) directly, so no discovery step is needed."
+        "The two servers differ in how a client reaches a tool. The hosted Falcon MCP works "
+        "through discovery: a client calls `search_tools` to find a Falcon tool by name or "
+        "keyword, then `execute_tool` to run it with arguments. This server registers each "
+        "`falcon_*` tool up front instead, so a client calls one by name with no discovery "
+        "round-trip."
+    )
+    lines.append("")
+    lines.append(
+        "If you self-host and want the same discovery pattern, enable "
+        f"[dynamic mode]({SITE_BASE_PATH}/usage/dynamic-mode/): it swaps the full tool surface "
+        "for `falcon_search_tools`, `falcon_execute_tool`, and an always-on "
+        "`falcon_list_enabled_tools` inventory. Mind the `falcon_` prefix — those three are "
+        "this server's tools, not the hosted MCP's."
     )
     lines.append("")
     lines.append("Module and tool coverage also differs:")
     lines.append("")
     lines.append(
-        "- **AgentWorks**, **Fusion SOAR**, and **Zero Trust Assessment** are available only "
+        f"- [Fusion SOAR]({_module_link('fusion')}) and "
+        f"[Zero Trust Assessment]({_module_link('zerotrustassessment')}) are available only "
         "on this self-hosted server; the hosted MCP has no equivalent modules."
     )
     lines.append(
-        f"- [Cloud Security]({SITE_BASE_PATH}/modules/cloud/): `falcon_search_cloud_insights`, "
+        f"- [Cloud Security]({_module_link('cloud')}): `falcon_search_cloud_insights`, "
         "`falcon_list_cloud_insight_definitions`, and `falcon_get_cloud_asset_insights` are not "
-        "yet available on the hosted MCP."
+        "available on the hosted MCP."
     )
     lines.append(
-        f"- [Discover]({SITE_BASE_PATH}/modules/discover/): `falcon_search_managed_assets` is "
+        f"- [Discover]({_module_link('discover')}): `falcon_search_managed_assets` is "
         "not available on the hosted MCP."
     )
     lines.append(
-        f"- [Policies]({SITE_BASE_PATH}/modules/policies/): the hosted MCP does not use the "
+        f"- [Policies]({_module_link('policies')}): the hosted MCP does not use the "
         "unified `policy_type`-discriminated tools. It instead exposes six policy-type-specific "
         "variants of each tool (for example `falcon_search_policies_firewall`, "
         "`falcon_create_policy_prevention`)."
@@ -1468,12 +1480,46 @@ def generate_overview_page(modules: dict[str, dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
+def validate_hosted_mcp_notes(modules: dict[str, dict[str, Any]]) -> None:
+    """Fail loudly when a hosted-MCP note key matches no module or no registered tool.
+
+    Both note dicts are keyed by name, so a module or tool rename silently drops the
+    note: the page regenerates without it, the committed docs match, and the docs
+    freshness check passes. Raise here instead so a rename is caught at generation time.
+    """
+    stale_modules = sorted(set(HOSTED_MCP_MODULE_NOTES) - set(modules))
+
+    known_tools = {
+        f"falcon_{registered}"
+        for mod_info in modules.values()
+        for registered in extract_registered_tool_names(mod_info["cls"]).values()
+    }
+    stale_tools = sorted(set(HOSTED_MCP_TOOL_NOTES) - known_tools)
+
+    problems = []
+    if stale_modules:
+        problems.append(
+            f"HOSTED_MCP_MODULE_NOTES keys match no discovered module: {', '.join(stale_modules)}"
+        )
+    if stale_tools:
+        problems.append(
+            f"HOSTED_MCP_TOOL_NOTES keys match no registered tool: {', '.join(stale_tools)}"
+        )
+    if problems:
+        raise ValueError(
+            "Stale hosted-MCP note keys in scripts/generate_module_docs.py. "
+            "Update or remove them after a rename:\n  " + "\n  ".join(problems)
+        )
+
+
 def main() -> None:
     """Generate all module documentation pages."""
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
     modules = discover_module_classes()
     print(f"Discovered {len(modules)} modules: {', '.join(sorted(modules.keys()))}")
+
+    validate_hosted_mcp_notes(modules)
 
     # Generate overview page
     overview = generate_overview_page(modules)

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -96,6 +96,10 @@ HOSTED_MCP_MODULE_NOTES: dict[str, str] = {
         "This module is not available on CrowdStrike's hosted Falcon MCP; it is only "
         f"available when self-hosting this server. See [module overview]({_OVERVIEW_LINK})."
     ),
+    "rtr": (
+        "This module is not available on CrowdStrike's hosted Falcon MCP; it is only "
+        f"available when self-hosting this server. See [module overview]({_OVERVIEW_LINK})."
+    ),
     "policies": (
         "CrowdStrike's hosted Falcon MCP does not use these unified, `policy_type`-discriminated "
         "tools. It instead exposes six policy-type-specific variants of each tool below, suffixed "
@@ -1457,9 +1461,10 @@ def generate_overview_page(modules: dict[str, dict[str, Any]]) -> str:
     lines.append("Module and tool coverage also differs:")
     lines.append("")
     lines.append(
-        f"- [Fusion SOAR]({_module_link('fusion')}) and "
-        f"[Zero Trust Assessment]({_module_link('zerotrustassessment')}) are available only "
-        "on this self-hosted server; the hosted MCP has no equivalent modules."
+        f"- [Fusion SOAR]({_module_link('fusion')}), "
+        f"[Zero Trust Assessment]({_module_link('zerotrustassessment')}), and "
+        f"[Real Time Response]({_module_link('rtr')}) are available only on this self-hosted "
+        "server; the hosted MCP has no equivalent modules."
     )
     lines.append(
         f"- [Cloud Security]({_module_link('cloud')}): `falcon_search_cloud_insights`, "

--- a/scripts/generate_module_docs.py
+++ b/scripts/generate_module_docs.py
@@ -75,6 +75,51 @@ MODULE_METADATA: dict[str, dict[str, Any]] = {
     },
 }
 
+_OVERVIEW_LINK = f"{SITE_BASE_PATH}/modules/overview/#crowdstrike-hosted-mcp-differences"
+
+# Notes on differences from CrowdStrike's hosted Falcon MCP, rendered as an
+# admonition under the module description. Keyed by module_key. See
+# generate_overview_page for the summary of these differences.
+HOSTED_MCP_MODULE_NOTES: dict[str, str] = {
+    "agentworks": (
+        "This module is not available on CrowdStrike's hosted Falcon MCP; it is only "
+        f"available when self-hosting this server. See [module overview]({_OVERVIEW_LINK})."
+    ),
+    "fusion": (
+        "This module is not available on CrowdStrike's hosted Falcon MCP; it is only "
+        f"available when self-hosting this server. See [module overview]({_OVERVIEW_LINK})."
+    ),
+    "zerotrustassessment": (
+        "This module is not available on CrowdStrike's hosted Falcon MCP; it is only "
+        f"available when self-hosting this server. See [module overview]({_OVERVIEW_LINK})."
+    ),
+    "policies": (
+        "CrowdStrike's hosted Falcon MCP does not use these unified, `policy_type`-discriminated "
+        "tools. It instead exposes six policy-type-specific variants of each tool below, suffixed "
+        "by type (`_prevention`, `_sensor_update`, `_firewall`, `_device_control`, `_response`, "
+        "`_content_update`) with no `policy_type` parameter — for example `falcon_search_policies` "
+        "here corresponds to `falcon_search_policies_firewall`, `falcon_search_policies_prevention`, "
+        f"etc. on the hosted MCP. See [module overview]({_OVERVIEW_LINK})."
+    ),
+}
+
+# Notes on tools not (yet) available on CrowdStrike's hosted Falcon MCP, rendered
+# as an admonition under the tool heading. Keyed by full tool name (falcon_*).
+HOSTED_MCP_TOOL_NOTES: dict[str, str] = {
+    "falcon_search_cloud_insights": (
+        f"Not available on CrowdStrike's hosted Falcon MCP. See [module overview]({_OVERVIEW_LINK})."
+    ),
+    "falcon_get_cloud_asset_insights": (
+        f"Not available on CrowdStrike's hosted Falcon MCP. See [module overview]({_OVERVIEW_LINK})."
+    ),
+    "falcon_list_cloud_insight_definitions": (
+        f"Not available on CrowdStrike's hosted Falcon MCP. See [module overview]({_OVERVIEW_LINK})."
+    ),
+    "falcon_search_managed_assets": (
+        f"Not available on CrowdStrike's hosted Falcon MCP. See [module overview]({_OVERVIEW_LINK})."
+    ),
+}
+
 # Natural language prompt examples for each tool, shown in generated docs
 TOOL_EXAMPLES: dict[str, list[str]] = {
     # AgentWorks
@@ -1279,6 +1324,12 @@ def generate_module_page(module_key: str, module_cls: type, auto_title: str, aut
     lines.append(description)
     lines.append("")
 
+    # Note on differences from CrowdStrike's hosted Falcon MCP, if any
+    if module_key in HOSTED_MCP_MODULE_NOTES:
+        lines.append("> [!NOTE]")
+        lines.append(f"> {HOSTED_MCP_MODULE_NOTES[module_key]}")
+        lines.append("")
+
     # API Scopes
     if scopes:
         lines.append("## API Scopes")
@@ -1297,6 +1348,12 @@ def generate_module_page(module_key: str, module_cls: type, auto_title: str, aut
 
             lines.append(f"### `{tool['name']}`")
             lines.append("")
+
+            # Note on hosted-MCP availability, if any
+            if tool["name"] in HOSTED_MCP_TOOL_NOTES:
+                lines.append("> [!NOTE]")
+                lines.append(f"> {HOSTED_MCP_TOOL_NOTES[tool['name']]}")
+                lines.append("")
 
             # Admonition for mutating/destructive tools
             if destructive:
@@ -1369,6 +1426,44 @@ def generate_overview_page(modules: dict[str, dict[str, Any]]) -> str:
         desc = meta.get("description", fallback_desc)
         lines.append(f"| [{title}]({SITE_BASE_PATH}/modules/{slug}/) | {scopes} | {desc} |")
 
+    lines.append("")
+    lines.append("## CrowdStrike-hosted MCP differences")
+    lines.append("")
+    lines.append("> [!NOTE]")
+    lines.append(
+        "> This section compares this self-hosted server against CrowdStrike's hosted "
+        "Falcon MCP. It does not apply if you're only running this server yourself."
+    )
+    lines.append("")
+    lines.append(
+        "The hosted Falcon MCP does not register each `falcon_*` tool directly. Instead it "
+        "exposes two tools, `search_tools` and `execute_tool`: a client calls `search_tools` "
+        "to find the right Falcon tool by name or keyword, then `execute_tool` to invoke it by "
+        "name with arguments. This server registers every `falcon_*` tool (and its `falcon://` "
+        "resources) directly, so no discovery step is needed."
+    )
+    lines.append("")
+    lines.append("Module and tool coverage also differs:")
+    lines.append("")
+    lines.append(
+        "- **AgentWorks**, **Fusion SOAR**, and **Zero Trust Assessment** are available only "
+        "on this self-hosted server; the hosted MCP has no equivalent modules."
+    )
+    lines.append(
+        f"- [Cloud Security]({SITE_BASE_PATH}/modules/cloud/): `falcon_search_cloud_insights`, "
+        "`falcon_list_cloud_insight_definitions`, and `falcon_get_cloud_asset_insights` are not "
+        "yet available on the hosted MCP."
+    )
+    lines.append(
+        f"- [Discover]({SITE_BASE_PATH}/modules/discover/): `falcon_search_managed_assets` is "
+        "not available on the hosted MCP."
+    )
+    lines.append(
+        f"- [Policies]({SITE_BASE_PATH}/modules/policies/): the hosted MCP does not use the "
+        "unified `policy_type`-discriminated tools. It instead exposes six policy-type-specific "
+        "variants of each tool (for example `falcon_search_policies_firewall`, "
+        "`falcon_create_policy_prevention`)."
+    )
     lines.append("")
     return "\n".join(lines)
 

--- a/tests/test_generate_module_docs.py
+++ b/tests/test_generate_module_docs.py
@@ -29,6 +29,7 @@ from scripts.generate_module_docs import (  # noqa: E402
     generate_module_page,
     generate_overview_page,
     main,
+    validate_hosted_mcp_notes,
 )
 
 # ---------------------------------------------------------------------------
@@ -1081,6 +1082,86 @@ class TestMain(unittest.TestCase):
                 _gmd.OUTPUT_DIR = original_dir
 
             self.assertFalse(stale.exists(), "Stale file should have been removed by main()")
+
+
+# ---------------------------------------------------------------------------
+# TestHostedMcpNotes — note keys must track real module and tool names
+# ---------------------------------------------------------------------------
+
+class TestHostedMcpNotes(unittest.TestCase):
+    """Both hosted-MCP note dicts are keyed by name, so a rename silently drops the note.
+
+    The docs freshness check cannot catch that: regenerating after a rename removes the
+    note from the committed page too, so committed and generated agree. These tests are
+    the guard instead, mirroring the bidirectional coverage test for filter hints.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.modules = discover_module_classes()
+        cls.tool_names = {
+            f"falcon_{registered}"
+            for mod_info in cls.modules.values()
+            for registered in extract_registered_tool_names(mod_info["cls"]).values()
+        }
+
+    def test_module_note_keys_are_real_modules(self):
+        from scripts.generate_module_docs import HOSTED_MCP_MODULE_NOTES
+
+        for key in HOSTED_MCP_MODULE_NOTES:
+            self.assertIn(key, self.modules, f"HOSTED_MCP_MODULE_NOTES key {key!r} is not a module")
+
+    def test_tool_note_keys_are_registered_tools(self):
+        from scripts.generate_module_docs import HOSTED_MCP_TOOL_NOTES
+
+        for name in HOSTED_MCP_TOOL_NOTES:
+            self.assertIn(
+                name, self.tool_names, f"HOSTED_MCP_TOOL_NOTES key {name!r} is not a registered tool"
+            )
+
+    def test_live_registry_passes_validation(self):
+        validate_hosted_mcp_notes(self.modules)  # must not raise
+
+    def test_stale_module_key_raises(self):
+        import scripts.generate_module_docs as _gmd
+
+        with patch.dict(_gmd.HOSTED_MCP_MODULE_NOTES, {"zero_trust_assessment": "x"}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                validate_hosted_mcp_notes(self.modules)
+        self.assertIn("zero_trust_assessment", str(ctx.exception))
+
+    def test_stale_tool_key_raises(self):
+        import scripts.generate_module_docs as _gmd
+
+        with patch.dict(_gmd.HOSTED_MCP_TOOL_NOTES, {"falcon_search_cloud_insight": "x"}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                validate_hosted_mcp_notes(self.modules)
+        self.assertIn("falcon_search_cloud_insight", str(ctx.exception))
+
+    def test_overview_mentions_every_noted_module_and_tool(self):
+        """The overview summary is hand-written prose; keep it in step with the note dicts."""
+        from scripts.generate_module_docs import (
+            HOSTED_MCP_MODULE_NOTES,
+            HOSTED_MCP_TOOL_NOTES,
+            MODULE_METADATA,
+        )
+
+        page = generate_overview_page(self.modules)
+        section = page.split("## CrowdStrike-hosted MCP differences", 1)[1]
+
+        for key in HOSTED_MCP_MODULE_NOTES:
+            slug = MODULE_METADATA.get(key, {}).get("slug", key)
+            self.assertIn(
+                f"/modules/{slug}/",
+                section,
+                f"Module {key!r} has a hosted-MCP note but is not linked in the overview summary",
+            )
+        for name in HOSTED_MCP_TOOL_NOTES:
+            self.assertIn(
+                name,
+                section,
+                f"Tool {name!r} has a hosted-MCP note but is not named in the overview summary",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a "CrowdStrike-hosted MCP differences" section to the module docs, comparing this self-hosted server's tool surface against CrowdStrike's hosted Falcon MCP: the hosted MCP's search_tools/execute_tool discovery pattern, modules only available on one side or the other, and a few tools/shapes that differ between the two. Implemented as data in generate_module_docs.py rather than hand-edited markdown, so the notes survive regeneration and the docs-freshness CI check.