### PR TITLE
test(integration): make filter and sort tests able to fail

### DIFF
--- a/falcon_mcp/modules/cloud/cloud_iom.py
+++ b/falcon_mcp/modules/cloud/cloud_iom.py
@@ -91,6 +91,9 @@ class _CloudIomMixin(_CloudBase):
                 cloud_provider -> cloud.provider
                 service -> resource.service
 
+                severity sorts by the underlying severity code, where critical is the
+                lowest value, so 'severity.asc' returns the MOST severe findings first.
+
                 Examples: 'severity.desc', 'last_detected.desc', 'first_detected.asc'
             """
             ).strip(),

--- a/tests/integration/cloud/test_cloud_assets.py
+++ b/tests/integration/cloud/test_cloud_assets.py
@@ -82,22 +82,62 @@ class TestCloudAssetsIntegration(BaseIntegrationTest):
         )
 
     def test_search_cspm_assets_with_tag_filter(self):
-        result = self.call_method(
+        """`tag_key` selects assets carrying that key in their `tags` map.
+
+        The filter names a key; the response returns the whole tag map, so the check is for
+        membership rather than a value. Assets with no tags at all come back without a
+        `tags` key, which is what makes this predicate able to fail: a filter that was
+        being dropped would return untagged assets alongside the tagged ones.
+        """
+        self.assert_filter_matches(
             self.module.search_cspm_assets,
-            filter="tag_key:'Environment'",
+            "tag_key:'Environment'",
+            predicate=lambda asset: "Environment" in (asset.get("tags") or {}),
+            predicate_desc="'Environment' in asset.tags",
+            note="tag_key matches the key name only; tag_value filters the value.",
             limit=10,
         )
-        self.assert_no_error(result, context="search_cspm_assets with tag filter")
-        self.assert_valid_list_response(result, min_length=0, context="search_cspm_assets with tag filter")
 
-    def test_search_cspm_assets_with_sort(self):
-        result = self.call_method(
-            self.module.search_cspm_assets,
-            sort="updated_at.desc",
-            limit=3,
+    def test_search_cspm_assets_sort_orders_by_resource_name(self):
+        """`resource_name` really orders the query step, in both directions.
+
+        This is the other half of `test_search_cspm_assets_returns_rows_in_query_step_order`
+        below. That one proves the hydration step preserves whatever order it was handed;
+        this one proves there was an order to preserve, which a tool that quietly stopped
+        forwarding `sort` would still pass.
+
+        `allow_ties=True` because nothing on this endpoint is tie-free — duplicate resource
+        names are common, and every other documented key ties harder. Ties are safe for what
+        is compared here (the value sequence, within a single response) and unsafe only for
+        comparing two runs row by row, which this does not do. `updated_at`, the tool's own
+        example, is monotone but ties heavily; `creation_time` is absent on many assets and
+        its descending page is not ordered at all.
+        """
+        key = "resource_name"
+        ascending = self.call_method(self.module.search_cspm_assets, sort=f"{key}.asc", limit=50)
+        descending = self.call_method(self.module.search_cspm_assets, sort=f"{key}.desc", limit=50)
+        self.assert_no_error(ascending, context=f"search_cspm_assets {key}.asc")
+        self.assert_no_error(descending, context=f"search_cspm_assets {key}.desc")
+
+        def names(result, direction):
+            assets = self.skip_unless_tenant_has(result, "CSPM assets", f"{key}.{direction}")
+            missing = [a["id"] for a in assets if not a.get(key)]
+            # Sorting on resource_name returns only assets that have one, so this is a
+            # statement about the endpoint rather than defensive noise: an unnamed asset in
+            # a name-sorted page means the sort was not applied to the query at all.
+            assert not missing, (
+                f"{len(missing)} of {len(assets)} assets in the {key}.{direction} page carry "
+                f"no {key}, so their order cannot be compared. First few: {missing[:3]}"
+            )
+            return [a[key] for a in assets]
+
+        self.assert_sort_orders_rows(
+            names(ascending, "asc"),
+            names(descending, "desc"),
+            key,
+            context="search_cspm_assets",
+            allow_ties=True,
         )
-        self.assert_no_error(result, context="search_cspm_assets with sort")
-        self.assert_valid_list_response(result, min_length=0, context="search_cspm_assets with sort")
 
     def test_search_cspm_assets_returns_rows_in_query_step_order(self):
         """Hydrated assets come back in the order the query step reported them.

--- a/tests/integration/cloud/test_cloud_containers.py
+++ b/tests/integration/cloud/test_cloud_containers.py
@@ -27,22 +27,49 @@ class TestCloudContainersIntegration(BaseIntegrationTest):
         )
 
     def test_search_kubernetes_containers_with_filter(self):
-        result = self.call_method(
+        """`running_status:true` selects only containers the response reports as running."""
+        self.assert_filter_matches(
             self.module.search_kubernetes_containers,
-            filter="running_status:true",
-            limit=3,
+            "running_status:true",
+            predicate=lambda container: container.get("running_status") is True,
+            predicate_desc="container.running_status is True",
+            note="Most containers in a real inventory are stopped, so this must select.",
+            limit=5,
         )
-        self.assert_no_error(result, context="search_kubernetes_containers with filter")
-        self.assert_valid_list_response(result, min_length=0, context="search_kubernetes_containers with filter")
 
-    def test_search_kubernetes_containers_with_sort(self):
-        result = self.call_method(
-            self.module.search_kubernetes_containers,
-            sort="last_seen.desc",
-            limit=3,
+    def test_search_kubernetes_containers_sort_orders_by_cluster_name(self):
+        """`cluster_name` is the one documented sort key this endpoint orders reliably.
+
+        `allow_ties=True` is unavoidable here: containers share clusters, so any page is
+        tied several times over. What that costs is small, because `ReadContainerCombined`
+        returns whole records in one call — there is no hydration step to scramble the order,
+        so the thing worth catching is the sort being dropped or ignored, which a tied
+        comparison still catches.
+
+        The other documented keys do not survive an order assertion against live data, which
+        is worth knowing before reaching for one: `last_seen` and `first_seen` are null on
+        most containers, so the ascending page has nothing to compare; `container_name`,
+        `namespace`, `cloud_name` and `cloud_region` return pages that are genuinely out of
+        order once empty-string values mix in; and `image_vulnerability_count` holds for a
+        short page but breaks partway down a longer one.
+        """
+        key = "cluster_name"
+        ascending = self.call_method(
+            self.module.search_kubernetes_containers, sort=f"{key}.asc", limit=50
         )
-        self.assert_no_error(result, context="search_kubernetes_containers with sort")
-        self.assert_valid_list_response(result, min_length=0, context="search_kubernetes_containers with sort")
+        descending = self.call_method(
+            self.module.search_kubernetes_containers, sort=f"{key}.desc", limit=50
+        )
+        self.assert_no_error(ascending, context=f"search_kubernetes_containers {key}.asc")
+        self.assert_no_error(descending, context=f"search_kubernetes_containers {key}.desc")
+
+        self.assert_sort_orders_rows(
+            [c[key] for c in self.skip_unless_tenant_has(ascending, "Kubernetes containers")],
+            [c[key] for c in self.skip_unless_tenant_has(descending, "Kubernetes containers")],
+            key,
+            context="search_kubernetes_containers",
+            allow_ties=True,
+        )
 
     def test_count_kubernetes_containers(self):
         """Validates the ReadContainerCount operation name is correct."""
@@ -68,13 +95,25 @@ class TestCloudContainersIntegration(BaseIntegrationTest):
         """Validates the ReadCombinedVulnerabilities operation name is correct."""
         result = self.call_method(self.module.search_images_vulnerabilities, limit=5)
         self.assert_no_error(result, context="search_images_vulnerabilities")
-        self.assert_valid_list_response(result, min_length=0, context="search_images_vulnerabilities")
+        self.skip_unless_tenant_has(result, "image vulnerabilities", "search_images_vulnerabilities")
+
+        self.assert_search_returns_details(
+            result,
+            expected_fields=["cve_id", "severity", "cvss_score"],
+            context="search_images_vulnerabilities",
+        )
 
     def test_search_images_vulnerabilities_with_filter(self):
-        result = self.call_method(
+        """`cvss_score` accepts numeric comparison operators.
+
+        This is the only converted filter here whose response field is named like the
+        filter field, so the predicate reads the same name on both sides.
+        """
+        self.assert_filter_matches(
             self.module.search_images_vulnerabilities,
-            filter="cvss_score:>5",
-            limit=3,
+            "cvss_score:>5",
+            predicate=lambda vuln: vuln.get("cvss_score") is not None and vuln["cvss_score"] > 5,
+            predicate_desc="vuln.cvss_score > 5",
+            note="A tenant with any assessed images has CVEs above a mid CVSS score.",
+            limit=5,
         )
-        self.assert_no_error(result, context="search_images_vulnerabilities with filter")
-        self.assert_valid_list_response(result, min_length=0, context="search_images_vulnerabilities with filter")

--- a/tests/integration/cloud/test_cloud_iom.py
+++ b/tests/integration/cloud/test_cloud_iom.py
@@ -29,30 +29,128 @@ class TestCloudIomIntegration(BaseIntegrationTest):
         )
 
     def test_search_iom_findings_with_severity_filter(self):
-        result = self.call_method(
+        """`severity` filters on the value nested at `evaluation.severity`.
+
+        The filter is flat and the response is not, so a test written from the filter name
+        alone would look for a top-level `severity` that never exists.
+        """
+        self.assert_filter_matches(
             self.module.search_iom_findings,
-            filter="severity:'critical'",
-            limit=3,
+            "severity:'critical'",
+            predicate=lambda finding: finding.get("evaluation", {}).get("severity") == "critical",
+            predicate_desc="finding.evaluation.severity == 'critical'",
+            note="Every guide and example in this repo uses these lowercase severity names.",
+            limit=5,
         )
-        self.assert_valid_list_response(result, min_length=0, context="search_iom_findings severity filter")
 
     def test_search_iom_findings_with_cloud_provider_filter(self):
-        result = self.call_method(
-            self.module.search_iom_findings,
-            filter="cloud_provider:'aws'",
-            limit=3,
-        )
-        self.assert_no_error(result, context="search_iom_findings with cloud_provider filter")
-        self.assert_valid_list_response(result, min_length=0, context="search_iom_findings cloud_provider filter")
+        """`cloud_provider` filters on the value the response nests at `cloud.provider`.
 
-    def test_search_iom_findings_with_sort(self):
-        result = self.call_method(
+        Lowercase is the only spelling this operation accepts — uppercase comes back as an
+        empty HTTP 200 rather than an error, which
+        `test_cloud_provider_casing_differs_across_cloud_endpoints` pins from the other side.
+        """
+        self.assert_filter_matches(
             self.module.search_iom_findings,
-            sort="severity|desc",
-            limit=3,
+            "cloud_provider:'aws'",
+            predicate=lambda finding: finding.get("cloud", {}).get("provider") == "aws",
+            predicate_desc="finding.cloud.provider == 'aws'",
+            note="The filter is cloud_provider; the response calls it cloud.provider.",
+            limit=5,
         )
-        self.assert_no_error(result, context="search_iom_findings with sort")
-        self.assert_valid_list_response(result, min_length=0, context="search_iom_findings with sort")
+
+    def test_search_iom_findings_sort_orders_by_last_detected(self):
+        """`last_detected` orders findings, and the order survives entity hydration.
+
+        `last_detected` is the probe because it is the documented key with the most distinct
+        values per page, which is what lets this catch `_reorder_by_ids` losing the order
+        during hydration. `severity` and `status` hold a handful of values across half a
+        million findings, so a page of either is almost entirely tied; `first_detected`
+        returns a descending page that is genuinely out of order (3 of 3 trials).
+
+        Comparison is truncated to milliseconds because that is the precision the endpoint
+        actually orders on. The response carries nanoseconds, and findings written inside the
+        same millisecond come back in arbitrary sub-millisecond order — measured on 6 of 6
+        descending trials during a write burst, while every truncated comparison held. The
+        full-precision value looks tie-free and is not, which is the flake this avoids; it
+        also means the truncated values tie, hence `allow_ties`.
+
+        The window filter is not cosmetic: unfiltered, the ascending page is entirely
+        records with no `last_detected` at all, and null sort values cannot be compared.
+        Read the value from `evaluation`, not the root — see
+        `test_iom_sort_keys_are_never_at_the_record_root`.
+        """
+        key = "last_detected"
+        window = f"{key}:>'now-3650d'"
+
+        def to_millis(finding):
+            """'YYYY-MM-DDTHH:MM:SS.mmm' — everything the endpoint's ordering respects."""
+            return finding["evaluation"][key][:23]
+
+        ascending = self.call_method(
+            self.module.search_iom_findings, filter=window, sort=f"{key}.asc", limit=20
+        )
+        descending = self.call_method(
+            self.module.search_iom_findings, filter=window, sort=f"{key}.desc", limit=20
+        )
+        self.assert_no_error(ascending, context=f"search_iom_findings {key}.asc")
+        self.assert_no_error(descending, context=f"search_iom_findings {key}.desc")
+
+        desc_millis = [
+            to_millis(f) for f in self.skip_unless_tenant_has(descending, "IOM findings")
+        ]
+        self.assert_sort_orders_rows(
+            [to_millis(f) for f in self.skip_unless_tenant_has(ascending, "IOM findings")],
+            desc_millis,
+            key,
+            context="search_iom_findings",
+            allow_ties=True,
+        )
+
+        piped = self.call_method(
+            self.module.search_iom_findings, filter=window, sort=f"{key}|desc", limit=20
+        )
+        self.assert_no_error(piped, context=f"search_iom_findings {key}|desc")
+        assert [
+            to_millis(f) for f in self.skip_unless_tenant_has(piped, "IOM findings")
+        ] == desc_millis, (
+            f"'{key}|desc' and '{key}.desc' disagree. The tool documents the dot form and "
+            "the pipe form is the API's own; both have to reach the same ordering. Only the "
+            "millisecond-truncated sequence is compared: two runs seconds apart can legally "
+            "return different rows within a tied millisecond."
+        )
+
+    def test_iom_severity_sort_puts_the_most_severe_first_in_ascending_order(self):
+        """`severity.asc` returns critical findings; `severity.desc` returns informational.
+
+        The endpoint sorts the underlying severity code, and critical is its lowest value,
+        so the direction reads backwards from the word. An agent asking for the worst
+        findings needs `severity.asc`, which is why the `sort` description says so and why
+        this pins it — the failure is silent, and 'fixing' the tool to invert it would give
+        the opposite of what was asked with no error to show for it.
+        """
+        severity_code = {"critical": 0, "high": 1, "medium": 2, "low": 3, "informational": 4}
+
+        def leading_severity(direction):
+            result = self.call_method(
+                self.module.search_iom_findings, sort=f"severity.{direction}", limit=20
+            )
+            self.assert_no_error(result, context=f"search_iom_findings severity.{direction}")
+            findings = self.skip_unless_tenant_has(result, "IOM findings", f"severity.{direction}")
+            codes = [severity_code[f["evaluation"]["severity"]] for f in findings]
+            assert codes == sorted(codes, reverse=direction == "desc"), (
+                f"severity.{direction} did not order findings by severity code: {codes}"
+            )
+            return findings[0]["evaluation"]["severity"]
+
+        assert leading_severity("asc") == "critical", (
+            "severity.asc no longer leads with critical findings. If the endpoint now sorts "
+            "severity by rank rather than by its numeric code, the note in the sort "
+            "description is backwards and has to change with it."
+        )
+        assert leading_severity("desc") == "informational", (
+            "severity.desc no longer leads with informational findings."
+        )
 
     def test_iom_sort_keys_are_never_at_the_record_root(self):
         """Every documented sort field reads back from a nested key, not the root.

--- a/tests/integration/test_fusion.py
+++ b/tests/integration/test_fusion.py
@@ -47,6 +47,13 @@ class TestFusionIntegration(BaseIntegrationTest):
 
     # ------------------------------------------------------------------
     # Helpers
+    #
+    # Filter coverage below uses BaseIntegrationTest.assert_filter_matches, which
+    # requires a non-empty result and checks every row against a predicate. Both
+    # halves matter here: an unknown property on these endpoints is a 400 that
+    # names it, but a known property with an unsupported operator comes back as an
+    # empty 200, so only rows prove the documented construction works — and only a
+    # per-row check proves the filter selected on what it claims to.
     # ------------------------------------------------------------------
 
     def assert_envelope_ok(self, result, context=""):
@@ -96,20 +103,6 @@ class TestFusionIntegration(BaseIntegrationTest):
             )
         return records[0]
 
-    def assert_filter_matches(self, search, filter, note=""):
-        """Assert a documented filter returns at least one row.
-
-        A workflow search returns a 400 that names an unknown property, but a
-        known property with an unsupported operator returns an empty 200 instead.
-        So only a non-empty result proves the documented construction works.
-        """
-        result = search(filter=filter, limit=2)
-        assert result["results"], (
-            f"Documented filter returned zero rows: {filter}. {note} "
-            "Either the guide is wrong or the tenant has no matching data."
-        )
-        return result
-
     # ------------------------------------------------------------------
     # search_workflow_definitions
     # ------------------------------------------------------------------
@@ -156,14 +149,14 @@ class TestFusionIntegration(BaseIntegrationTest):
         definition = self.a_definition()
         workflow_name = definition["name"]
 
-        exact = self.assert_filter_matches(
+        self.assert_filter_matches(
             self.search_definitions,
             f"name.raw:'{workflow_name}'",
+            predicate=lambda record: record.get("name") == workflow_name,
+            predicate_desc=f"definition.name == {workflow_name!r}",
             note="name.raw is the unanalyzed field and the only one doing exact matching.",
+            limit=2,
         )
-        assert any(
-            record["name"] == workflow_name for record in exact["results"]
-        ), f"name.raw exact match did not return {workflow_name!r}"
 
         analyzed = self.search_definitions(filter=f"name:'{workflow_name}'", limit=2)
         assert not analyzed["results"], (
@@ -180,13 +173,24 @@ class TestFusionIntegration(BaseIntegrationTest):
         self.assert_filter_matches(
             self.search_definitions,
             f"name.raw:*'*{fragment}*'",
+            predicate=lambda record: fragment in record.get("name", ""),
+            predicate_desc=f"{fragment!r} in definition.name",
             note="Substring matching needs name.raw with the :* operator.",
+            limit=2,
         )
 
     def test_definitions_filter_name_token_match(self):
-        """The analyzed `name` field matches whole tokens with ~."""
+        """The analyzed `name` field matches whole tokens with ~.
+
+        Whitespace and hyphens are token boundaries; an underscore is not. Splitting on
+        `_` as well produces a fragment that is not a token, which matches nothing —
+        `name:~'RS'` against 'RS_Test Notify on ...' returns zero rows, and
+        `name:~'Teds'` against 'Teds_CloudRisks_Workflow' only appears to work because
+        other workflows carry 'Teds' as a real token. That made this test pass or fail on
+        which definition the fixture happened to return.
+        """
         workflow_name = self.a_definition()["name"]
-        token = re.split(r"[\s\-_]+", workflow_name.strip())[0]
+        token = re.split(r"[\s\-]+", workflow_name.strip())[0]
         if len(token) < 3:
             self.skip_with_warning(
                 f"First token of {workflow_name!r} is too short to match on",
@@ -197,39 +201,69 @@ class TestFusionIntegration(BaseIntegrationTest):
         self.assert_filter_matches(
             self.search_definitions,
             f"name:~'{token}'",
+            predicate=lambda record: token.lower() in record.get("name", "").lower(),
+            predicate_desc=f"{token.lower()!r} in definition.name.lower()",
             note="`name` matches whole tokens only, so a full token must hit.",
+            limit=2,
         )
 
     def test_definitions_filter_id(self):
         """`id` does exact matching on a definition ID."""
         definition_id = self.a_definition()["id"]
         self.assert_filter_matches(
-            self.search_definitions, f"id:'{definition_id}'"
+            self.search_definitions,
+            f"id:'{definition_id}'",
+            predicate=lambda record: record.get("id") == definition_id,
+            predicate_desc=f"definition.id == {definition_id!r}",
+            limit=2,
         )
 
     def test_definitions_filter_enabled(self):
         """`enabled` matches on the definition's own boolean value."""
         definition = self.a_definition()
-        enabled = "true" if definition.get("enabled") else "false"
-        self.assert_filter_matches(self.search_definitions, f"enabled:{enabled}")
+        expected = bool(definition.get("enabled"))
+        self.assert_filter_matches(
+            self.search_definitions,
+            f"enabled:{'true' if expected else 'false'}",
+            predicate=lambda record: bool(record.get("enabled")) is expected,
+            predicate_desc=f"definition.enabled is {expected}",
+            limit=2,
+        )
 
     def test_definitions_filter_trigger_type(self):
         """`trigger.type` matches on the definition's own trigger type."""
         trigger_type = self.a_definition()["trigger"]["type"]
         self.assert_filter_matches(
-            self.search_definitions, f"trigger.type:'{trigger_type}'"
+            self.search_definitions,
+            f"trigger.type:'{trigger_type}'",
+            predicate=lambda record: record.get("trigger", {}).get("type") == trigger_type,
+            predicate_desc=f"definition.trigger.type == {trigger_type!r}",
+            limit=2,
         )
 
     def test_definitions_filter_version(self):
         """`version` accepts numeric operators."""
-        self.assert_filter_matches(self.search_definitions, "version:>0")
+        self.assert_filter_matches(
+            self.search_definitions,
+            "version:>0",
+            predicate=lambda record: (record.get("version") or 0) > 0,
+            predicate_desc="definition.version > 0",
+            limit=2,
+        )
 
     def test_definitions_filter_last_modified_timestamp(self):
-        """`last_modified_timestamp` accepts relative dates."""
+        """`last_modified_timestamp` accepts relative dates.
+
+        No predicate: a ten-year window matches every definition that exists, so any
+        check against it would pass whatever the filter did. The row count is the
+        assertion — this pins that the field and the relative-date form are accepted,
+        and `test_definitions_unknown_filter_field_is_loud` covers the rejection side.
+        """
         self.assert_filter_matches(
             self.search_definitions,
             "last_modified_timestamp:>'now-3650d'",
             note="A ten-year window should match any definition that exists.",
+            limit=2,
         )
 
     def test_definitions_filter_description_token_match(self):
@@ -371,22 +405,35 @@ class TestFusionIntegration(BaseIntegrationTest):
     def test_executions_filter_id(self):
         """The filter field `id` matches the response's `execution_id`."""
         execution_id = self.an_execution()["execution_id"]
-        matched = self.assert_filter_matches(
+        self.assert_filter_matches(
             self.search_executions,
             f"id:'{execution_id}'",
+            predicate=lambda record: record.get("execution_id") == execution_id,
+            predicate_desc=f"execution.execution_id == {execution_id!r}",
             note="The response calls this execution_id; the filter calls it id.",
+            limit=2,
         )
-        assert matched["results"][0]["execution_id"] == execution_id
 
     def test_executions_filter_definition_id(self):
         """`definition_id` lists one workflow's run history."""
         definition_id = self.an_execution()["definition_id"]
         self.assert_filter_matches(
-            self.search_executions, f"definition_id:'{definition_id}'"
+            self.search_executions,
+            f"definition_id:'{definition_id}'",
+            predicate=lambda record: record.get("definition_id") == definition_id,
+            predicate_desc=f"execution.definition_id == {definition_id!r}",
+            limit=2,
         )
 
     def test_executions_filter_definition_name_token_match(self):
-        """`definition_name` is analyzed and matches whole tokens with ~."""
+        """`definition_name` is analyzed and matches whole tokens with ~.
+
+        Split on whitespace and hyphens only, for the reason spelled out in
+        `test_definitions_filter_name_token_match`: an underscore is not a token boundary
+        here. `definition_name:~'MainWF'` returns nothing for a run of
+        'MainWF_Mohamad_Nabulsi_SNow_Automation_CRs' — the whole underscored string is the
+        token.
+        """
         execution = self.an_execution()
         definition_name = execution.get("definition_name")
         if not definition_name:
@@ -395,7 +442,7 @@ class TestFusionIntegration(BaseIntegrationTest):
             )
             return
 
-        token = re.split(r"[\s\-_]+", definition_name.strip())[0]
+        token = re.split(r"[\s\-]+", definition_name.strip())[0]
         if len(token) < 3:
             self.skip_with_warning(
                 f"First token of {definition_name!r} is too short to match on",
@@ -404,15 +451,27 @@ class TestFusionIntegration(BaseIntegrationTest):
             return
 
         self.assert_filter_matches(
-            self.search_executions, f"definition_name:~'{token}'"
+            self.search_executions,
+            f"definition_name:~'{token}'",
+            predicate=lambda record: token.lower() in (record.get("definition_name") or "").lower(),
+            predicate_desc=f"{token.lower()!r} in execution.definition_name.lower()",
+            limit=2,
         )
 
     def test_executions_filter_started_timestamp(self):
-        """`started_timestamp` is the filter name; `start_timestamp` is response-only."""
+        """`started_timestamp` is the filter name; `start_timestamp` is response-only.
+
+        The predicate reads the response's spelling, which is the whole point of the
+        pairing: a row that came back without `start_timestamp` would mean the two names
+        are no longer the same field.
+        """
         self.assert_filter_matches(
             self.search_executions,
             "started_timestamp:>'now-3650d'",
+            predicate=lambda record: bool(record.get("start_timestamp")),
+            predicate_desc="execution.start_timestamp is populated",
             note="A ten-year window should match any execution that exists.",
+            limit=2,
         )
 
         response_named = self.call_method(
@@ -426,27 +485,56 @@ class TestFusionIntegration(BaseIntegrationTest):
         )
 
     def test_executions_filter_completed_timestamp(self):
-        """`completed_timestamp` is the filter name; `end_timestamp` is response-only."""
+        """`completed_timestamp` is the filter name; `end_timestamp` is response-only.
+
+        Filtering on it selects finished runs, and only a finished run carries an
+        `end_timestamp` — an in-progress execution has no such key at all. So the
+        predicate can actually fail, unlike a bare ten-year window.
+        """
         self.assert_filter_matches(
-            self.search_executions, "completed_timestamp:>'now-3650d'"
+            self.search_executions,
+            "completed_timestamp:>'now-3650d'",
+            predicate=lambda record: bool(record.get("end_timestamp")),
+            predicate_desc="execution.end_timestamp is populated",
+            note="A ten-year window should match any completed execution.",
+            limit=2,
         )
 
     def test_executions_filter_definition_version(self):
         """`definition_version` accepts numeric operators."""
-        self.assert_filter_matches(self.search_executions, "definition_version:>0")
+        self.assert_filter_matches(
+            self.search_executions,
+            "definition_version:>0",
+            predicate=lambda record: (record.get("definition_version") or 0) > 0,
+            predicate_desc="execution.definition_version > 0",
+            limit=2,
+        )
 
     def test_executions_filter_test_mode(self):
-        """`test_mode` matches on the execution's own boolean value."""
+        """`test_mode` matches on the execution's own boolean value.
+
+        No predicate: the response does not carry `test_mode` at all, so any check would
+        read `None` and pass regardless of what the filter did. The fixture's value is
+        still used to pick the side that must have rows.
+        """
         execution = self.an_execution()
         test_mode = "true" if execution.get("test_mode") else "false"
-        self.assert_filter_matches(self.search_executions, f"test_mode:{test_mode}")
+        self.assert_filter_matches(
+            self.search_executions,
+            f"test_mode:{test_mode}",
+            limit=2,
+        )
 
     def test_executions_filter_contains_mocks(self):
         """`contains_mocks` matches on the execution's own boolean value."""
         execution = self.an_execution()
-        contains_mocks = "true" if execution.get("contains_mocks") else "false"
+        expected = bool(execution.get("contains_mocks"))
         self.assert_filter_matches(
-            self.search_executions, f"contains_mocks:{contains_mocks}"
+            self.search_executions,
+            f"contains_mocks:{'true' if expected else 'false'}",
+            predicate=lambda record: bool(record.get("contains_mocks")) is expected,
+            predicate_desc=f"execution.contains_mocks is {expected}",
+            limit=2,
         )
 
     def test_executions_sort_requires_dot_notation(self):
@@ -613,9 +701,16 @@ class TestFusionIntegration(BaseIntegrationTest):
 
         Disabled and ineligible-trigger share status 412, so the message is the
         only thing telling them apart — this asserts the message, not the code.
+
+        `version:>0` is part of the fixture filter because a definition that was never
+        published sits at version 0, and the execute endpoint cannot resolve one: it
+        answers 404 "definition not found" instead of the 412 under test. 167 of this
+        tenant's 518 disabled on-demand definitions are in that state, so which one the
+        search happened to return decided whether the test passed. The enabled-definition
+        fixture below needs no such guard — a workflow cannot be enabled at version 0.
         """
         disabled = self.search_definitions(
-            filter="enabled:false+trigger.type:'On demand'", limit=2
+            filter="enabled:false+trigger.type:'On demand'+version:>0", limit=2
         )["results"]
         if not disabled:
             self.skip_with_warning(

--- a/tests/integration/utils/base_integration_test.py
+++ b/tests/integration/utils/base_integration_test.py
@@ -200,6 +200,7 @@ class BaseIntegrationTest:
         desc: list[Any],
         key: str,
         context: str = "",
+        allow_ties: bool = False,
     ) -> None:
         """Assert an ascending/descending sort really ordered the rows.
 
@@ -208,16 +209,26 @@ class BaseIntegrationTest:
         `BaseModule._reorder_by_ids` exists to fix) still returns rows and still passes
         `assert_no_error` — only comparing the actual key sequence catches it.
 
-        Both directions must be *strictly* monotone. Ties are treated as a failure rather
-        than tolerated, because a tied key tie-breaks unstably and would make the test
-        flaky; if this starts failing on ties, the field is no longer a valid probe and
-        the test should move to a different one rather than relax the assertion.
+        Both directions must be *strictly* monotone by default. Ties are treated as a
+        failure rather than tolerated, because a tied key tie-breaks unstably and would
+        make the test flaky; if this starts failing on ties, the field is no longer a valid
+        probe and the test should move to a different one rather than relax the assertion.
+
+        `allow_ties=True` is for endpoints where no documented sort key is tie-free and the
+        strict default would mean no ordering coverage at all — a severity enum, say, where
+        a page of 50 rows holds one or two distinct values. What tie-breaks unstably is
+        *which rows* come back in a tied run, not the key sequence, and the sequence is all
+        this compares, so ties do not make these assertions flaky. The one thing they would
+        break is the `asc != desc` check, since an all-tied page looks identical in both
+        directions; that is replaced by requiring at least two distinct values across the
+        two pages and asserting the pages start at opposite ends.
 
         Args:
             asc: The sort key's value for each row, from the ascending call.
             desc: The same, from the descending call.
             key: The sort field name, for error messages.
             context: Optional context string for the error messages.
+            allow_ties: Accept repeated values, for keys with no tie-free alternative.
         """
         ctx = f" ({context})" if context else ""
 
@@ -231,19 +242,33 @@ class BaseIntegrationTest:
             f"Need more than one row to test {key} ordering{ctx}, got {len(desc)}"
         )
 
-        assert len(set(map(str, asc))) == len(asc), (
-            f"{key} has tied values{ctx}, so sort order is not deterministic and this "
-            f"test cannot distinguish a real ordering from a tie-break: {asc}"
-        )
-        assert len(set(map(str, desc))) == len(desc), (
-            f"{key} has tied values{ctx}: {desc}"
-        )
+        if not allow_ties:
+            assert len(set(map(str, asc))) == len(asc), (
+                f"{key} has tied values{ctx}, so sort order is not deterministic and this "
+                f"test cannot distinguish a real ordering from a tie-break: {asc}"
+            )
+            assert len(set(map(str, desc))) == len(desc), (
+                f"{key} has tied values{ctx}: {desc}"
+            )
 
         assert asc == sorted(asc), f"{key}.asc is not ascending{ctx}: {asc}"
         assert desc == sorted(desc, reverse=True), f"{key}.desc is not descending{ctx}: {desc}"
-        assert asc != desc, (
-            f"{key}.asc and {key}.desc returned the same order{ctx}, so the sort "
-            f"direction was ignored: {asc}"
+
+        if not allow_ties:
+            assert asc != desc, (
+                f"{key}.asc and {key}.desc returned the same order{ctx}, so the sort "
+                f"direction was ignored: {asc}"
+            )
+            return
+
+        assert len(set(map(str, asc)) | set(map(str, desc))) > 1, (
+            f"Every row in both {key} pages holds the same value{ctx}, so nothing here "
+            f"could tell an ordering from an arbitrary one: {asc}"
+        )
+        assert desc[0] > asc[0], (
+            f"{key}.asc and {key}.desc both start at {asc[0]!r}{ctx}. With more than one "
+            f"distinct value present the two directions have to land on opposite ends of "
+            f"the same ordering — this is what an ignored sort parameter looks like."
         )
 
     def assert_rows_in_query_step_order(


### PR DESCRIPTION
Most of the filter and sort tests in the cloud integration files asserted only that a list came back with at least zero items, which nothing can trip. These query APIs answer an unsupported field, an unsupported operator, or a sort key they don't honour with an empty 200, so zero rows never told us whether the filter was broken or the tenant simply had no matching data. A tool that stopped forwarding filter or sort altogether would have looked fine.

The nine sites named in the issue now require rows and check every record that comes back against a predicate. Picking those predicates is the fiddly part, because the filter field and the response field usually aren't the same name: severity lands at evaluation.severity, cloud_provider at cloud.provider, and tag_key has to be checked as membership in the tags map.

The sort keys changed too. What a sort parameter accepts and what it actually orders are different things, so each test now uses a key the endpoint really sorts on. search_iom_findings compares last_detected truncated to milliseconds, which is as far as the ordering goes even though the response carries nanoseconds — at full precision the values look unique and come back out of order. Neither search_cspm_assets nor search_kubernetes_containers has a tie-free key at all, so assert_sort_orders_rows now takes an opt-in for tied values that drops only the assertion ties would invalidate.

While in there: the IOM sort description now mentions that severity.asc returns the most severe findings first. The endpoint sorts the numeric severity code and critical is its lowest value, so an agent that reaches for desc gets the opposite of what it asked for and no error.

test_fusion.py had its own assert_filter_matches, which shadowed the base-class helper for every test in the file and took no predicate. That's gone, and the call sites carry predicates wherever the response holds the field. Two latent flakes in the same file are fixed as well. The disabled-definition test could draw a fixture the execute endpoint can't resolve, giving it a 404 instead of the 412 it asserts, and both name-token tests split the fixture name on underscores, which aren't token boundaries here.

The rest of the ~150 zero-tolerant sites in the other integration files are still to do under the same issue.

Relates to #551
