### PR TITLE
fix(dynamic): stop generic words deciding which tools are reachable

### DIFF
--- a/docs/usage/dynamic-mode.md
+++ b/docs/usage/dynamic-mode.md
@@ -85,7 +85,7 @@ including every parameter (type, required, description, examples) with FQL or CQ
 inlined. `query`, `module`, and `limit` are ignored. Naming two or more tools compares candidates in
 a single call.
 
-Splitting the two is what makes discovery cheap: on the full 117-tool catalog the input schema is
+Splitting the two is what makes discovery cheap: on the full 141-tool catalog the input schema is
 roughly two thirds of an entry's bytes, and at the moment of searching the agent has not chosen a
 tool to need it. A 50-result discovery response plus the schema for the one chosen tool costs
 slightly less than 20 results with schemas did.
@@ -165,17 +165,30 @@ avoid large responses.
 
 Results are ordered by relevance. A tool whose name matches the query outranks one that only
 mentions it in its description, and an exact tool name — with or without the `falcon_` prefix —
-ranks first. When two tools are otherwise tied — a bare noun like `iocs` matches `falcon_search_iocs`
-and `falcon_remove_iocs` equally — the read-only one ranks first, so the order never steers toward a
-mutator by default. Ordering is deterministic: the same query returns the same order on every server
-process. A query with no keywords (module browsing) is ordered by tool name.
+returns that tool alone, since naming a tool is a request for it rather than a keyword search. Tools
+matching every word the search narrowed on are ordered ahead of tools that matched only some, and
+within each of those groups the tool covering more of the query comes first. When two tools are
+otherwise tied — a bare noun like `iocs` matches `falcon_search_iocs` and `falcon_remove_iocs`
+equally — the read-only one ranks first, so the order never steers toward a mutator by default.
+Ordering is deterministic: the same query returns the same order on every server process. A query
+with no keywords (module browsing) is ordered by tool name.
 
-Every token in `query` is matched against the tool's name, description, module, and parameter
-names. Tools matching every token are preferred; when no tool matches all of them, the search falls
-back to tools matching at least one, so a phrase like `real-time response command` returns ranked
-candidates instead of nothing. The `hint` field says when that fallback was used. The order is a
-keyword match with no view of intent, so read each candidate's description and its `read_only` /
-`destructive` flags and pick the one that fits, rather than taking the first row on trust.
+Every word in `query` is matched against the tool's name, description, module, and parameter names.
+Generic words — `list`, `show`, `get`, `find`, `all`, and similar filler — are not used to narrow the
+candidate set, because they appear as prose in most descriptions ("returns an empty list on success")
+and so would select whichever tools happened to use the word rather than the ones the query is about.
+They still count toward ranking wherever they appear in a tool's own name, so `list case templates`
+still ranks `falcon_list_case_templates` first.
+
+On the remaining words the search prefers tools matching all of them. When too few tools do to
+choose between, it also returns tools matching at least half of those words, or carrying any one of
+them in their own name, ranked below the full matches; if that is still too thin, it widens once more
+to any tool matching a single one of those words — so a phrase like `real-time response command`
+returns ranked candidates instead of nothing. The `hint` field describes the split, saying how many
+results matched every word and how many matched only some. A query whose every word is generic has
+narrowed nothing, so all of its results are reported as loose matches. The order is a keyword match
+with no view of intent, so read each candidate's description and its `read_only` / `destructive`
+flags and pick the one that fits, rather than taking the first row on trust.
 
 `module` ignores case and separators, so `hostgroups`, `host_groups`, and `Host-Groups` all select
 the same module. `falcon_list_enabled_tools` returns a `by_module` map whose keys are the exact
@@ -187,13 +200,14 @@ returns only what the map lists.
 Every response carries `total` (the number of tools matching the query, before any limit) and
 `truncated`, so a capped result set is never mistaken for the complete set. When results are
 truncated, raise `limit` (up to 500) or narrow the query. The default is 50: lean discovery entries
-are cheap enough that a wide window costs less than a narrow one did with schemas attached, so a
-query like `host` — which matches 35 tools — is not truncated at all. In schema mode `total` counts
+are cheap enough that a wide window costs less than a narrow one did with schemas attached, and
+because generic words no longer widen the candidate set, ordinary keyword queries land well inside
+it — a query like `host` matches 40 tools and is not truncated at all. In schema mode `total` counts
 the entries returned, since no query ran for it to describe.
 
-If no tools match, no word in the query appears anywhere in the available surface. The response says
-so and points at `falcon_list_enabled_tools`. A capability absent from that full inventory is not
-available on that server — report that rather than searching again.
+If no tools match, none of the query's non-generic words appears anywhere in the available surface.
+The response says so and points at `falcon_list_enabled_tools`. A capability absent from that full
+inventory is not available on that server — report that rather than searching again.
 
 ## Tool Filtering in Dynamic Mode
 

--- a/falcon_mcp/dynamic.py
+++ b/falcon_mcp/dynamic.py
@@ -26,6 +26,36 @@ logger = get_logger(__name__)
 _TOOL_PREFIX = "falcon_"
 _NON_ALNUM = re.compile(r"[^a-z0-9]+")
 
+# Words that carry intent but not identity: generic verbs, determiners, and
+# conversational filler. They are stripped before the every-token conjunction and
+# score nothing outside a tool's own name, because they reach most of the corpus as
+# prose ('returns an empty list') and so decide nothing about which tool is wanted.
+#
+# Membership is a claim about how far a word reaches as prose, not about how generic
+# it feels. Words that identify an entity or an operation kind stay out — 'count',
+# 'aggregate', 'preview', 'members', 'details' and 'full' all genuinely narrow.
+# 'falcon' and 'return'/'returns' are here because they reach very nearly every
+# entry: search_corpus is built from the prefixed tool name, and almost every
+# docstring has a "Returns" line.
+_STOPWORDS = frozenset(
+    """
+    a an the of for to in on at and or from with by is are was were be been am
+    i me my we our us you your it its this that these those there
+    do does did done can could would should will shall may might must
+    what which who whom whose when where why how
+    show list get find search see look tell give fetch return returns retrieve display
+    all any some every each single both many much more most
+    please thanks thank hey hi ok okay just really actually now right currently
+    need needs want wants know knows help helps figure out way best able
+    have has had having falcon
+    """.split()
+)
+
+# How many matches make a block an answer on its own. Below this, the next-wider tier
+# is admitted to rescue a right answer the conjunction excluded; at or above it a
+# precise query never pays for the wider set.
+_TIER_RESCUE_BELOW = 3
+
 # Relative weights only: a name match must outrank any number of description
 # matches, so the gap between tiers exceeds the most tokens a query realistically
 # carries. A token matching nothing anywhere scores nothing — it is neither
@@ -81,6 +111,17 @@ class ToolEntry:
         self.module_words = _words(self.module)
         self.module_key = normalize_identifier(self.module)
 
+    def names_any(self, tokens: list[str]) -> bool:
+        """True when any token hits this tool's own name.
+
+        The same two name tiers ``score()`` rewards, asked as a yes/no. Candidate
+        selection counts corpus hits without regard to where they land, which lets a
+        tool matching several words only in prose qualify while a sibling named for
+        the query misses the count — the score already treats a name hit as worth many
+        prose hits, and this keeps selection consistent with that.
+        """
+        return any(t in self.name_words or t in self.unprefixed_name for t in tokens)
+
     def score(self, tokens: list[str], query_key: str) -> tuple[int, int]:
         """Rank this entry against a tokenized query; higher sorts earlier.
 
@@ -89,7 +130,8 @@ class ToolEntry:
         outranks one covering less regardless of where the hits land. ``strength`` is
         the weighted sum within that coverage, scoring each token once at the strongest
         field it hits, so a tool named for the query outranks one that only mentions it
-        in prose. A token matching nothing adds to neither.
+        in prose. A token matching nothing adds to neither, and a generic token
+        (``_STOPWORDS``) counts only where it hits this tool's own name.
         """
         if query_key and query_key in self.name_key:
             # Sorts above any real query: full coverage plus a strength no per-token
@@ -103,6 +145,11 @@ class ToolEntry:
                 strength += _SCORE_NAME_WORD
             elif token in self.unprefixed_name:
                 strength += _SCORE_NAME_SUBSTRING
+            elif token in _STOPWORDS:
+                # A generic word reaches most descriptions as prose, so crediting it
+                # outside a tool's own name measures docstring wording rather than
+                # relevance — enough to let a mutator outrank its read-only sibling.
+                continue
             elif token in self.module_words:
                 strength += _SCORE_MODULE_WORD
             elif token in self.module_key:
@@ -216,19 +263,41 @@ class DynamicToolCatalog:
         """
         return len(self._matches(query, module))
 
+    def full_coverage_count(self, query: str = "", module: str | None = None) -> int:
+        """How many matches cover every gate token; any others rank below them.
+
+        The composition of the result page, which is what the search hint describes:
+        generic words are excluded from the count's basis, so this is coverage of the
+        words the query actually narrowed on.
+        """
+        return len(self._match_set(query, module)[0])
+
     def relaxed(self, query: str = "", module: str | None = None) -> bool:
-        """True when the results came from the any-token fallback."""
-        return self._match_set(query, module)[1]
+        """True when nothing matched every gate token, so every result is partial.
+
+        Once a page can carry both blocks at once this no longer means "the results
+        are poor" — only that none of them covered the whole query.
+        """
+        return self.full_coverage_count(query, module) == 0
 
     def _match_set(
         self, query: str, module: str | None
-    ) -> tuple[list[ToolEntry], bool]:
-        """Select matching entries; the flag reports whether the fallback ran.
+    ) -> tuple[list[ToolEntry], list[ToolEntry]]:
+        """Split matching entries into a full-coverage block and a partial one.
 
-        Requiring every token narrows well when the query is already tool-shaped,
-        but a phrase carrying one word the catalog does not use matches nothing at
-        all. Falling back to any-token keeps such a query answerable; ranking is
-        what makes the wider set usable.
+        Requiring every token narrows well when the query is already tool-shaped, but
+        it also lets one incidental word decide eligibility: a generic verb appears as
+        prose across most descriptions, so conjoining on it can shrink the set to
+        whichever tools happen to use it in passing — excluding the right tool while
+        looking precise. Two rules keep that from happening.
+
+        Generic words (``_STOPWORDS``) are dropped before the conjunction, so they
+        cannot veto; ranking still sees every token. And when the full-coverage block
+        is too small to be a usable answer on its own, entries carrying at least half
+        the gate tokens — or any one of them in their own name — join it as a second,
+        lower-ranked block, so a near miss is demoted rather than dropped. A query
+        whose conjunction already works keeps its narrow set untouched and pays
+        nothing for the wider one.
         """
         candidates: list[ToolEntry] = list(self._entries.values())
 
@@ -237,60 +306,104 @@ class DynamicToolCatalog:
             candidates = [e for e in candidates if e.module_key == module_key]
 
         if not query:
-            return candidates, False
+            return candidates, []
 
         tokens = list(_words(query))
         query_key = normalize_identifier(query)
-        # Match every-token first for precision. Tokenizing on _NON_ALNUM (not a bare
-        # split) means 'hosts?' and 'search-hosts' reach the corpus the same way the
-        # corpus was built; the glued 'searchhosts' form has no usable token, so admit
-        # an entry whose whole name key equals the normalized query to rescue it. This
-        # mirrors score()'s exact-name short-circuit — membership, not substring, so a
-        # short query is not silently absorbed into an unrelated collapsed name.
-        def hits(entry: ToolEntry) -> bool:
-            return query_key in entry.name_key
 
-        strict = [
+        # Naming a tool is a request for that tool, not a keyword search, so every
+        # other entry sharing a token is noise. Membership, not substring, so a short
+        # query is not absorbed into an unrelated collapsed name. This mirrors
+        # score()'s exact-name short-circuit, and reaches the glued 'searchhosts' form
+        # that tokenizing alone cannot.
+        if query_key:
+            exact = [e for e in candidates if query_key in e.name_key]
+            if exact:
+                return exact, []
+
+        if not tokens:
+            # Punctuation only: nothing to match on, and an empty gate would otherwise
+            # make the conjunction vacuously true for every entry.
+            return [], []
+
+        # Falling back to the raw words when every one of them is generic keeps the
+        # query answerable, but the result is a partial match by construction: these
+        # tools carry the words incidentally, which is the whole reason the words do
+        # not gate. Reporting it as full coverage would tell the model the opposite —
+        # 'a' is a substring of every corpus, so it would present the entire catalog
+        # as a precise match.
+        gate = [t for t in tokens if t not in _STOPWORDS]
+        if not gate:
+            return [], [
+                e for e in candidates if all(t in e.search_corpus for t in tokens)
+            ]
+        # At least half the gate tokens, rounding up: enough to demote a near miss
+        # rather than drop it, without admitting every tool that shares one word.
+        threshold = (len(gate) + 1) // 2
+
+        full: list[ToolEntry] = []
+        partial: list[ToolEntry] = []
+        for entry in candidates:
+            hits = sum(1 for t in gate if t in entry.search_corpus)
+            if hits == len(gate):
+                full.append(entry)
+            elif hits >= threshold or entry.names_any(gate):
+                partial.append(entry)
+
+        if len(full) >= _TIER_RESCUE_BELOW:
+            # A full-coverage block this size is already an answer, so a precise query
+            # pays nothing for the wider set.
+            return full, []
+        if len(full) + len(partial) >= _TIER_RESCUE_BELOW:
+            return full, partial
+        # Still too thin to answer with. Drop to any single gate token, so a match the
+        # threshold excluded is demoted rather than lost — otherwise a near miss by one
+        # tool would suppress the rescue for all of them, which is the conjunction's own
+        # failure one tier down. Generic tokens stay out even here: the shortest of them
+        # ('a', 'on') are substrings of every corpus, so admitting them would return the
+        # whole catalog on the strength of a letter.
+        covered = {e.tool.name for e in full}
+        return full, [
             e
             for e in candidates
-            if (tokens and all(t in e.search_corpus for t in tokens)) or hits(e)
+            if e.tool.name not in covered and any(t in e.search_corpus for t in gate)
         ]
-        if strict:
-            return strict, False
-        return (
-            [
-                e
-                for e in candidates
-                if any(t in e.search_corpus for t in tokens) or hits(e)
-            ],
-            True,
-        )
 
     def _matches(self, query: str, module: str | None) -> list[ToolEntry]:
-        candidates, _ = self._match_set(query, module)
+        full, partial = self._match_set(query, module)
 
         if not query:
             # Browsing has no relevance signal, so order by name to stay stable
             # across processes.
-            return sorted(candidates, key=lambda e: e.tool.name)
+            return sorted(full, key=lambda e: e.tool.name)
 
         tokens = list(_words(query))
         query_key = normalize_identifier(query)
-        # Coverage first: a tool matching more of the query's words is the more
-        # relevant answer. Within equal coverage, strength orders by where the hits
-        # landed. When both still tie — a bare noun matches a read-only tool and its
-        # destructive sibling identically (search_iocs vs remove_iocs) — read-only
-        # wins, so ordering never steers an agent to the mutator first. Only then do
-        # ties break toward the least-qualified name and finally alphabetically, since
-        # catalog insertion order follows a set of module names and is not stable
-        # across processes.
-        def sort_key(e: ToolEntry) -> tuple[int, int, int, bool, str]:
+        # Full coverage first, so a tool matching every gate token always outranks one
+        # that missed a word. Within a block, coverage leads: a tool matching more of
+        # the query's words is the more relevant answer, and strength then orders by
+        # where the hits landed. When both still tie — a bare noun matches a read-only
+        # tool and its destructive sibling identically (search_iocs vs remove_iocs) —
+        # read-only wins, so ordering never steers an agent to the mutator first. Only
+        # then do ties break toward the least-qualified name and finally
+        # alphabetically, since catalog insertion order follows a set of module names
+        # and is not stable across processes.
+        full_names = {e.tool.name for e in full}
+
+        def sort_key(e: ToolEntry) -> tuple[int, int, int, int, bool, str]:
             matched, strength = e.score(tokens, query_key)
             annotations = e.tool.annotations
             read_only = annotations.readOnlyHint if annotations else True
-            return (-matched, -strength, len(e.name_words), not read_only, e.tool.name)
+            return (
+                0 if e.tool.name in full_names else 1,
+                -matched,
+                -strength,
+                len(e.name_words),
+                not read_only,
+                e.tool.name,
+            )
 
-        return sorted(candidates, key=sort_key)
+        return sorted(full + partial, key=sort_key)
 
     @staticmethod
     def _append_hint(params: dict[str, Any], key: str, text: str) -> None:
@@ -468,7 +581,7 @@ class DynamicMode:
         ready to pass to falcon_execute_tool. Naming several at once compares them.
 
         Read total and truncated to tell a capped list from a complete one, and hint
-        for whether the match had to be loosened.
+        for how much of the query each result matched.
         """
         # Naming tools is a schema lookup, not a search, so the match-set fields
         # describe what was asked for rather than a query nobody ran.
@@ -522,11 +635,21 @@ class DynamicMode:
             "truncated": truncated,
         }
         hints: list[str] = []
-        if self.catalog.relaxed(query=query, module=module):
+        full_on_page = min(
+            self.catalog.full_coverage_count(query=query, module=module), len(results)
+        )
+        partial_on_page = len(results) - full_on_page
+        if not full_on_page:
             hints.append(
                 "No tool matched every word, so these match at least one of them, "
                 "ordered by likely relevance. Read the descriptions and pick the one "
                 "that fits rather than assuming the capability is missing."
+            )
+        elif partial_on_page:
+            hints.append(
+                f"The first {full_on_page} match every word; the remaining "
+                f"{partial_on_page} match only some of them and rank below. Read the "
+                "descriptions rather than assuming the top result is the right tool."
             )
         if truncated:
             hints.append(

--- a/tests/modules/test_dynamic.py
+++ b/tests/modules/test_dynamic.py
@@ -65,17 +65,6 @@ class TestDynamicToolCatalog(unittest.TestCase):
         results = catalog.search(query="severity")
         self.assertGreater(len(results), 0)
 
-    def test_search_prefers_entries_matching_every_token(self):
-        catalog = DynamicToolCatalog(self.modules)
-        results = catalog.search(query="search detections")
-        names = [r["name"] for r in results]
-        self.assertIn("falcon_search_detections", names)
-        # Every result matches both tokens, so the fallback stayed out of it.
-        self.assertFalse(catalog.relaxed(query="search detections"))
-        for entry in (catalog.entries[n] for n in names):
-            self.assertIn("search", entry.search_corpus)
-            self.assertIn("detections", entry.search_corpus)
-
     def test_search_falls_back_to_any_token_when_no_entry_matches_all(self):
         """A phrase carrying one unknown word must not wipe out the whole result set."""
         catalog = DynamicToolCatalog(self.modules)
@@ -326,10 +315,22 @@ class TestLeanDiscoveryAndSchemaLookup(unittest.TestCase):
         )
 
     def test_count_matches_describes_discovery_not_the_requested_names(self):
-        """total must keep meaning "how many tools match", not "how many I asked for"."""
+        """total must keep meaning "how many tools match", not "how many I asked for".
+
+        Both sides calling the same code would pass under any implementation, so the
+        count is also pinned against an independently derived expectation: every tool
+        whose corpus carries the query word.
+        """
+        expected = {
+            name
+            for name, entry in self.catalog.entries.items()
+            if "detections" in entry.search_corpus
+        }
+        self.assertTrue(expected)
+        self.assertEqual(self.catalog.count_matches(query="detections"), len(expected))
         self.assertEqual(
-            self.catalog.count_matches(query="detections"),
-            len(self.catalog.search(query="detections", limit=10_000)),
+            {r["name"] for r in self.catalog.search(query="detections", limit=10_000)},
+            expected,
         )
 
     def test_tool_names_dedupes_repeated_names(self):
@@ -367,14 +368,57 @@ class TestSearchToolsTwoModeEnvelope(unittest.TestCase):
         The query is a genuine fallback case (no tool matches every word), so all three
         hint fragments — relaxed, truncated, and the schema instruction — are present at
         once, and the schema instruction must survive alongside them.
+
+        Every content word has to be one this fixture's two modules actually serve.
+        A word they do not use ('iocs') now matches nothing at all rather than riding
+        in on a stopword's prose hits, which would make this a zero-result case and
+        exercise the wrong branch.
         """
-        query = "find all the iocs added this week"
+        query = "find all the detections added this week"
         self.assertTrue(self.dynamic.catalog.relaxed(query=query))
         result = self._search(query=query, module=None, limit=1)
         self.assertTrue(result["truncated"])
         self.assertIn("match at least one", result["hint"])
         self.assertIn("Showing 1 of", result["hint"])
         self.assertIn("tool_names", result["hint"])
+
+    def test_all_generic_query_hint_does_not_claim_a_precise_match(self):
+        """A filler-only query must be told it matched loosely, not exactly.
+
+        'a' appears in every description, so the old raw-token fallback put the whole
+        catalog in the full-coverage block and emitted no caveat at all — the model
+        was handed every tool on the server as if each matched the query precisely.
+        """
+        result = self._search(query="a", module=None, limit=50)
+        self.assertTrue(result["results"])
+        self.assertIn("match at least one", result["hint"])
+        self.assertNotIn("match every word", result["hint"])
+
+    def test_mixed_page_hint_reports_the_actual_composition(self):
+        """When both blocks share a page, the hint must count them correctly."""
+        result = self._search(query="detections severity hostname", module=None, limit=50)
+        full = self.dynamic.catalog.full_coverage_count(query="detections severity hostname")
+        self.assertGreater(full, 0)
+        self.assertLess(full, len(result["results"]), "page must carry both blocks")
+        self.assertIn(f"The first {full} match every word", result["hint"])
+        self.assertIn(
+            f"remaining {len(result['results']) - full} match only some", result["hint"]
+        )
+
+    def test_page_smaller_than_the_full_block_claims_no_partial_results(self):
+        """A truncated page of only full matches must not report a partial remainder.
+
+        full_coverage_count() counts the whole match set, not the page, so a limit
+        below the size of the full-coverage block would otherwise subtract its way to
+        a negative count and announce "the remaining -30 match only some of them".
+        """
+        query = "detections"
+        full = self.dynamic.catalog.full_coverage_count(query=query)
+        self.assertGreater(full, 2, "fixture must have more full matches than the limit")
+        result = self._search(query=query, module=None, limit=2)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertNotIn("match only some", result["hint"])
+        self.assertNotIn("-", result["hint"].split("Showing")[0])
 
     def test_tool_names_dedupes_and_does_not_inflate_total(self):
         """A repeated name returns one schema and total counts what came back."""
@@ -570,21 +614,61 @@ class TestSearchRanking(unittest.TestCase):
                 )
 
     def test_count_matches_equals_len_search_at_large_limit(self):
-        """search() and count_matches() must not drift: they share _matches."""
-        for query in ("host", "hosts", "detections", "vulnerabilities", "", "no_such_thing"):
+        """search() and count_matches() must not drift: they share _matches.
+
+        Sharing the code makes the equality tautological on its own, so each query
+        also carries an independent expectation for the count — otherwise a change
+        that broke both identically would still pass here.
+
+        The zero case needs a token that appears in no corpus at all. 'no_such_thing'
+        does not qualify: 'no' is a substring of plenty of real descriptions and tool
+        names, so it legitimately matches.
+        """
+        expected = {
+            "zzzqabsenttoken": 0,
+            "": len(self.catalog.entries),
+        }
+        for query in (
+            "host",
+            "hosts",
+            "detections",
+            "vulnerabilities",
+            "",
+            "zzzqabsenttoken",
+        ):
             with self.subTest(query=query):
+                total = self.catalog.count_matches(query=query)
                 self.assertEqual(
-                    self.catalog.count_matches(query=query),
-                    len(self.catalog.search(query=query, limit=10_000)),
+                    total, len(self.catalog.search(query=query, limit=10_000))
                 )
+                if query in expected:
+                    self.assertEqual(total, expected[query])
+                else:
+                    self.assertGreater(total, 0)
+                    self.assertLess(
+                        total,
+                        len(self.catalog.entries),
+                        "a keyword query matching the whole catalog is not a match",
+                    )
 
     def test_count_matches_equals_len_search_with_module_filter(self):
+        """Same drift guard for the module path, with an independent count.
+
+        A module browse must return exactly that module's tools — pinning it against
+        the catalog's own module attribution keeps this from passing vacuously.
+        """
         for module in ("hosts", "detections", "hostgroups"):
             with self.subTest(module=module):
-                self.assertEqual(
-                    self.catalog.count_matches(module=module),
-                    len(self.catalog.search(module=module, limit=10_000)),
-                )
+                total = self.catalog.count_matches(module=module)
+                results = self.catalog.search(module=module, limit=10_000)
+                self.assertEqual(total, len(results))
+                expected = {
+                    name
+                    for name, entry in self.catalog.entries.items()
+                    if entry.module_key == module.replace("_", "")
+                }
+                self.assertTrue(expected, f"no tools attributed to {module}")
+                self.assertEqual({r["name"] for r in results}, expected)
 
     def test_ranking_does_not_change_the_matched_set(self):
         """Scoring reorders; it must not add or drop a match."""
@@ -600,11 +684,17 @@ class TestSearchRanking(unittest.TestCase):
                 self.assertFalse(self.catalog.relaxed(query=query))
                 self.assertEqual(set(self._names(query, limit=10_000)), expected)
 
-    def test_fallback_only_engages_when_strict_matching_is_empty(self):
-        """Precision is preserved: a query the strict filter can serve is served by it."""
+    def test_relaxed_stays_false_when_a_query_has_full_coverage_matches(self):
+        """Precision is preserved: a query the conjunction can serve is served by it.
+
+        relaxed() now means "nothing matched every gate token" rather than "the
+        any-token fallback ran", so a query with a healthy full-coverage block must
+        still report False even though a partial block can now share the page.
+        """
         for query in ("host details", "search detections", "quarantined files"):
             with self.subTest(query=query):
                 self.assertFalse(self.catalog.relaxed(query=query))
+                self.assertGreater(self.catalog.full_coverage_count(query=query), 0)
 
     def test_fallback_rescues_a_natural_language_phrase(self):
         """The reported zero-hit cases must return a usable, ranked result set."""
@@ -633,6 +723,193 @@ class TestSearchRanking(unittest.TestCase):
                 self.assertEqual(
                     self._names(query, limit=10_000),
                     [r["name"] for r in reversed_catalog.search(query=query, limit=10_000)],
+                )
+
+    def test_full_coverage_entries_rank_ahead_of_partial_ones(self):
+        """The two blocks are ordered, not merged: a full match never sorts below.
+
+        A partial match is admitted to keep the right tool reachable, so it must be
+        visibly demoted rather than allowed to displace a tool that matched every word
+        the query narrowed on.
+
+        This query is one of the few where the blocks genuinely disagree with the
+        score: falcon_list_cloud_insight_definitions is only a partial match yet
+        outscores the full match falcon_execute_workflow, so it would overtake it if
+        the block stopped leading the sort key.
+        """
+        query = "list workflow definitions"
+        full, partial = self.catalog._match_set(query, None)
+        self.assertTrue(full, "fixture query must produce a full-coverage block")
+        self.assertTrue(partial, "fixture query must produce a partial block")
+        names = self._names(query, limit=10_000)
+        last_full = max(names.index(e.tool.name) for e in full)
+        first_partial = min(names.index(e.tool.name) for e in partial)
+        self.assertLess(last_full, first_partial)
+        self.assertEqual(self.catalog.full_coverage_count(query=query), len(full))
+
+    def test_a_thin_candidate_set_widens_instead_of_being_served_as_is(self):
+        """Too few matches to choose between must widen, not ship as a short page.
+
+        The near-miss threshold can admit a wrong tool while excluding the right one,
+        which is the conjunction's own defect one tier down. Widening whenever the
+        blocks are together too thin — the same test that decides whether the partial
+        block is needed at all — is what keeps that from happening: here
+        falcon_search_images_vulnerabilities is reachable only because the set was
+        widened past the single tool that cleared the threshold.
+        """
+        query = "docker image cves"
+        self.assertGreater(self.catalog.count_matches(query=query), 2)
+        self.assertIn("falcon_search_images_vulnerabilities", self._names(query))
+
+    def test_a_mostly_matching_description_is_admitted_without_a_name_hit(self):
+        """Covering most of the query is evidence on its own, name hit or not.
+
+        falcon_set_policy_precedence answers 'change the evaluation order of policies'
+        but shares no word with its own name — 'policy' is not 'policies', and neither
+        'order' nor 'evaluation' appears in the name. It carries three of the four gate
+        tokens in its description, which is what admits it, and it then wins the block
+        outright. Requiring a name hit or full coverage would drop it entirely.
+        """
+        query = "change the evaluation order of policies"
+        entry = self.catalog.entries["falcon_set_policy_precedence"]
+        self.assertFalse(
+            entry.names_any(["change", "evaluation", "order", "policies"]),
+            "fixture no longer isolates the description path",
+        )
+        self.assertEqual(self._names(query)[0], "falcon_set_policy_precedence")
+
+    def test_an_all_generic_query_is_never_reported_as_full_coverage(self):
+        """A query of only filler words has narrowed nothing, and must say so.
+
+        Every word being generic leaves nothing to gate on, so the raw words are used
+        to stay answerable. But 'a' is a substring of every corpus, so counting that
+        as full coverage would present the entire catalog to the model as a precise
+        match. These are partial matches by construction.
+        """
+        for query in ("a", "for", "all the", "please show me everything"):
+            with self.subTest(query=query):
+                self.assertEqual(self.catalog.full_coverage_count(query=query), 0)
+                self.assertTrue(self.catalog.relaxed(query=query))
+
+    def test_generic_words_do_not_narrow_the_candidate_set(self):
+        """A generic verb must not decide which tools are eligible.
+
+        'list' reaches 37 of the catalog's descriptions as prose ("returns an empty
+        list on success"), so conjoining on it selects whichever tools happen to use
+        the word rather than the ones the query is about — only 3 tools carry both
+        'list' and 'detections'. Dropping it from the gate must leave exactly the set
+        the entity word alone produces.
+
+        Runs against the whole catalog on purpose: on a small fixture every tool tends
+        to use 'list' somewhere, so the two sets coincide and the test proves nothing.
+        'list detections' rather than 'search detections' because the latter collapses
+        to 'searchdetections', an exact tool name reached by a different path.
+        """
+        with_verb = set(self._names("list detections", limit=10_000))
+        without = set(self._names("detections", limit=10_000))
+        self.assertTrue(with_verb)
+        self.assertEqual(with_verb, without)
+
+    def test_generic_verb_query_reaches_the_read_only_search_tool(self):
+        """'list X' must reach the tool that lists X.
+
+        'list' appears as prose in dozens of descriptions ("returns an empty list on
+        success"), so conjoining on it selected whichever tools used the word and
+        excluded the search tool the query is asking for. Because that set was
+        non-empty it also looked precise, so nothing widened it.
+        """
+        for query, intended in (
+            ("list host groups", "falcon_search_host_groups"),
+            ("list exclusions", "falcon_search_exclusions"),
+            ("list firewall rules", "falcon_search_firewall_rules"),
+            ("list quarantined files", "falcon_search_quarantined_files"),
+            ("count detections by severity", "falcon_aggregate_detections"),
+        ):
+            with self.subTest(query=query):
+                self.assertIn(intended, self._names(query))
+
+    def test_generic_verb_query_does_not_lead_with_the_destructive_sibling(self):
+        """A read query must not put a mutator first, even on coverage.
+
+        Crediting a generic word wherever it appeared let falcon_delete_host_groups
+        outscore falcon_search_host_groups on 'list host groups' — its description
+        happens to say "returns an empty list on success". Coverage is the primary
+        sort key, so the read-only tiebreak never got the chance to fire.
+        """
+        for query, read_only, destructive in (
+            ("list host groups", "falcon_search_host_groups", "falcon_delete_host_groups"),
+            ("list exclusions", "falcon_search_exclusions", "falcon_delete_exclusions"),
+            (
+                "list quarantined files",
+                "falcon_search_quarantined_files",
+                "falcon_delete_quarantined_files",
+            ),
+        ):
+            with self.subTest(query=query):
+                names = self._names(query, limit=10_000)
+                self.assertEqual(names[0], read_only)
+                self.assertLess(names.index(read_only), names.index(destructive))
+
+    def test_a_tool_named_for_a_query_word_is_not_dropped_for_a_prose_match(self):
+        """Selection must respect the name-over-prose weighting score() already uses.
+
+        Counting corpus hits without regard to where they land split two siblings for
+        the same capability: falcon_execute_rtr_read_only_command carries 'command' in
+        its own name but matched one word, while tools mentioning several query words
+        only in prose cleared the threshold. Naming a tool is stronger evidence than
+        mentioning it.
+        """
+        names = self._names("real-time response command", limit=10_000)
+        self.assertIn("falcon_execute_rtr_read_only_command", names)
+        self.assertIn("falcon_run_rtr_read_only_command_and_wait", names)
+
+    def test_exact_name_query_returns_only_that_tool(self):
+        """Naming a tool is a request for it, not a keyword search.
+
+        score() already short-circuits on an exact name, but selection did not, so an
+        exact-name query still unioned in every tool sharing a token — a page of
+        dozens of entries to answer a question with one right answer.
+        """
+        for query in ("falcon_search_hosts", "search_hosts", "searchhosts"):
+            with self.subTest(query=query):
+                self.assertEqual(self._names(query, limit=10_000), ["falcon_search_hosts"])
+
+    def test_ordering_is_identical_across_independently_built_catalogs(self):
+        """Result order must be reproducible across processes.
+
+        Catalog insertion order follows a set of module names and token order comes
+        from a frozenset, so neither is stable under hash randomization. Every new
+        token consumer has to stay order-independent and every sort key has to end in
+        the tool name. Comparing two independently built catalogs is what actually
+        checks that, rather than reading the code and trusting it.
+        """
+        from falcon_mcp.client import FalconClient
+
+        mock_client = MagicMock(spec=FalconClient)
+        available = registry.get_available_modules()
+        other = DynamicToolCatalog(
+            {name: available[name](mock_client) for name in reversed(list(available))}
+        )
+        queries = (
+            "",
+            "host",
+            "host details",
+            "list host groups",
+            "search detections",
+            "real-time response command",
+            "vulnerabilities in containers",
+            "find all the iocs added this week",
+            "falcon_search_hosts",
+        )
+        for query in queries:
+            with self.subTest(query=query):
+                self.assertEqual(
+                    self._names(query, limit=10_000),
+                    [r["name"] for r in other.search(query=query, limit=10_000)],
+                )
+                self.assertEqual(
+                    self.catalog.count_matches(query=query),
+                    other.count_matches(query=query),
                 )
 
     def test_read_only_tool_outranks_destructive_sibling_on_single_token_query(self):
@@ -986,13 +1263,21 @@ class TestExecuteFalconTool(unittest.TestCase):
         self.assertIn("falcon_list_enabled_tools", result["hint"])
 
     def test_search_tools_with_results_returns_envelope(self):
+        """An exact-name query returns that one tool, and total agrees with it.
+
+        Asserting total == len(results) alone passed only because this fixture serves
+        7 tools, comfortably under limit=50 — it would have passed for any query.
+        Naming a tool pins the count to exactly one.
+        """
         result = run_async(
             self.dynamic._search_tools(
                 query="search_detections", module=None, limit=50
             )
         )
-        self.assertGreater(len(result["results"]), 0)
-        self.assertEqual(result["total"], len(result["results"]))
+        self.assertEqual(
+            [r["name"] for r in result["results"]], ["falcon_search_detections"]
+        )
+        self.assertEqual(result["total"], 1)
         self.assertFalse(result["truncated"])
 
 


### PR DESCRIPTION
Dynamic mode's falcon_search_tools is the only way to reach a capability, so what it returns is what an agent can find. It was requiring every word of a query to appear in a tool's text. Generic words like "list" show up as prose all over the descriptions ("returns an empty list on success"), so one incidental hit produced a small set that looked precise while leaving out the tool the query was actually about. And because that set was not empty, the fallback that would have widened it never ran. Searching "list host groups" gave back three unrelated tools, no falcon_search_host_groups anywhere, and a delete tool at the top.

Generic words no longer narrow the candidate set, though they still count where they appear in a tool's own name, so naming falcon_list_case_templates still promotes it. Candidates now come back in two groups: tools matching every meaningful word, then tools matching only some. The second group only appears when the first is too small to choose between, and it always ranks below. A tool carrying a query word in its own name is kept regardless, since selection had been ignoring the name-over-prose weighting the scorer already applies, which was splitting sibling tools for the same capability. Naming a tool outright now returns just that tool instead of everything sharing a word with it.

Ranking improves and the worst-case response shrinks from the whole catalog to a fraction of it. Every phrasing that previously hid the right tool now surfaces it, and no read query leads with a destructive tool.

Worth flagging one trade. "detections I already have ids for" now puts falcon_update_detections above the correct falcon_get_detection_details. The old order was right there by luck, because conjoining on "for" and "have" happened to exclude the mutator. Driving a real model over it, it reads past the mutator to the right tool, and the query an agent actually composes for that intent does not surface the mutator at all.